### PR TITLE
Add operator constants

### DIFF
--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -41,6 +41,8 @@ const (
 type Op string
 
 const (
+	MinLengthOp        Op = "minLength"
+	MaxLengthOp        Op = "maxLength"
 	EqualOp            Op = "=="
 	NotEqualOp         Op = "!="
 	LessThanOp         Op = "<"

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -317,10 +317,10 @@ func (jenny *Builder) constraint(argumentName string, constraint ast.TypeConstra
 }
 
 func (jenny *Builder) constraintComparison(argumentName string, constraint ast.TypeConstraint) string {
-	if constraint.Op == ast.GreaterThanEqualOp {
+	if constraint.Op == ast.MinLengthOp {
 		return fmt.Sprintf("len([]rune(%[1]s)) >= %[2]v", argumentName, constraint.Args[0])
 	}
-	if constraint.Op == ast.LessThanEqualOp {
+	if constraint.Op == ast.MaxLengthOp {
 		return fmt.Sprintf("len([]rune(%[1]s)) <= %[2]v", argumentName, constraint.Args[0])
 	}
 

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -235,10 +235,10 @@ func (jenny *Builder) constraint(argumentName string, constraint ast.TypeConstra
 }
 
 func (jenny *Builder) constraintComparison(argumentName string, constraint ast.TypeConstraint) string {
-	if constraint.Op == ast.GreaterThanEqualOp {
+	if constraint.Op == ast.MinLengthOp {
 		return fmt.Sprintf("%[1]s.length >= %[2]v", argumentName, constraint.Args[0])
 	}
-	if constraint.Op == ast.LessThanEqualOp {
+	if constraint.Op == ast.MaxLengthOp {
 		return fmt.Sprintf("%[1]s.length <= %[2]v", argumentName, constraint.Args[0])
 	}
 

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -400,7 +400,7 @@ func (g *generator) declareStringConstraints(v cue.Value) ([]ast.TypeConstraint,
 			}
 
 			constraints = append(constraints, ast.TypeConstraint{
-				Op:   ast.GreaterThanEqualOp,
+				Op:   ast.MinLengthOp,
 				Args: []any{scalar},
 			})
 
@@ -411,7 +411,7 @@ func (g *generator) declareStringConstraints(v cue.Value) ([]ast.TypeConstraint,
 			}
 
 			constraints = append(constraints, ast.TypeConstraint{
-				Op:   ast.LessThanEqualOp,
+				Op:   ast.MaxLengthOp,
 				Args: []any{scalar},
 			})
 		}


### PR DESCRIPTION
It set the operators as constants. 

Its necessary for https://github.com/grafana/cog/pull/22 and we should have some consistency.