### PR TITLE
Include the package name in generator-originated error messages

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -45,25 +45,25 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 	compiler := schemaparser.NewCompiler()
 	compiler.ExtractAnnotations = true
 	if err := compiler.AddResource("schema", schemaReader); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[%s] %w", c.Package, err)
 	}
 
 	schema, err := compiler.Compile("schema")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[%s] %w", c.Package, err)
 	}
 
 	// The root of the schema is an actual type/object
 	if schema.Ref == nil {
 		if err := g.declareDefinition(c.Package, schema); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("[%s] %w", c.Package, err)
 		}
 	} else {
 		definitionName := g.definitionNameFromRef(schema)
 
 		// The root of the schema contains definitions, and a reference to the "main" object
 		if err := g.declareDefinition(definitionName, schema.Ref); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("[%s] %w", c.Package, err)
 		}
 	}
 

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -39,7 +39,7 @@ func GenerateAST(filePath string, cfg Config) (*ast.Schema, error) {
 	}
 
 	if err := oapi.Validate(context.Background()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
 	}
 
 	g := &generator{
@@ -54,7 +54,7 @@ func GenerateAST(filePath string, cfg Config) (*ast.Schema, error) {
 	}
 
 	if err := g.declareDefinition(oapi.Components.Schemas); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
 	}
 
 	return g.schema, nil

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -41,11 +41,11 @@ func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
 
 	if c.ForceVariantEnvelope {
 		if err := g.walkCueSchemaWithVariantEnvelope(val); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("[%s] %w", c.Package, err)
 		}
 	} else {
 		if err := g.walkCueSchema(val); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("[%s] %w", c.Package, err)
 		}
 	}
 


### PR DESCRIPTION
This makes it slightly easier to know which schema caused the error.