### PR TITLE
Handle disjunctions defined in a map value type

### DIFF
--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -80,6 +80,10 @@ func (pass *DisjunctionToType) processType(file *ast.File, def ast.Type) (ast.Ty
 		return pass.processArray(file, def)
 	}
 
+	if def.Kind == ast.KindMap {
+		return pass.processMap(file, def)
+	}
+
 	if def.Kind == ast.KindStruct {
 		return pass.processStruct(file, def)
 	}
@@ -97,7 +101,22 @@ func (pass *DisjunctionToType) processArray(file *ast.File, def ast.Type) (ast.T
 		return ast.Type{}, err
 	}
 
-	return ast.NewArray(processedType), nil
+	newArray := def
+	newArray.Array.ValueType = processedType
+
+	return newArray, nil
+}
+
+func (pass *DisjunctionToType) processMap(file *ast.File, def ast.Type) (ast.Type, error) {
+	processedValueType, err := pass.processType(file, def.AsMap().ValueType)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	newMap := def
+	newMap.Map.ValueType = processedValueType
+
+	return newMap, nil
 }
 
 func (pass *DisjunctionToType) processStruct(file *ast.File, def ast.Type) (ast.Type, error) {

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -114,6 +114,38 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnObject(t *testing.T) {
 	runDisjunctionPass(t, objects, expectedObjects)
 }
 
+func TestDisjunctionToType_WithDisjunctionOfScalars_AsAMapValueType(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("ADisjunctionOfScalars", ast.NewMap(
+			ast.String(),
+			ast.NewDisjunction([]ast.Type{
+				ast.String(),
+				ast.Bool(),
+			}),
+		)),
+	}
+
+	// Prepare expected output
+	disjunctionStructType := ast.NewStruct(
+		ast.NewStructField("ValString", ast.String(ast.Nullable())),
+		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+	)
+	// The original disjunction definition is preserved as a hint
+	disjunctionStructType.Struct.Hint[ast.HintDisjunctionOfScalars] = objects[0].Type.AsMap().ValueType.AsDisjunction()
+
+	expectedObjects := []ast.Object{
+		ast.NewObject("ADisjunctionOfScalars", ast.NewMap(
+			ast.String(),
+			ast.NewRef("StringOrBool"),
+		)),
+		ast.NewObject("StringOrBool", disjunctionStructType),
+	}
+
+	// Call the compiler pass
+	runDisjunctionPass(t, objects, expectedObjects)
+}
+
 func TestDisjunctionToType_WithDisjunctionOfScalars_AsAStructField(t *testing.T) {
 	// Prepare test input
 	disjunctionType := ast.NewDisjunction([]ast.Type{

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -170,13 +170,6 @@ func NewStruct(fields ...StructField) Type {
 	}
 }
 
-func NewNullableStruct(fields ...StructField) Type {
-	def := NewStruct(fields...)
-	def.Nullable = true
-
-	return def
-}
-
 func NewRef(referredTypeName string, opts ...TypeOption) Type {
 	def := Type{
 		Kind: KindRef,


### PR DESCRIPTION
There was a case that wasn't handled by the `DisjunctionToType` compiler pass: a disjunction defined in the value type of a map. Ex:

```cue
SomeMap: {
  [string]: string | bool
}
```

This PR fixes that.