### PR TITLE
Use a less verbose naming strategy for anonymous enums

### DIFF
--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -76,7 +76,7 @@
                             }
                         },
                         {
-                            "Name": "FieldAnonymousEnum",
+                            "Name": "Operator",
                             "Required": true,
                             "Type": {
                                 "Kind": "enum",
@@ -184,7 +184,7 @@ export interface SomeStruct {
 	FieldDisjunctionOfScalars: string | boolean;
 	FieldMixedDisjunction: string | SomeOtherStruct;
 	FieldDisjunctionWithNull: string | null;
-	FieldAnonymousEnum: ">" | "<";
+	Operator: ">" | "<";
 	FieldArrayOfStrings: string[];
 	FieldMapOfStringToString: Record<string, string>;
 	FieldAnonymousStruct: {
@@ -197,7 +197,7 @@ export const defaultSomeStruct = (): SomeStruct => ({
 	FieldDisjunctionOfScalars: "",
 	FieldMixedDisjunction: "",
 	FieldDisjunctionWithNull: "",
-	FieldAnonymousEnum: ">",
+	Operator: ">",
 	FieldArrayOfStrings: [],
 	FieldMapOfStringToString: {},
 	FieldAnonymousStruct: {
@@ -223,7 +223,7 @@ type SomeStruct struct {
 	FieldDisjunctionOfScalars StringOrBool `json:"FieldDisjunctionOfScalars"`
 	FieldMixedDisjunction StringOrSomeOtherStruct `json:"FieldMixedDisjunction"`
 	FieldDisjunctionWithNull *string `json:"FieldDisjunctionWithNull"`
-	FieldAnonymousEnum FieldAnonymousEnumEnum `json:"FieldAnonymousEnum"`
+	Operator SomeStructOperator `json:"Operator"`
 	FieldArrayOfStrings []string `json:"FieldArrayOfStrings"`
 	FieldMapOfStringToString map[string]string `json:"FieldMapOfStringToString"`
 	FieldAnonymousStruct struct {
@@ -235,10 +235,10 @@ type SomeOtherStruct struct {
 	FieldAny any `json:"FieldAny"`
 }
 
-type FieldAnonymousEnumEnum string
+type SomeStructOperator string
 const (
-	FieldAnonymousEnumEnumFieldAnonymousEnumGreaterThan FieldAnonymousEnumEnum = ">"
-	FieldAnonymousEnumEnumFieldAnonymousEnumLessThan FieldAnonymousEnumEnum = "<"
+	SomeStructOperatorGreaterThan SomeStructOperator = ">"
+	SomeStructOperatorLessThan SomeStructOperator = "<"
 )
 
 

--- a/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
@@ -26,7 +26,7 @@
                             }
                         },
                         {
-                            "Name": "FieldAnonymousEnum",
+                            "Name": "Operator",
                             "Required": false,
                             "Type": {
                                 "Kind": "enum",
@@ -114,7 +114,7 @@
 export interface SomeStruct {
 	FieldRef?: SomeOtherStruct;
 	FieldString?: string;
-	FieldAnonymousEnum?: ">" | "<";
+	Operator?: ">" | "<";
 	FieldArrayOfStrings?: string[];
 	FieldAnonymousStruct?: {
 		FieldAny: any;
@@ -139,7 +139,7 @@ package types
 type SomeStruct struct {
 	FieldRef *SomeOtherStruct `json:"FieldRef,omitempty"`
 	FieldString *string `json:"FieldString,omitempty"`
-	FieldAnonymousEnum *FieldAnonymousEnumEnum `json:"FieldAnonymousEnum,omitempty"`
+	Operator *SomeStructOperator `json:"Operator,omitempty"`
 	FieldArrayOfStrings []string `json:"FieldArrayOfStrings,omitempty"`
 	FieldAnonymousStruct *struct {
 	FieldAny any `json:"FieldAny"`
@@ -150,10 +150,10 @@ type SomeOtherStruct struct {
 	FieldAny any `json:"FieldAny"`
 }
 
-type FieldAnonymousEnumEnum string
+type SomeStructOperator string
 const (
-	FieldAnonymousEnumEnumFieldAnonymousEnumGreaterThan FieldAnonymousEnumEnum = ">"
-	FieldAnonymousEnumEnumFieldAnonymousEnumLessThan FieldAnonymousEnumEnum = "<"
+	SomeStructOperatorGreaterThan SomeStructOperator = ">"
+	SomeStructOperatorLessThan SomeStructOperator = "<"
 )
 
 


### PR DESCRIPTION
This strategy is more robust against collisions and generate friendlier names.