### PR TITLE
Support references to types defined in another package

### DIFF
--- a/internal/ast/compiler/anonymous_enum.go
+++ b/internal/ast/compiler/anonymous_enum.go
@@ -8,7 +8,8 @@ import (
 var _ Pass = (*AnonymousEnumToExplicitType)(nil)
 
 type AnonymousEnumToExplicitType struct {
-	newObjects []ast.Object
+	newObjects     []ast.Object
+	currentPackage string
 }
 
 func (pass *AnonymousEnumToExplicitType) Process(files []*ast.File) ([]*ast.File, error) {
@@ -28,6 +29,7 @@ func (pass *AnonymousEnumToExplicitType) Process(files []*ast.File) ([]*ast.File
 
 func (pass *AnonymousEnumToExplicitType) processFile(file *ast.File) (*ast.File, error) {
 	pass.newObjects = nil
+	pass.currentPackage = file.Package
 
 	processedObjects := make([]ast.Object, 0, len(file.Definitions))
 	for _, object := range file.Definitions {
@@ -105,5 +107,5 @@ func (pass *AnonymousEnumToExplicitType) processAnonymousEnum(parentName string,
 		Type: ast.NewEnum(values),
 	})
 
-	return ast.NewRef(enumTypeName)
+	return ast.NewRef(pass.currentPackage, enumTypeName)
 }

--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -164,7 +164,7 @@ func (pass *DisjunctionToType) processDisjunction(file *ast.File, def ast.Type) 
 	// if we already generated a new object for this disjunction, let's return
 	// a reference to it.
 	if _, ok := pass.newObjects[newTypeName]; ok {
-		ref := ast.NewRef(newTypeName)
+		ref := ast.NewRef(file.Package, newTypeName)
 		if disjunction.Branches.HasNullType() {
 			ref.Nullable = true
 		}
@@ -215,7 +215,7 @@ func (pass *DisjunctionToType) processDisjunction(file *ast.File, def ast.Type) 
 		Type: structType,
 	}
 
-	ref := ast.NewRef(newTypeName)
+	ref := ast.NewRef(file.Package, newTypeName)
 	if disjunction.Branches.HasNullType() {
 		ref.Nullable = true
 	}

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -12,7 +12,7 @@ func TestDisjunctionToType_WithNonDisjunctionObjects_HasNoImpact(t *testing.T) {
 	// Prepare test input
 	objects := []ast.Object{
 		ast.NewObject("AMap", ast.NewMap(ast.String(), ast.String())),
-		ast.NewObject("ARef", ast.NewRef("AMap")),
+		ast.NewObject("ARef", ast.NewRef("test", "AMap")),
 		ast.NewObject("AnEnum", ast.NewEnum([]ast.EnumValue{
 			{
 				Name:  "Foo",
@@ -44,14 +44,14 @@ func TestDisjunctionToType_WithDisjunctionOfTypeAndNull_AsAnObject(t *testing.T)
 			ast.Null(),
 		})),
 		ast.NewObject("RefWithNull", ast.NewDisjunction([]ast.Type{
-			ast.NewRef("SomeType"),
+			ast.NewRef("test", "SomeType"),
 			ast.Null(),
 		})),
 	}
 
 	expectedObjects := []ast.Object{
 		ast.NewObject("ScalarWithNull", ast.String(ast.Nullable())),
-		ast.NewObject("RefWithNull", ast.NewRef("SomeType", ast.Nullable())),
+		ast.NewObject("RefWithNull", ast.NewRef("test", "SomeType", ast.Nullable())),
 	}
 
 	// Call the compiler pass
@@ -69,7 +69,7 @@ func TestDisjunctionToType_WithDisjunctionOfTypeAndNull_AsAStructField(t *testin
 		)),
 		ast.NewObject("StructWithRefWithNull", ast.NewStruct(
 			ast.NewStructField("Field", ast.NewDisjunction([]ast.Type{
-				ast.NewRef("SomeType"),
+				ast.NewRef("test", "SomeType"),
 				ast.Null(),
 			})),
 		)),
@@ -80,7 +80,7 @@ func TestDisjunctionToType_WithDisjunctionOfTypeAndNull_AsAStructField(t *testin
 			ast.NewStructField("Field", ast.String(ast.Nullable())),
 		)),
 		ast.NewObject("StructWithRefWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.NewRef("SomeType", ast.Nullable())),
+			ast.NewStructField("Field", ast.NewRef("test", "SomeType", ast.Nullable())),
 		)),
 	}
 
@@ -106,7 +106,7 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnObject(t *testing.T) {
 	disjunctionStructType.Struct.Hint[ast.HintDisjunctionOfScalars] = objects[0].Type.AsDisjunction()
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("ADisjunctionOfScalars", ast.NewRef("StringOrBool")),
+		ast.NewObject("ADisjunctionOfScalars", ast.NewRef("test", "StringOrBool")),
 		ast.NewObject("StringOrBool", disjunctionStructType),
 	}
 
@@ -137,7 +137,7 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAMapValueType(t *testing.T
 	expectedObjects := []ast.Object{
 		ast.NewObject("ADisjunctionOfScalars", ast.NewMap(
 			ast.String(),
-			ast.NewRef("StringOrBool"),
+			ast.NewRef("test", "StringOrBool"),
 		)),
 		ast.NewObject("StringOrBool", disjunctionStructType),
 	}
@@ -168,7 +168,7 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAStructField(t *testing.T)
 
 	expectedObjects := []ast.Object{
 		ast.NewObject("AStructWithADisjunctionOfScalars", ast.NewStruct(
-			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("StringOrBool")),
+			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("test", "StringOrBool")),
 		)),
 		ast.NewObject("StringOrBool", disjunctionStructType),
 	}
@@ -196,7 +196,7 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnArrayValueType(t *testin
 	disjunctionStructType.Struct.Hint[ast.HintDisjunctionOfScalars] = disjunctionType.AsDisjunction()
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("AnArrayWithADisjunctionOfScalars", ast.NewArray(ast.NewRef("StringOrBool"))),
+		ast.NewObject("AnArrayWithADisjunctionOfScalars", ast.NewArray(ast.NewRef("test", "StringOrBool"))),
 		ast.NewObject("StringOrBool", disjunctionStructType),
 	}
 
@@ -210,8 +210,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 	// Prepare test input
 	objects := []ast.Object{
 		ast.NewObject("ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
-			ast.NewRef("SomeStruct"),
-			ast.NewRef("OtherStruct"),
+			ast.NewRef("test", "SomeStruct"),
+			ast.NewRef("test", "OtherStruct"),
 		})),
 
 		ast.NewObject("SomeStruct", ast.NewStruct(
@@ -238,8 +238,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 
 	// Prepare test input
 	disjunctionType := ast.NewDisjunction([]ast.Type{
-		ast.NewRef("SomeStruct"),
-		ast.NewRef("OtherStruct"),
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
 	})
 	disjunctionType.Disjunction.Discriminator = "MapOfString"
 
@@ -270,8 +270,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 
 	// Prepare test input
 	disjunctionType := ast.NewDisjunction([]ast.Type{
-		ast.NewRef("SomeStruct"),
-		ast.NewRef("OtherStruct"),
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
 	})
 	disjunctionType.Disjunction.Discriminator = "Type"
 
@@ -302,8 +302,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 
 	// Prepare test input
 	disjunctionType := ast.NewDisjunction([]ast.Type{
-		ast.NewRef("SomeStruct"),
-		ast.NewRef("OtherStruct"),
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
 	})
 	disjunctionType.Disjunction.Discriminator = "DoesNotExist"
 
@@ -333,8 +333,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 	// Prepare test input
 	objects := []ast.Object{
 		ast.NewObject("ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
-			ast.NewRef("SomeStruct"),
-			ast.NewRef("OtherStruct"),
+			ast.NewRef("test", "SomeStruct"),
+			ast.NewRef("test", "OtherStruct"),
 		})),
 
 		ast.NewObject("SomeStruct", ast.NewStruct(
@@ -349,8 +349,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("OtherStruct", ast.Nullable())),
+		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -364,7 +364,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 	disjunctionStructType.Struct.Hint[ast.HintDiscriminatedDisjunctionOfRefs] = disjunctionTypeWithDiscriminatorMeta
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("SomeStructOrOtherStruct")),
+		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct")),
 		objects[1],
 		objects[2],
 		ast.NewObject("SomeStructOrOtherStruct", disjunctionStructType),
@@ -378,8 +378,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 	// Prepare test input
 
 	disjunctionType := ast.NewDisjunction([]ast.Type{
-		ast.NewRef("SomeStruct"),
-		ast.NewRef("OtherStruct"),
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
 	})
 	// Add discriminator-related metadata to the disjunction
 	// Mapping omitted: it will be inferred
@@ -402,8 +402,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("OtherStruct", ast.Nullable())),
+		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -417,7 +417,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 	disjunctionStructType.Struct.Hint[ast.HintDiscriminatedDisjunctionOfRefs] = disjunctionTypeWithDiscriminatorMeta
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("SomeStructOrOtherStruct")),
+		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct")),
 		objects[1],
 		objects[2],
 		ast.NewObject("SomeStructOrOtherStruct", disjunctionStructType),
@@ -430,8 +430,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFieldAndMappingSet(t *testing.T) {
 	// Prepare test input
 	disjunctionType := ast.NewDisjunction([]ast.Type{
-		ast.NewRef("SomeStruct"),
-		ast.NewRef("OtherStruct"),
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
 	})
 	// Add discriminator-related metadata to the disjunction
 	disjunctionType.Disjunction.Discriminator = "Kind"
@@ -457,8 +457,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("OtherStruct", ast.Nullable())),
+		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -472,7 +472,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 	disjunctionStructType.Struct.Hint[ast.HintDiscriminatedDisjunctionOfRefs] = disjunctionTypeWithDiscriminatorMeta
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("SomeStructOrOtherStruct")),
+		ast.NewObject("ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct")),
 		objects[1],
 		objects[2],
 		ast.NewObject("SomeStructOrOtherStruct", disjunctionStructType),

--- a/internal/ast/compiler/not_required_as_nullable_test.go
+++ b/internal/ast/compiler/not_required_as_nullable_test.go
@@ -18,9 +18,9 @@ func TestNotRequiredFieldAsNullableType(t *testing.T) {
 			ast.NewStructField("RequiredNullableString", ast.String(ast.Nullable()), ast.Required()),
 			ast.NewStructField("NotRequiredString", ast.String()),
 
-			ast.NewStructField("RequiredRef", ast.NewRef("SomeStruct"), ast.Required()),
-			ast.NewStructField("RequiredNullableRef", ast.NewRef("SomeStruct", ast.Nullable()), ast.Required()),
-			ast.NewStructField("NotRequiredRef", ast.NewRef("SomeStruct")),
+			ast.NewStructField("RequiredRef", ast.NewRef("test", "SomeStruct"), ast.Required()),
+			ast.NewStructField("RequiredNullableRef", ast.NewRef("test", "SomeStruct", ast.Nullable()), ast.Required()),
+			ast.NewStructField("NotRequiredRef", ast.NewRef("test", "SomeStruct")),
 
 			ast.NewStructField("NotRequiredArray", ast.NewArray(ast.String())),
 			ast.NewStructField("RequiredArray", ast.NewArray(ast.String()), ast.Required()),
@@ -45,9 +45,9 @@ func TestNotRequiredFieldAsNullableType(t *testing.T) {
 			ast.NewStructField("RequiredNullableString", ast.String(ast.Nullable()), ast.Required()),
 			ast.NewStructField("NotRequiredString", ast.String(ast.Nullable())), // should become nullable
 
-			ast.NewStructField("RequiredRef", ast.NewRef("SomeStruct"), ast.Required()),
-			ast.NewStructField("RequiredNullableRef", ast.NewRef("SomeStruct", ast.Nullable()), ast.Required()),
-			ast.NewStructField("NotRequiredRef", ast.NewRef("SomeStruct", ast.Nullable())), // should become nullable
+			ast.NewStructField("RequiredRef", ast.NewRef("test", "SomeStruct"), ast.Required()),
+			ast.NewStructField("RequiredNullableRef", ast.NewRef("test", "SomeStruct", ast.Nullable()), ast.Required()),
+			ast.NewStructField("NotRequiredRef", ast.NewRef("test", "SomeStruct", ast.Nullable())), // should become nullable
 
 			ast.NewStructField("NotRequiredArray", ast.NewArray(ast.String(), ast.Nullable())), // should become nullable
 			ast.NewStructField("RequiredArray", ast.NewArray(ast.String()), ast.Required()),

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -231,10 +231,11 @@ func NewStruct(fields ...StructField) Type {
 	}
 }
 
-func NewRef(referredTypeName string, opts ...TypeOption) Type {
+func NewRef(referredPkg string, referredTypeName string, opts ...TypeOption) Type {
 	def := Type{
 		Kind: KindRef,
 		Ref: &RefType{
+			ReferredPkg:  referredPkg,
 			ReferredType: referredTypeName,
 		},
 	}
@@ -594,11 +595,13 @@ func NewStructField(name string, fieldType Type, opts ...StructFieldOption) Stru
 }
 
 type RefType struct {
+	ReferredPkg  string
 	ReferredType string
 }
 
 func (t RefType) DeepCopy() RefType {
 	return RefType{
+		ReferredPkg:  t.ReferredPkg,
 		ReferredType: t.ReferredType,
 	}
 }

--- a/internal/ast/types_test.go
+++ b/internal/ast/types_test.go
@@ -32,14 +32,14 @@ func TestTypes_HasOnlyScalarOrArray(t *testing.T) {
 			description: "scalars and an array of refs",
 			types: []Type{
 				NewScalar(KindString),
-				NewArray(NewRef("SomeType")),
+				NewArray(NewRef("pkg", "SomeType")),
 			},
 			expected: false,
 		},
 		{
 			description: "ref",
 			types: []Type{
-				NewRef("SomeType"),
+				NewRef("pkg", "SomeType"),
 			},
 			expected: false,
 		},
@@ -47,7 +47,7 @@ func TestTypes_HasOnlyScalarOrArray(t *testing.T) {
 			description: "scalars and ref",
 			types: []Type{
 				NewScalar(KindString),
-				NewRef("SomeType"),
+				NewRef("pkg", "SomeType"),
 			},
 			expected: false,
 		},
@@ -89,15 +89,15 @@ func TestTypes_HasOnlyRefs(t *testing.T) {
 		{
 			description: "refs",
 			types: []Type{
-				NewRef("SomeType"),
-				NewRef("SomeOtherType"),
+				NewRef("pkg", "SomeType"),
+				NewRef("pkg", "SomeOtherType"),
 			},
 			expected: true,
 		},
 		{
 			description: "ref",
 			types: []Type{
-				NewRef("SomeType"),
+				NewRef("pkg", "SomeType"),
 			},
 			expected: true,
 		},
@@ -137,7 +137,7 @@ func TestArrayType_IsArrayOfScalars(t *testing.T) {
 		{
 			description: "array of refs",
 			array: ArrayType{
-				ValueType: NewRef("SomeType"),
+				ValueType: NewRef("pkg", "SomeType"),
 			},
 			Expected: false,
 		},

--- a/internal/jennies/golang/importmap.go
+++ b/internal/jennies/golang/importmap.go
@@ -1,0 +1,32 @@
+package golang
+
+import (
+	"fmt"
+	"strings"
+)
+
+type importMap map[string]string
+
+func newImportMap() importMap {
+	return make(map[string]string)
+}
+
+func (im importMap) Add(alias string, importPath string) {
+	im[alias] = importPath
+}
+
+func (im importMap) Format() string {
+	if len(im) == 0 {
+		return ""
+	}
+
+	statements := make([]string, 0, len(im))
+
+	for alias, importPath := range im {
+		statements = append(statements, fmt.Sprintf(`	%s "%s"`, alias, importPath))
+	}
+
+	return fmt.Sprintf(`import (
+%[1]s
+)`, strings.Join(statements, "\n"))
+}

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -27,7 +27,7 @@ func Jennies() *codejen.JennyList[[]*ast.File] {
 				// apply common veneers
 				builders = veneers.Common().ApplyTo(builders)
 
-				// apply TS-specific veneers
+				// apply Go-specific veneers
 				return Veneers().ApplyTo(builders)
 			},
 		),

--- a/internal/jennies/golang/veneers/disjunction_of_scalars.types.json_marshal.go.tmpl
+++ b/internal/jennies/golang/veneers/disjunction_of_scalars.types.json_marshal.go.tmpl
@@ -16,7 +16,7 @@ func (resource *{{ .def.Name|formatIdentifier }}) UnmarshalJSON(raw []byte) erro
 	var errList []error
 {{ range .def.Type.Struct.Fields }}
 	// {{ .Name|formatIdentifier }}
-	var {{ .Name }} {{ trimPrefix (formatType .Type "") "*" }}
+	var {{ .Name }} {{ trimPrefix (formatType .Type $.pkgMapper) "*" }}
 	if err := json.Unmarshal(raw, &{{ .Name }}); err != nil {
 		errList = append(errList, err)
 		resource.{{ .Name|formatIdentifier }} = nil

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Builder struct {
+	imports importMap
 }
 
 func (jenny *Builder) JennyName() string {
@@ -37,14 +38,16 @@ func (jenny *Builder) Generate(builders []ast.Builder) (codejen.Files, error) {
 func (jenny *Builder) generateBuilder(builders ast.Builders, builder ast.Builder) ([]byte, error) {
 	var buffer strings.Builder
 
+	jenny.imports = newImportMap()
+
 	objectName := tools.UpperCamelCase(builder.For.Name)
 
 	// imports
-	buffer.WriteString(fmt.Sprintf("import * as types from \"../../types/%s/types_gen\";\n", builder.Package))
-	buffer.WriteString("import { OptionsBuilder } from \"../../options_builder_gen\";\n\n")
+	jenny.imports.Add("types", fmt.Sprintf("../../types/%s/types_gen", builder.Package))
+	buffer.WriteString("import { CogOptionsBuilder } from \"../../options_builder_gen\";\n\n")
 
 	// Builder class declaration
-	buffer.WriteString(fmt.Sprintf("export class %[1]sBuilder implements OptionsBuilder<types.%[1]s> {\n", objectName))
+	buffer.WriteString(fmt.Sprintf("export class %[1]sBuilder implements CogOptionsBuilder<types.%[1]s> {\n", objectName))
 
 	// internal property, representing the object being built
 	buffer.WriteString(fmt.Sprintf("\tprivate internal: types.%[1]s;\n", objectName))
@@ -69,7 +72,12 @@ func (jenny *Builder) generateBuilder(builders ast.Builders, builder ast.Builder
 	// End builder class declaration
 	buffer.WriteString("}\n")
 
-	return []byte(buffer.String()), nil
+	importStatements := jenny.imports.Format()
+	if importStatements != "" {
+		importStatements += "\n"
+	}
+
+	return []byte(importStatements + buffer.String()), nil
 }
 
 func (jenny *Builder) generateConstructor(builders ast.Builders, builder ast.Builder) string {
@@ -119,8 +127,8 @@ func (jenny *Builder) emptyValueForType(builders ast.Builders, pkg string, typeD
 	case ast.KindDisjunction:
 		return jenny.emptyValueForType(builders, pkg, typeDef.AsDisjunction().Branches[0])
 	case ast.KindRef:
-		referredTypeName := typeDef.AsRef().ReferredType
-		referredTypeBuilder, _ := builders.LocateByObject(pkg, referredTypeName)
+		ref := typeDef.AsRef()
+		referredTypeBuilder, _ := builders.LocateByObject(ref.ReferredPkg, ref.ReferredType)
 
 		return jenny.emptyValueForType(builders, referredTypeBuilder.Package, referredTypeBuilder.For.Type)
 	case ast.KindStruct:
@@ -195,10 +203,10 @@ func (jenny *Builder) typeHasBuilder(builders ast.Builders, builder ast.Builder,
 		return "", false
 	}
 
-	referredTypeName := t.AsRef().ReferredType
-	_, builderFound := builders.LocateByObject(builder.Package, referredTypeName)
+	ref := t.AsRef()
+	_, builderFound := builders.LocateByObject(builder.Package, ref.ReferredType)
 
-	return referredTypeName, builderFound
+	return ref.ReferredPkg, builderFound
 }
 
 func (jenny *Builder) generateInitAssignment(builders ast.Builders, builder ast.Builder, assignment ast.Assignment) string {
@@ -260,7 +268,15 @@ func (jenny *Builder) generateOption(builders ast.Builders, builder ast.Builder,
 }
 
 func (jenny *Builder) generateArgument(builders ast.Builders, builder ast.Builder, arg ast.Argument) string {
-	typeName := formatType(arg.Type, "types")
+	typeName := formatType(arg.Type, func(pkg string) string {
+		if pkg == builder.Package {
+			return "types"
+		}
+
+		jenny.imports.Add(pkg, fmt.Sprintf("../../types/%s/types_gen", pkg))
+
+		return pkg
+	})
 
 	if referredTypeName, found := jenny.typeHasBuilder(builders, builder, arg.Type); found {
 		return fmt.Sprintf(`%[1]s: OptionsBuilder<types.%[2]s>`, arg.Name, referredTypeName)

--- a/internal/jennies/typescript/importmap.go
+++ b/internal/jennies/typescript/importmap.go
@@ -1,0 +1,30 @@
+package typescript
+
+import (
+	"fmt"
+	"strings"
+)
+
+type importMap map[string]string
+
+func newImportMap() importMap {
+	return make(map[string]string)
+}
+
+func (im importMap) Add(alias string, importPath string) {
+	im[alias] = importPath
+}
+
+func (im importMap) Format() string {
+	if len(im) == 0 {
+		return ""
+	}
+
+	statements := make([]string, 0, len(im))
+
+	for alias, importPath := range im {
+		statements = append(statements, fmt.Sprintf(`import * as %s from "%s";`, alias, importPath))
+	}
+
+	return strings.Join(statements, "\n")
+}

--- a/internal/jennies/typescript/optionsbuilder.go
+++ b/internal/jennies/typescript/optionsbuilder.go
@@ -19,7 +19,7 @@ func (jenny OptionsBuilder) Generate(_ []*ast.File) (*codejen.File, error) {
 }
 
 func (jenny OptionsBuilder) generateFile() string {
-	return `export interface OptionsBuilder<T> {
+	return `export interface CogOptionsBuilder<T> {
   build: () => T;
 }
 `

--- a/internal/jennies/typescript/optionsbuilder_test.go
+++ b/internal/jennies/typescript/optionsbuilder_test.go
@@ -16,7 +16,7 @@ func TestOptionsBuilder(t *testing.T) {
 
 	req.Equal("options_builder_gen.ts", file.RelativePath)
 	req.NotEmpty(file.From)
-	req.Equal(`export interface OptionsBuilder<T> {
+	req.Equal(`export interface CogOptionsBuilder<T> {
   build: () => T;
 }
 `, string(file.Data))

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -9,6 +9,8 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
+type pkgMapper func(string) string
+
 type RawTypes struct {
 }
 
@@ -30,8 +32,20 @@ func (jenny RawTypes) Generate(file *ast.File) (codejen.Files, error) {
 func (jenny RawTypes) generateFile(file *ast.File) ([]byte, error) {
 	var buffer strings.Builder
 
+	imports := newImportMap()
+
+	packageMapper := func(pkg string) string {
+		if pkg == file.Package {
+			return ""
+		}
+
+		imports.Add(pkg, fmt.Sprintf("../%s/types_gen", pkg))
+
+		return pkg
+	}
+
 	for _, typeDef := range file.Definitions {
-		typeDefGen, err := jenny.formatObject(typeDef, "")
+		typeDefGen, err := jenny.formatObject(typeDef, packageMapper)
 		if err != nil {
 			return nil, err
 		}
@@ -40,10 +54,15 @@ func (jenny RawTypes) generateFile(file *ast.File) ([]byte, error) {
 		buffer.WriteString("\n")
 	}
 
-	return []byte(buffer.String()), nil
+	importStatements := imports.Format()
+	if importStatements != "" {
+		importStatements += "\n\n"
+	}
+
+	return []byte(importStatements + buffer.String()), nil
 }
 
-func (jenny RawTypes) formatObject(def ast.Object, typesPkg string) ([]byte, error) {
+func (jenny RawTypes) formatObject(def ast.Object, packageMapper pkgMapper) ([]byte, error) {
 	var buffer strings.Builder
 
 	for _, commentLine := range def.Comments {
@@ -55,7 +74,7 @@ func (jenny RawTypes) formatObject(def ast.Object, typesPkg string) ([]byte, err
 	switch def.Type.Kind {
 	case ast.KindStruct:
 		buffer.WriteString(fmt.Sprintf("interface %s ", def.Name))
-		buffer.WriteString(formatStructFields(def.Type.AsStruct().Fields, typesPkg))
+		buffer.WriteString(formatStructFields(def.Type.AsStruct().Fields, packageMapper))
 		buffer.WriteString("\n")
 
 		buffer.WriteString("\n")
@@ -67,12 +86,8 @@ func (jenny RawTypes) formatObject(def ast.Object, typesPkg string) ([]byte, err
 			buffer.WriteString(fmt.Sprintf("\t%s = %s,\n", tools.UpperCamelCase(val.Name), formatScalar(val.Value)))
 		}
 		buffer.WriteString("}\n")
-	case ast.KindRef:
-		refType := def.Type.AsRef()
-
-		buffer.WriteString(fmt.Sprintf("type %s = %s;", def.Name, refType.ReferredType))
-	case ast.KindDisjunction, ast.KindMap, ast.KindArray:
-		buffer.WriteString(fmt.Sprintf("type %s = %s;\n", def.Name, formatType(def.Type, "")))
+	case ast.KindDisjunction, ast.KindMap, ast.KindArray, ast.KindRef:
+		buffer.WriteString(fmt.Sprintf("type %s = %s;\n", def.Name, formatType(def.Type, packageMapper)))
 	case ast.KindScalar:
 		scalarType := def.Type.AsScalar()
 		if scalarType.Value != nil {
@@ -87,13 +102,13 @@ func (jenny RawTypes) formatObject(def ast.Object, typesPkg string) ([]byte, err
 	return []byte(buffer.String()), nil
 }
 
-func formatStructFields(fields []ast.StructField, typesPkg string) string {
+func formatStructFields(fields []ast.StructField, packageMapper pkgMapper) string {
 	var buffer strings.Builder
 
 	buffer.WriteString("{\n")
 
 	for _, fieldDef := range fields {
-		fieldDefGen := formatField(fieldDef, typesPkg)
+		fieldDefGen := formatField(fieldDef, packageMapper)
 
 		buffer.WriteString(
 			strings.TrimSuffix(
@@ -127,7 +142,7 @@ func formatStructDefaults(def ast.Object) string {
 	return buffer.String()
 }
 
-func formatField(def ast.StructField, typesPkg string) []byte {
+func formatField(def ast.StructField, packageMapper pkgMapper) []byte {
 	var buffer strings.Builder
 
 	for _, commentLine := range def.Comments {
@@ -139,7 +154,7 @@ func formatField(def ast.StructField, typesPkg string) []byte {
 		required = "?"
 	}
 
-	formattedType := formatType(def.Type, typesPkg)
+	formattedType := formatType(def.Type, packageMapper)
 
 	buffer.WriteString(fmt.Sprintf(
 		"%s%s: %s;\n",
@@ -151,22 +166,23 @@ func formatField(def ast.StructField, typesPkg string) []byte {
 	return []byte(buffer.String())
 }
 
-func formatType(def ast.Type, typesPkg string) string {
+func formatType(def ast.Type, packageMapper pkgMapper) string {
 	switch def.Kind {
 	case ast.KindDisjunction:
-		return formatDisjunction(def.AsDisjunction(), typesPkg)
+		return formatDisjunction(def.AsDisjunction(), packageMapper)
 	case ast.KindRef:
-		if typesPkg != "" {
-			return typesPkg + "." + def.AsRef().ReferredType
+		referredPkg := packageMapper(def.AsRef().ReferredPkg)
+		if referredPkg != "" {
+			return referredPkg + "." + def.AsRef().ReferredType
 		}
 
 		return def.AsRef().ReferredType
 	case ast.KindArray:
-		return formatArray(def.AsArray(), typesPkg)
+		return formatArray(def.AsArray(), packageMapper)
 	case ast.KindStruct:
-		return formatStructFields(def.AsStruct().Fields, typesPkg)
+		return formatStructFields(def.AsStruct().Fields, packageMapper)
 	case ast.KindMap:
-		return formatMap(def.AsMap(), typesPkg)
+		return formatMap(def.AsMap(), packageMapper)
 	case ast.KindEnum:
 		return formatAnonymousEnum(def.AsEnum())
 	case ast.KindScalar:
@@ -206,24 +222,24 @@ func formatScalarKind(kind ast.ScalarKind) string {
 	}
 }
 
-func formatArray(def ast.ArrayType, typesPkg string) string {
-	subTypeString := formatType(def.ValueType, typesPkg)
+func formatArray(def ast.ArrayType, packageMapper pkgMapper) string {
+	subTypeString := formatType(def.ValueType, packageMapper)
 
 	return fmt.Sprintf("%s[]", subTypeString)
 }
 
-func formatDisjunction(def ast.DisjunctionType, typesPkg string) string {
+func formatDisjunction(def ast.DisjunctionType, packageMapper pkgMapper) string {
 	subTypes := make([]string, 0, len(def.Branches))
 	for _, subType := range def.Branches {
-		subTypes = append(subTypes, formatType(subType, typesPkg))
+		subTypes = append(subTypes, formatType(subType, packageMapper))
 	}
 
 	return strings.Join(subTypes, " | ")
 }
 
-func formatMap(def ast.MapType, typesPkg string) string {
-	keyTypeString := formatType(def.IndexType, typesPkg)
-	valueTypeString := formatType(def.ValueType, typesPkg)
+func formatMap(def ast.MapType, packageMapper pkgMapper) string {
+	keyTypeString := formatType(def.IndexType, packageMapper)
+	valueTypeString := formatType(def.ValueType, packageMapper)
 
 	return fmt.Sprintf("Record<%s, %s>", keyTypeString, valueTypeString)
 }

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -198,7 +198,8 @@ func (g *generator) walkRef(schema *schemaparser.Schema) (ast.Type, error) {
 		return ast.Type{}, err
 	}
 
-	return ast.NewRef(referredKindName), nil
+	// TODO: get the correct package for the referred type
+	return ast.NewRef(g.file.Package, referredKindName), nil
 }
 
 func (g *generator) walkString(_ *schemaparser.Schema) (ast.Type, error) {

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 
 	"cuelang.org/go/cue"
+	cueast "cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/format"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -225,13 +227,81 @@ func (g *generator) structFields(v cue.Value) ([]ast.StructField, error) {
 	return fields, nil
 }
 
+// FIXME: this is probably very brittle and not always correct :|
+func (g *generator) referencePackage(source cueast.Node) (string, error) {
+	switch source.(type) { //nolint: gocritic
+	case *cueast.SelectorExpr:
+		selector := source.(*cueast.SelectorExpr)
+
+		x := selector.X.(*cueast.Ident)
+
+		return x.Name, nil
+	case *cueast.Field:
+		field := source.(*cueast.Field)
+
+		if _, ok := field.Value.(*cueast.SelectorExpr); ok {
+			return g.referencePackage(field.Value)
+		}
+
+		ident := field.Value.(*cueast.Ident)
+
+		if ident.Scope == nil {
+			return g.file.Package, nil
+		}
+
+		if _, ok := ident.Scope.(*cueast.File); !ok {
+			return g.file.Package, nil
+		}
+
+		scope := ident.Scope.(*cueast.File)
+		if len(scope.Decls) == 0 {
+			return g.file.Package, nil
+		}
+
+		referredTypePkg := scope.Decls[0].(*cueast.Package).Name
+
+		return referredTypePkg.Name, nil
+	case *cueast.Ident:
+		ident := source.(*cueast.Ident)
+		if ident.Scope == nil {
+			return g.file.Package, nil
+		}
+
+		if _, ok := ident.Scope.(*cueast.File); !ok {
+			return g.file.Package, nil
+		}
+
+		scope := ident.Scope.(*cueast.File)
+		if len(scope.Decls) == 0 {
+			return g.file.Package, nil
+		}
+
+		referredTypePkg := ident.Scope.(*cueast.File).Decls[0].(*cueast.Package).Name
+
+		return referredTypePkg.Name, nil
+	case *cueast.Ellipsis: // TODO: this makes no sense
+		return g.file.Package, nil
+	default:
+		spew.Dump(source)
+		return "", fmt.Errorf("can't extract reference package")
+	}
+}
+
 func (g *generator) declareNode(v cue.Value) (ast.Type, error) {
 	// This node is referring to another definition
 	_, path := v.ReferencePath()
 	if path.String() != "" {
 		selectors := path.Selectors()
 
-		return ast.NewRef(selectorLabel(selectors[len(selectors)-1])), nil
+		refPkg, err := g.referencePackage(v.Source())
+		if err != nil {
+			return ast.Type{}, errorWithCueRef(v, err.Error())
+		}
+
+		return ast.NewRef(
+			refPkg,
+			selectorLabel(selectors[len(selectors)-1]),
+		), nil
 	}
 
 	disjunctions := appendSplit(nil, cue.OrOp, v)

--- a/testdata/jennies/rawtypes/arrays.txtar
+++ b/testdata/jennies/rawtypes/arrays.txtar
@@ -42,7 +42,7 @@
                 "Array": {
                     "ValueType": {
                         "Kind": "ref",
-                        "Ref": {"ReferredType": "someStruct"}
+                        "Ref": {"ReferredPkg": "arrays", "ReferredType": "someStruct"}
                     }
                 }
             }

--- a/testdata/jennies/rawtypes/disjunctions.txtar
+++ b/testdata/jennies/rawtypes/disjunctions.txtar
@@ -80,7 +80,7 @@
                         },
                         {
                             "Kind": "ref",
-                            "Ref": {"ReferredType": "SomeStruct"}
+                            "Ref": {"ReferredPkg": "disjunctions", "ReferredType": "SomeStruct"}
                         }
                     ]
                 }
@@ -146,15 +146,15 @@
                     "Branches": [
                         {
                             "Kind": "ref",
-                            "Ref": {"ReferredType": "SomeStruct"}
+                            "Ref": {"ReferredPkg": "disjunctions", "ReferredType": "SomeStruct"}
                         },
                         {
                             "Kind": "ref",
-                            "Ref": {"ReferredType": "SomeOtherStruct"}
+                            "Ref": {"ReferredPkg": "disjunctions", "ReferredType": "SomeOtherStruct"}
                         },
                         {
                             "Kind": "ref",
-                            "Ref": {"ReferredType": "YetAnotherStruct"}
+                            "Ref": {"ReferredPkg": "disjunctions", "ReferredType": "YetAnotherStruct"}
                         }
                     ]
                 }

--- a/testdata/jennies/rawtypes/maps.txtar
+++ b/testdata/jennies/rawtypes/maps.txtar
@@ -67,7 +67,7 @@
                     },
                     "ValueType": {
                         "Kind": "ref",
-                        "Ref": {"ReferredType": "SomeStruct"}
+                        "Ref": {"ReferredPkg": "maps", "ReferredType": "SomeStruct"}
                     }
                 }
             }

--- a/testdata/jennies/rawtypes/refs.txtar
+++ b/testdata/jennies/rawtypes/refs.txtar
@@ -25,13 +25,22 @@
             "Name": "RefToSomeStruct",
             "Type": {
                 "Kind": "ref",
-                "Ref": {"ReferredType": "SomeStruct"}
+                "Ref": {"ReferredPkg": "refs", "ReferredType": "SomeStruct"}
+            }
+        },
+        {
+            "Name": "RefToSomeStructFromOtherPackage",
+            "Type": {
+                "Kind": "ref",
+                "Ref": {"ReferredPkg": "otherpkg", "ReferredType": "SomeDistantStruct"}
             }
         }
     ]
 }
 -- out/jennies/TypescriptRawTypes --
 == types/refs/types_gen.ts
+import * as otherpkg from "../otherpkg/types_gen";
+
 export interface SomeStruct {
 	FieldAny: any;
 }
@@ -40,13 +49,22 @@ export const defaultSomeStruct: Partial<SomeStruct> = {
 };
 
 export type RefToSomeStruct = SomeStruct;
+
+export type RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct;
+
 -- out/jennies/GoRawTypes --
 == types/refs/types_gen.go
 package types
+
+import (
+	otherpkg "github.com/grafana/cog/generated/types/otherpkg"
+)
 
 type SomeStruct struct {
 	FieldAny any `json:"FieldAny"`
 }
 
 type RefToSomeStruct SomeStruct
+
+type RefToSomeStructFromOtherPackage otherpkg.SomeDistantStruct
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -15,7 +15,7 @@
                             "Required": true,
                             "Type": {
                                 "Kind": "ref",
-                                "Ref": {"ReferredType": "SomeOtherStruct"}
+                                "Ref": {"ReferredPkg": "struct_complex_fields", "ReferredType": "SomeOtherStruct"}
                             }
                         },
                         {
@@ -50,7 +50,7 @@
                                         },
                                         {
                                             "Kind": "ref",
-                                            "Ref": {"ReferredType": "SomeOtherStruct"}
+                                            "Ref": {"ReferredPkg": "struct_complex_fields", "ReferredType": "SomeOtherStruct"}
                                         }
                                     ]
                                 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
@@ -14,7 +14,7 @@
                             "Required": false,
                             "Type": {
                                 "Kind": "ref",
-                                "Ref": {"ReferredType": "SomeOtherStruct"}
+                                "Ref": {"ReferredPkg": "struct_optional_fields", "ReferredType": "SomeOtherStruct"}
                             }
                         },
                         {


### PR DESCRIPTION
Now that we're more seriously looking into supporting composability, we have to address some of the shortcomings of our current "types" IR.

Namely: references to types defined in another package/schema couldn't be represented. See [the timeseries panel schema](https://github.com/grafana/kind-registry/blob/5d2ae9bf05a6dfcd72d4ef2eee472cef45896ae6/grafana/next/composable/timeseries/panelcfg.cue#L16) for example.

This PR introduces a naive way to get that working. IE: it works just enough to make the code we generate compile.

We still hard-code import paths for example, but we can refactor that once we actually need to.