### PR TITLE
Generate default values for structs in typescript

### DIFF
--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -57,6 +57,10 @@ func (jenny RawTypes) formatObject(def ast.Object, typesPkg string) ([]byte, err
 		buffer.WriteString(fmt.Sprintf("interface %s ", def.Name))
 		buffer.WriteString(formatStructFields(def.Type.AsStruct().Fields, typesPkg))
 		buffer.WriteString("\n")
+
+		buffer.WriteString("\n")
+		buffer.WriteString(formatStructDefaults(def))
+		buffer.WriteString("\n")
 	case ast.KindEnum:
 		buffer.WriteString(fmt.Sprintf("enum %s {\n", def.Name))
 		for _, val := range def.Type.AsEnum().Values {
@@ -88,22 +92,37 @@ func formatStructFields(fields []ast.StructField, typesPkg string) string {
 
 	buffer.WriteString("{\n")
 
-	for i, fieldDef := range fields {
+	for _, fieldDef := range fields {
 		fieldDefGen := formatField(fieldDef, typesPkg)
 
 		buffer.WriteString(
 			strings.TrimSuffix(
 				prefixLinesWith(string(fieldDefGen), "\t"),
-				"\n\t",
+				"\t",
 			),
 		)
-
-		if i != len(fields)-1 {
-			buffer.WriteString("\n")
-		}
 	}
 
-	buffer.WriteString("\n}")
+	buffer.WriteString("}")
+
+	return buffer.String()
+}
+
+func formatStructDefaults(def ast.Object) string {
+	var buffer strings.Builder
+
+	buffer.WriteString(fmt.Sprintf("export const default%[1]s: Partial<%[2]s> = {\n", tools.UpperCamelCase(def.Name), def.Name))
+
+	fields := def.Type.AsStruct().Fields
+	for _, field := range fields {
+		if field.Default == nil {
+			continue
+		}
+
+		buffer.WriteString(fmt.Sprintf("\t%s: %s,\n", field.Name, formatScalar(field.Default)))
+	}
+
+	buffer.WriteString("};")
 
 	return buffer.String()
 }
@@ -124,7 +143,7 @@ func formatField(def ast.StructField, typesPkg string) []byte {
 
 	buffer.WriteString(fmt.Sprintf(
 		"%s%s: %s;\n",
-		tools.LowerCamelCase(def.Name),
+		def.Name,
 		required,
 		formattedType,
 	))

--- a/testdata/jennies/rawtypes/arrays.txtar
+++ b/testdata/jennies/rawtypes/arrays.txtar
@@ -73,8 +73,11 @@
 export type ArrayOfStrings = string[];
 
 export interface someStruct {
-	fieldAny: any;
+	FieldAny: any;
 }
+
+export const defaultSomeStruct: Partial<someStruct> = {
+};
 
 export type ArrayOfRefs = someStruct[];
 

--- a/testdata/jennies/rawtypes/disjunctions.txtar
+++ b/testdata/jennies/rawtypes/disjunctions.txtar
@@ -170,21 +170,30 @@ export type RefreshRate = string | boolean;
 export type StringOrNull = string | null;
 
 export interface SomeStruct {
-	type: "some-struct";
-	fieldAny: any;
+	Type: "some-struct";
+	FieldAny: any;
 }
+
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
 
 export type BoolOrRef = boolean | SomeStruct;
 
 export interface SomeOtherStruct {
-	type: "some-other-struct";
-	foo: string;
+	Type: "some-other-struct";
+	Foo: string;
 }
 
+export const defaultSomeOtherStruct: Partial<SomeOtherStruct> = {
+};
+
 export interface YetAnotherStruct {
-	type: "yet-another-struct";
-	bar: number;
+	Type: "yet-another-struct";
+	Bar: number;
 }
+
+export const defaultYetAnotherStruct: Partial<YetAnotherStruct> = {
+};
 
 export type SeveralRefs = SomeStruct | SomeOtherStruct | YetAnotherStruct;
 

--- a/testdata/jennies/rawtypes/maps.txtar
+++ b/testdata/jennies/rawtypes/maps.txtar
@@ -108,8 +108,11 @@ export type MapOfStringToAny = Record<string, any>;
 export type MapOfStringToString = Record<string, string>;
 
 export interface SomeStruct {
-	fieldAny: any;
+	FieldAny: any;
 }
+
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
 
 export type MapOfStringToRef = Record<string, SomeStruct>;
 

--- a/testdata/jennies/rawtypes/refs.txtar
+++ b/testdata/jennies/rawtypes/refs.txtar
@@ -33,8 +33,11 @@
 -- out/jennies/TypescriptRawTypes --
 == types/refs/types_gen.ts
 export interface SomeStruct {
-	fieldAny: any;
+	FieldAny: any;
 }
+
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
 
 export type RefToSomeStruct = SomeStruct;
 -- out/jennies/GoRawTypes --

--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -180,21 +180,27 @@
 == types/struct_complex_fields/types_gen.ts
 // This struct does things.
 export interface SomeStruct {
-	fieldRef: SomeOtherStruct;
-	fieldDisjunctionOfScalars: string | boolean;
-	fieldMixedDisjunction: string | SomeOtherStruct;
-	fieldDisjunctionWithNull: string | null;
-	fieldAnonymousEnum: ">" | "<";
-	fieldArrayOfStrings: string[];
-	fieldMapOfStringToString: Record<string, string>;
-	fieldAnonymousStruct: {
-		fieldAny: any;
+	FieldRef: SomeOtherStruct;
+	FieldDisjunctionOfScalars: string | boolean;
+	FieldMixedDisjunction: string | SomeOtherStruct;
+	FieldDisjunctionWithNull: string | null;
+	FieldAnonymousEnum: ">" | "<";
+	FieldArrayOfStrings: string[];
+	FieldMapOfStringToString: Record<string, string>;
+	FieldAnonymousStruct: {
+		FieldAny: any;
 	};
 }
 
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
+
 export interface SomeOtherStruct {
-	fieldAny: any;
+	FieldAny: any;
 }
+
+export const defaultSomeOtherStruct: Partial<SomeOtherStruct> = {
+};
 
 -- out/jennies/GoRawTypes --
 == types/struct_complex_fields/types_gen.go

--- a/testdata/jennies/rawtypes/struct_with_defaults.txtar
+++ b/testdata/jennies/rawtypes/struct_with_defaults.txtar
@@ -1,0 +1,92 @@
+# Basic struct with default values.
+-- ir.json --
+{
+    "Package": "defaults",
+    "Definitions": [
+        {
+            "Name": "SomeStruct",
+            "Type": {
+                "Kind": "struct",
+                "Struct": {
+                    "Fields": [
+                        {
+                            "Name": "fieldBool",
+                            "Required": true,
+                            "Default": true,
+                            "Type": {
+                                "Kind": "scalar",
+                                "Scalar": {"ScalarKind": "bool"}
+                            }
+                        },
+
+                        {
+                            "Name": "fieldString",
+                            "Required": true,
+                            "Default": "foo",
+                            "Type": {
+                                "Kind": "scalar",
+                                "Scalar": {"ScalarKind": "string"}
+                            }
+                        },
+                        {
+                            "Name": "FieldStringWithConstantValue",
+                            "Required": true,
+                            "Type": {
+                                "Kind": "scalar",
+                                "Scalar": {"ScalarKind": "string", "Value": "auto"}
+                            }
+                        },
+
+                        {
+                            "Name": "FieldFloat32",
+                            "Required": true,
+                            "Default": 42.42,
+                            "Type": {
+                                "Kind": "scalar",
+                                "Scalar": {"ScalarKind": "float32"}
+                            }
+                        },
+                        {
+                            "Name": "FieldInt32",
+                            "Required": true,
+                            "Default": 42,
+                            "Type": {
+                                "Kind": "scalar",
+                                "Scalar": {"ScalarKind": "int32"}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+-- out/jennies/TypescriptRawTypes --
+== types/defaults/types_gen.ts
+export interface SomeStruct {
+	fieldBool: boolean;
+	fieldString: string;
+	FieldStringWithConstantValue: "auto";
+	FieldFloat32: number;
+	FieldInt32: number;
+}
+
+export const defaultSomeStruct: Partial<SomeStruct> = {
+	fieldBool: true,
+	fieldString: "foo",
+	FieldFloat32: 42.42,
+	FieldInt32: 42,
+};
+
+-- out/jennies/GoRawTypes --
+== types/defaults/types_gen.go
+package types
+
+type SomeStruct struct {
+	FieldBool bool `json:"fieldBool"`
+	FieldString string `json:"fieldString"`
+	FieldStringWithConstantValue string `json:"FieldStringWithConstantValue"`
+	FieldFloat32 float32 `json:"FieldFloat32"`
+	FieldInt32 int32 `json:"FieldInt32"`
+}
+

--- a/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
@@ -112,18 +112,24 @@
 -- out/jennies/TypescriptRawTypes --
 == types/struct_optional_fields/types_gen.ts
 export interface SomeStruct {
-	fieldRef?: SomeOtherStruct;
-	fieldString?: string;
-	fieldAnonymousEnum?: ">" | "<";
-	fieldArrayOfStrings?: string[];
-	fieldAnonymousStruct?: {
-		fieldAny: any;
+	FieldRef?: SomeOtherStruct;
+	FieldString?: string;
+	FieldAnonymousEnum?: ">" | "<";
+	FieldArrayOfStrings?: string[];
+	FieldAnonymousStruct?: {
+		FieldAny: any;
 	};
 }
 
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
+
 export interface SomeOtherStruct {
-	fieldAny: any;
+	FieldAny: any;
 }
+
+export const defaultSomeOtherStruct: Partial<SomeOtherStruct> = {
+};
 
 -- out/jennies/GoRawTypes --
 == types/struct_optional_fields/types_gen.go

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
@@ -150,22 +150,25 @@
 export interface SomeStruct {
 	// Anything can go in there.
 	// Really, anything.
-	fieldAny: any;
-	fieldBool: boolean;
-	fieldBytes: string;
-	fieldString: string;
-	fieldStringWithConstantValue: "auto";
-	fieldFloat32: number;
-	fieldFloat64: number;
-	fieldUint8: number;
-	fieldUint16: number;
-	fieldUint32: number;
-	fieldUint64: number;
-	fieldInt8: number;
-	fieldInt16: number;
-	fieldInt32: number;
-	fieldInt64: number;
+	FieldAny: any;
+	FieldBool: boolean;
+	FieldBytes: string;
+	FieldString: string;
+	FieldStringWithConstantValue: "auto";
+	FieldFloat32: number;
+	FieldFloat64: number;
+	FieldUint8: number;
+	FieldUint16: number;
+	FieldUint32: number;
+	FieldUint64: number;
+	FieldInt8: number;
+	FieldInt16: number;
+	FieldInt32: number;
+	FieldInt64: number;
 }
+
+export const defaultSomeStruct: Partial<SomeStruct> = {
+};
 
 -- out/jennies/GoRawTypes --
 == types/basic/types_gen.go


### PR DESCRIPTION
Fixes #14 

Defaults are generated in the same way than cuetsy, to make (eventually) transitioning to cog that much easier.