### PR TITLE
Fix for disjunctions defined as a nullable type

### DIFF
--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -166,7 +166,7 @@ func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Ty
 	// a reference to it.
 	if _, ok := pass.newObjects[newTypeName]; ok {
 		ref := ast.NewRef(schema.Package, newTypeName)
-		if disjunction.Branches.HasNullType() {
+		if def.Nullable || disjunction.Branches.HasNullType() {
 			ref.Nullable = true
 		}
 
@@ -221,7 +221,7 @@ func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Ty
 	}
 
 	ref := ast.NewRef(schema.Package, newTypeName)
-	if disjunction.Branches.HasNullType() {
+	if def.Nullable || disjunction.Branches.HasNullType() {
 		ref.Nullable = true
 	}
 


### PR DESCRIPTION
If a disjunction was defined as an optional field, the `DisjunctionToType` compiler pass would "loose" that information.

Example in cue:

```cue
spanNulls?: bool | number
```