### PR TITLE
Represent assignment path as a strongly typed path

### DIFF
--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -1,5 +1,9 @@
 package ast
 
+import (
+	"fmt"
+)
+
 type Kind string
 
 const (
@@ -569,6 +573,10 @@ func NewStructField(name string, fieldType Type, opts ...StructFieldOption) Stru
 type RefType struct {
 	ReferredPkg  string
 	ReferredType string
+}
+
+func (t RefType) String() string {
+	return fmt.Sprintf("%s.%s", t.ReferredPkg, t.ReferredType)
 }
 
 func (t RefType) DeepCopy() RefType {

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -225,8 +225,9 @@ func (jenny *Builder) builderForType(builders ast.Builders, builder ast.Builder,
 
 func (jenny *Builder) generateInitAssignment(builders ast.Builders, builder ast.Builder, assignment ast.Assignment) string {
 	fieldPath := assignment.Path
+	valueType := assignment.Path.Last().Type
 
-	if _, valueHasBuilder := jenny.builderForType(builders, builder, assignment.ValueType); valueHasBuilder {
+	if _, valueHasBuilder := jenny.builderForType(builders, builder, valueType); valueHasBuilder {
 		return "constructor init assignment with type that has a builder is not supported yet"
 	}
 
@@ -306,8 +307,9 @@ func (jenny *Builder) generateArgument(builders ast.Builders, builder ast.Builde
 
 func (jenny *Builder) generateAssignment(builders ast.Builders, builder ast.Builder, assignment ast.Assignment) string {
 	fieldPath := assignment.Path
+	valueType := assignment.Path.Last().Type
 
-	if _, found := jenny.builderForType(builders, builder, assignment.ValueType); found {
+	if _, found := jenny.builderForType(builders, builder, valueType); found {
 		return fmt.Sprintf("\t\tthis.internal.%[1]s = %[2]s.build();", fieldPath, assignment.ArgumentName)
 	}
 

--- a/internal/tools/arrays.go
+++ b/internal/tools/arrays.go
@@ -9,3 +9,13 @@ func ItemInList[T comparable](needle T, haystack []T) bool {
 
 	return false
 }
+
+func Map[T any, O any](input []T, mapper func(T) O) []O {
+	output := make([]O, len(input))
+
+	for i := range input {
+		output[i] = mapper(input[i])
+	}
+
+	return output
+}

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -95,13 +95,13 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 				Type: field.Type,
 			})
 
-			newOpt.Assignments = append(newOpt.Assignments, ast.Assignment{
-				Path:              assignmentPathPrefix + "." + field.Name,
-				ArgumentName:      field.Name,
-				ValueType:         field.Type,
-				Constraints:       constraints,
-				IntoNullableField: field.Type.Nullable,
-			})
+			newAssignment := ast.Assignment{
+				ArgumentName: field.Name,
+				Constraints:  constraints,
+				Path:         assignmentPathPrefix.Append(ast.PathFromStructField(field)),
+			}
+
+			newOpt.Assignments = append(newOpt.Assignments, newAssignment)
 		}
 
 		if len(oldArgs) > 1 {
@@ -124,28 +124,16 @@ func UnfoldBooleanAction(unfoldOpts BooleanUnfold) RewriteAction {
 			{
 				Name:     unfoldOpts.OptionTrue,
 				Comments: option.Comments,
-				Args:     nil,
 				Assignments: []ast.Assignment{
-					{
-						Path:              option.Assignments[0].Path,
-						ValueType:         option.Assignments[0].ValueType,
-						IntoNullableField: option.Assignments[0].IntoNullableField,
-						Value:             true,
-					},
+					{Path: option.Assignments[0].Path, Value: true},
 				},
 			},
 
 			{
 				Name:     unfoldOpts.OptionFalse,
 				Comments: option.Comments,
-				Args:     nil,
 				Assignments: []ast.Assignment{
-					{
-						Path:              option.Assignments[0].Path,
-						ValueType:         option.Assignments[0].ValueType,
-						IntoNullableField: option.Assignments[0].IntoNullableField,
-						Value:             false,
-					},
+					{Path: option.Assignments[0].Path, Value: false},
 				},
 			},
 		}

--- a/internal/veneers/rewrite_test.go
+++ b/internal/veneers/rewrite_test.go
@@ -68,7 +68,10 @@ func testData() []rewriteTestCase {
 								{Name: "id", Type: ast.NewScalar(ast.KindInt64)},
 							},
 							Assignments: []ast.Assignment{
-								{Path: "id", ValueType: ast.NewScalar(ast.KindInt64), ArgumentName: "id"},
+								{
+									ArgumentName: "id",
+									Path:         ast.Path{{Identifier: "id", Type: ast.NewScalar(ast.KindInt64)}},
+								},
 							},
 						},
 						{
@@ -77,7 +80,10 @@ func testData() []rewriteTestCase {
 								{Name: "type", Type: ast.String()},
 							},
 							Assignments: []ast.Assignment{
-								{Path: "type", ValueType: ast.String(), ArgumentName: "type"},
+								{
+									ArgumentName: "type",
+									Path:         ast.Path{{Identifier: "type", Type: ast.String()}},
+								},
 							},
 						},
 					},
@@ -112,7 +118,10 @@ func testData() []rewriteTestCase {
 								{Name: "uid", Type: ast.String()},
 							},
 							Assignments: []ast.Assignment{
-								{Path: "uid", ValueType: ast.String(), ArgumentName: "uid"},
+								{
+									ArgumentName: "uid",
+									Path:         ast.Path{{Identifier: "uid", Type: ast.String()}},
+								},
 							},
 						},
 					},
@@ -141,7 +150,10 @@ func dashboardBuilder() ast.Builder {
 					{Name: "uid", Type: ast.String()},
 				},
 				Assignments: []ast.Assignment{
-					{Path: "uid", ValueType: ast.String(), ArgumentName: "uid"},
+					{
+						ArgumentName: "uid",
+						Path:         ast.Path{{Identifier: "uid", Type: ast.String()}},
+					},
 				},
 			},
 			{
@@ -150,7 +162,10 @@ func dashboardBuilder() ast.Builder {
 					{Name: "title", Type: ast.String()},
 				},
 				Assignments: []ast.Assignment{
-					{Path: "title", ValueType: ast.String(), ArgumentName: "title"},
+					{
+						ArgumentName: "title",
+						Path:         ast.Path{{Identifier: "title", Type: ast.String()}},
+					},
 				},
 			},
 		},
@@ -175,7 +190,10 @@ func panelBuilder() ast.Builder {
 					{Name: "id", Type: ast.NewScalar(ast.KindInt64)},
 				},
 				Assignments: []ast.Assignment{
-					{Path: "id", ValueType: ast.NewScalar(ast.KindInt64), ArgumentName: "id"},
+					{
+						ArgumentName: "id",
+						Path:         ast.Path{{Identifier: "id", Type: ast.NewScalar(ast.KindInt64)}},
+					},
 				},
 			},
 			{
@@ -184,7 +202,10 @@ func panelBuilder() ast.Builder {
 					{Name: "type", Type: ast.String()},
 				},
 				Assignments: []ast.Assignment{
-					{Path: "type", ValueType: ast.String(), ArgumentName: "type"},
+					{
+						ArgumentName: "type",
+						Path:         ast.Path{{Identifier: "type", Type: ast.String()}},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
A *path*, as used in `Assignment`, were described as just a string. Ex: `fieldConfig.defaults.custom.stacking`

Having this information described accurately, with the types of every element along the path, will allow us to generate "smarter" and more accurate code.