### PR TITLE
Fix incorrect generation of "arrays of references" in Go

### DIFF
--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -219,7 +219,7 @@ func formatType(def ast.Type, typesPkg string) string {
 	}
 
 	if def.Kind == ast.KindRef {
-		typeName := def.AsRef().ReferredType
+		typeName := tools.UpperCamelCase(def.AsRef().ReferredType)
 
 		if typesPkg != "" {
 			typeName = typesPkg + "." + typeName

--- a/testdata/jennies/rawtypes/arrays.txtar
+++ b/testdata/jennies/rawtypes/arrays.txtar
@@ -18,7 +18,7 @@
         },
 
         {
-            "Name": "SomeStruct",
+            "Name": "someStruct",
             "Type": {
                 "Kind": "struct",
                 "Struct": {
@@ -42,7 +42,7 @@
                 "Array": {
                     "ValueType": {
                         "Kind": "ref",
-                        "Ref": {"ReferredType": "SomeStruct"}
+                        "Ref": {"ReferredType": "someStruct"}
                     }
                 }
             }
@@ -72,11 +72,11 @@
 // List of tags, maybe?
 export type ArrayOfStrings = string[];
 
-export interface SomeStruct {
+export interface someStruct {
 	fieldAny: any;
 }
 
-export type ArrayOfRefs = SomeStruct[];
+export type ArrayOfRefs = someStruct[];
 
 export type ArrayOfArrayOfNumbers = number[][];
 


### PR DESCRIPTION
Our go raw types jenny was generating this (note the name of the struct in both type definitions):

```go
type SomeStruct struct {
    // fields
}

type ArrayOfRefs []someStruct
```