### PR TITLE
Make fields in structs generated out of a disjunction more readable

### DIFF
--- a/cmd/builder/go/main.go
+++ b/cmd/builder/go/main.go
@@ -31,7 +31,7 @@ func main() {
 		timeseries.LineWidth(5),
 		timeseries.DrawStyle(common.GraphDrawStyleBars),
 		timeseries.Targets([]types.Target{
-			someQuery.Internal(),
+			someQuery.Build(),
 		}),
 	)
 	if err != nil {
@@ -68,15 +68,15 @@ func main() {
 		}),
 
 		dashboard.Rows([]types.PanelOrRowPanel{
-			{ValRowPanel: overviewRow.Internal()},
-			{ValPanel: someTimeseriesPanel.Internal()},
+			{RowPanel: overviewRow.Build()},
+			{Panel: someTimeseriesPanel.Build()},
 		}),
 	)
 	if err != nil {
 		panic(err)
 	}
 
-	dashboardJson, err := json.MarshalIndent(builder.Internal(), "", "  ")
+	dashboardJson, err := json.MarshalIndent(builder.Build(), "", "  ")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -200,7 +200,7 @@ func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Ty
 		processedBranch.Nullable = true
 
 		fields = append(fields, ast.StructField{
-			Name:     "Val" + tools.UpperCamelCase(pass.typeName(processedBranch)),
+			Name:     pass.typeName(processedBranch),
 			Type:     processedBranch,
 			Required: false,
 		})

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -99,8 +99,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnObject(t *testing.T) {
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValString", ast.String(ast.Nullable())),
-		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = objects[0].Type.AsDisjunction()
@@ -128,8 +128,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAMapValueType(t *testing.T
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValString", ast.String(ast.Nullable())),
-		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = objects[0].Type.AsMap().ValueType.AsDisjunction()
@@ -160,8 +160,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAStructField(t *testing.T)
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValString", ast.String(ast.Nullable())),
-		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = disjunctionType.AsDisjunction()
@@ -191,8 +191,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsNullableAStructField(t *te
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValString", ast.String(ast.Nullable())),
-		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = disjunctionType.AsDisjunction()
@@ -220,8 +220,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnArrayValueType(t *testin
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValString", ast.String(ast.Nullable())),
-		ast.NewStructField("ValBool", ast.Bool(ast.Nullable())),
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = disjunctionType.AsDisjunction()
@@ -380,8 +380,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
+		ast.NewStructField("SomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("OtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -433,8 +433,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
+		ast.NewStructField("SomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("OtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -488,8 +488,8 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 
 	// Prepare expected output
 	disjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
+		ast.NewStructField("SomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("OtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := objects[0].Type.AsDisjunction()
@@ -542,9 +542,9 @@ func TestDisjunctionToType_WithNestedDisjunctionOfRefs_AsAnObject_NoDiscriminato
 
 	// Prepare expected output
 	fullDisjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
-		ast.NewStructField("ValLastStruct", ast.NewRef("test", "LastStruct", ast.Nullable())),
+		ast.NewStructField("SomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("OtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
+		ast.NewStructField("LastStruct", ast.NewRef("test", "LastStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	disjunctionTypeWithDiscriminatorMeta := ast.DisjunctionType{
@@ -565,8 +565,8 @@ func TestDisjunctionToType_WithNestedDisjunctionOfRefs_AsAnObject_NoDiscriminato
 	fullDisjunctionStructType.Hints[ast.HintDiscriminatedDisjunctionOfRefs] = disjunctionTypeWithDiscriminatorMeta
 
 	partialDisjunctionStructType := ast.NewStruct(
-		ast.NewStructField("ValSomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
-		ast.NewStructField("ValOtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
+		ast.NewStructField("SomeStruct", ast.NewRef("test", "SomeStruct", ast.Nullable())),
+		ast.NewStructField("OtherStruct", ast.NewRef("test", "OtherStruct", ast.Nullable())),
 	)
 	// The original disjunction definition is preserved as a hint
 	partialDisjunctionTypeWithDiscriminatorMeta := objects[1].Type.AsDisjunction()

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -20,6 +20,7 @@ func init() {
 	base := template.New("golang")
 	base.Funcs(map[string]any{
 		"formatIdentifier": tools.UpperCamelCase,
+		"lowerCamelCase":   tools.LowerCamelCase,
 		"formatType":       formatType,
 		"trimPrefix":       strings.TrimPrefix,
 	})

--- a/internal/jennies/golang/veneers/disjunction_of_refs.types.json_marshal.go.tmpl
+++ b/internal/jennies/golang/veneers/disjunction_of_refs.types.json_marshal.go.tmpl
@@ -31,12 +31,12 @@ func (resource *{{ .def.Name|formatIdentifier }}) UnmarshalJSON(raw []byte) erro
     {{- else }}
 	case "{{ $discriminatorValue }}":
 	{{- end }}
-		var val{{ $typeName|formatIdentifier }} {{ $typeName|formatIdentifier }}
-		if err := json.Unmarshal(raw, &val{{ $typeName|formatIdentifier }}); err != nil {
+		var {{ $typeName|lowerCamelCase }} {{ $typeName|formatIdentifier }}
+		if err := json.Unmarshal(raw, &{{ $typeName|lowerCamelCase }}); err != nil {
 			return err
 		}
 
-		resource.Val{{ $typeName|formatIdentifier }} = &val{{ $typeName|formatIdentifier }}
+		resource.{{ $typeName|formatIdentifier }} = &{{ $typeName|lowerCamelCase }}
 		return nil
 {{- end }}
 	}

--- a/internal/veneers/veneers.go
+++ b/internal/veneers/veneers.go
@@ -94,7 +94,7 @@ func Common() *Rewriter {
 			// Refresh(string) instead of Refresh(struct StringOrBool)
 			option.StructFieldsAsArguments(
 				option.ByName("Dashboard", "refresh"),
-				"ValString",
+				"String",
 			),
 
 			// We don't want these options at all

--- a/testdata/jennies/rawtypes/disjunctions.txtar
+++ b/testdata/jennies/rawtypes/disjunctions.txtar
@@ -240,25 +240,25 @@ type YetAnotherStruct struct {
 type SeveralRefs SomeStructOrSomeOtherStructOrYetAnotherStruct
 
 type BoolOrSomeStruct struct {
-	ValBool *bool `json:"ValBool,omitempty"`
-	ValSomeStruct *SomeStruct `json:"ValSomeStruct,omitempty"`
+	Bool *bool `json:"Bool,omitempty"`
+	SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
 }
 
 type SomeStructOrSomeOtherStructOrYetAnotherStruct struct {
-	ValSomeStruct *SomeStruct `json:"ValSomeStruct,omitempty"`
-	ValSomeOtherStruct *SomeOtherStruct `json:"ValSomeOtherStruct,omitempty"`
-	ValYetAnotherStruct *YetAnotherStruct `json:"ValYetAnotherStruct,omitempty"`
+	SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
+	SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
+	YetAnotherStruct *YetAnotherStruct `json:"YetAnotherStruct,omitempty"`
 }
 
 func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]byte, error) {
-	if resource.ValSomeStruct != nil {
-		return json.Marshal(resource.ValSomeStruct)
+	if resource.SomeStruct != nil {
+		return json.Marshal(resource.SomeStruct)
 	}
-	if resource.ValSomeOtherStruct != nil {
-		return json.Marshal(resource.ValSomeOtherStruct)
+	if resource.SomeOtherStruct != nil {
+		return json.Marshal(resource.SomeOtherStruct)
 	}
-	if resource.ValYetAnotherStruct != nil {
-		return json.Marshal(resource.ValYetAnotherStruct)
+	if resource.YetAnotherStruct != nil {
+		return json.Marshal(resource.YetAnotherStruct)
 	}
 
 	return nil, nil
@@ -282,28 +282,28 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 
 	switch discriminator {
 	case "some-other-struct":
-		var valSomeOtherStruct SomeOtherStruct
-		if err := json.Unmarshal(raw, &valSomeOtherStruct); err != nil {
+		var someOtherStruct SomeOtherStruct
+		if err := json.Unmarshal(raw, &someOtherStruct); err != nil {
 			return err
 		}
 
-		resource.ValSomeOtherStruct = &valSomeOtherStruct
+		resource.SomeOtherStruct = &someOtherStruct
 		return nil
 	case "some-struct":
-		var valSomeStruct SomeStruct
-		if err := json.Unmarshal(raw, &valSomeStruct); err != nil {
+		var someStruct SomeStruct
+		if err := json.Unmarshal(raw, &someStruct); err != nil {
 			return err
 		}
 
-		resource.ValSomeStruct = &valSomeStruct
+		resource.SomeStruct = &someStruct
 		return nil
 	case "yet-another-struct":
-		var valYetAnotherStruct YetAnotherStruct
-		if err := json.Unmarshal(raw, &valYetAnotherStruct); err != nil {
+		var yetAnotherStruct YetAnotherStruct
+		if err := json.Unmarshal(raw, &yetAnotherStruct); err != nil {
 			return err
 		}
 
-		resource.ValYetAnotherStruct = &valYetAnotherStruct
+		resource.YetAnotherStruct = &yetAnotherStruct
 		return nil
 	}
 
@@ -311,17 +311,17 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 }
 
 type StringOrBool struct {
-	ValString *string `json:"ValString,omitempty"`
-	ValBool *bool `json:"ValBool,omitempty"`
+	String *string `json:"String,omitempty"`
+	Bool *bool `json:"Bool,omitempty"`
 }
 
 func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
-	if resource.ValString != nil {
-		return json.Marshal(resource.ValString)
+	if resource.String != nil {
+		return json.Marshal(resource.String)
 	}
 
-	if resource.ValBool != nil {
-		return json.Marshal(resource.ValBool)
+	if resource.Bool != nil {
+		return json.Marshal(resource.Bool)
 	}
 
 	return nil, nil
@@ -334,23 +334,23 @@ func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
 
 	var errList []error
 
-	// ValString
-	var ValString string
-	if err := json.Unmarshal(raw, &ValString); err != nil {
+	// String
+	var String string
+	if err := json.Unmarshal(raw, &String); err != nil {
 		errList = append(errList, err)
-		resource.ValString = nil
+		resource.String = nil
 	} else {
-		resource.ValString = &ValString
+		resource.String = &String
 		return nil
 	}
 
-	// ValBool
-	var ValBool bool
-	if err := json.Unmarshal(raw, &ValBool); err != nil {
+	// Bool
+	var Bool bool
+	if err := json.Unmarshal(raw, &Bool); err != nil {
 		errList = append(errList, err)
-		resource.ValBool = nil
+		resource.Bool = nil
 	} else {
-		resource.ValBool = &ValBool
+		resource.Bool = &Bool
 		return nil
 	}
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -243,17 +243,17 @@ const (
 
 
 type StringOrBool struct {
-	ValString *string `json:"ValString,omitempty"`
-	ValBool *bool `json:"ValBool,omitempty"`
+	String *string `json:"String,omitempty"`
+	Bool *bool `json:"Bool,omitempty"`
 }
 
 func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
-	if resource.ValString != nil {
-		return json.Marshal(resource.ValString)
+	if resource.String != nil {
+		return json.Marshal(resource.String)
 	}
 
-	if resource.ValBool != nil {
-		return json.Marshal(resource.ValBool)
+	if resource.Bool != nil {
+		return json.Marshal(resource.Bool)
 	}
 
 	return nil, nil
@@ -266,23 +266,23 @@ func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
 
 	var errList []error
 
-	// ValString
-	var ValString string
-	if err := json.Unmarshal(raw, &ValString); err != nil {
+	// String
+	var String string
+	if err := json.Unmarshal(raw, &String); err != nil {
 		errList = append(errList, err)
-		resource.ValString = nil
+		resource.String = nil
 	} else {
-		resource.ValString = &ValString
+		resource.String = &String
 		return nil
 	}
 
-	// ValBool
-	var ValBool bool
-	if err := json.Unmarshal(raw, &ValBool); err != nil {
+	// Bool
+	var Bool bool
+	if err := json.Unmarshal(raw, &Bool); err != nil {
 		errList = append(errList, err)
-		resource.ValBool = nil
+		resource.Bool = nil
 	} else {
-		resource.ValBool = &ValBool
+		resource.Bool = &Bool
 		return nil
 	}
 
@@ -290,7 +290,7 @@ func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
 }
 
 type StringOrSomeOtherStruct struct {
-	ValString *string `json:"ValString,omitempty"`
-	ValSomeOtherStruct *SomeOtherStruct `json:"ValSomeOtherStruct,omitempty"`
+	String *string `json:"String,omitempty"`
+	SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
 }
 


### PR DESCRIPTION
Relates to #73