### PR TITLE
Simplify package layout for generate Go code

### DIFF
--- a/examples/_go/common.go
+++ b/examples/_go/common.go
@@ -1,25 +1,21 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common/reducedataoptions"
-	"github.com/grafana/cog/generated/common/vizlegendoptions"
-	gauge "github.com/grafana/cog/generated/gauge/panel"
-	logs "github.com/grafana/cog/generated/logs/panel"
-	loki "github.com/grafana/cog/generated/loki/dataquery"
-	prometheus "github.com/grafana/cog/generated/prometheus/dataquery"
-	timeseries "github.com/grafana/cog/generated/timeseries/panel"
-	common "github.com/grafana/cog/generated/types/common"
-	types "github.com/grafana/cog/generated/types/dashboard"
-	lokitypes "github.com/grafana/cog/generated/types/loki"
-	promtypes "github.com/grafana/cog/generated/types/prometheus"
+	"github.com/grafana/cog/generated/common"
+	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/gauge"
+	"github.com/grafana/cog/generated/logs"
+	"github.com/grafana/cog/generated/loki"
+	"github.com/grafana/cog/generated/prometheus"
+	"github.com/grafana/cog/generated/timeseries"
 )
 
 func toPtr[T any](input T) *T {
 	return &input
 }
 
-func basicPrometheusQuery(query string, legend string) *promtypes.Dataquery {
-	queryBuilder := prometheus.New().
+func basicPrometheusQuery(query string, legend string) *prometheus.Dataquery {
+	queryBuilder := prometheus.NewDataqueryBuilder().
 		Expr(query).
 		LegendFormat(legend)
 
@@ -31,8 +27,8 @@ func basicPrometheusQuery(query string, legend string) *promtypes.Dataquery {
 	return result
 }
 
-func basicLokiQuery(query string) *lokitypes.Dataquery {
-	queryBuilder := loki.New().
+func basicLokiQuery(query string) *loki.Dataquery {
+	queryBuilder := loki.NewDataqueryBuilder().
 		Expr(query)
 
 	result, err := queryBuilder.Build() // TODO
@@ -43,11 +39,11 @@ func basicLokiQuery(query string) *lokitypes.Dataquery {
 	return result
 }
 
-func tablePrometheusQuery(query string, ref string) *promtypes.Dataquery {
-	queryBuilder := prometheus.New().
+func tablePrometheusQuery(query string, ref string) *prometheus.Dataquery {
+	queryBuilder := prometheus.NewDataqueryBuilder().
 		Expr(query).
 		Instant(true).
-		Format(promtypes.PromQueryFormatTable).
+		Format(prometheus.PromQueryFormatTable).
 		RefId(ref)
 
 	result, err := queryBuilder.Build() // TODO
@@ -58,23 +54,23 @@ func tablePrometheusQuery(query string, ref string) *promtypes.Dataquery {
 	return result
 }
 
-func defaultTimeseries() *timeseries.Builder {
-	return timeseries.New().
+func defaultTimeseries() *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
 		LineWidth(1).
 		FillOpacity(10).
 		DrawStyle(common.GraphDrawStyleLine).
 		ShowPoints(common.VisibilityModeNever).
 		Legend(
-			vizlegendoptions.New().
+			common.NewVizLegendOptionsBuilder().
 				ShowLegend(true).
 				Placement(common.LegendPlacementBottom).
 				DisplayMode(common.LegendDisplayModeList),
 		)
 }
 
-func defaultLogs() *logs.Builder {
-	return logs.New().
-		Datasource(types.DataSourceRef{
+func defaultLogs() *logs.PanelBuilder {
+	return logs.NewPanelBuilder().
+		Datasource(dashboard.DataSourceRef{
 			Type: toPtr("loki"),
 			Uid:  toPtr("grafanacloud-logs"),
 		}).
@@ -84,8 +80,12 @@ func defaultLogs() *logs.Builder {
 		WrapLogMessage(true)
 }
 
-func defaultGauge() *gauge.Builder {
-	return gauge.New().
+func defaultGauge() *gauge.PanelBuilder {
+	return gauge.NewPanelBuilder().
 		Orientation(common.VizOrientationAuto).
-		ReduceOptions(reducedataoptions.New().Calcs([]string{"lastNotNull"}).Values(false)) // TODO: not intuitive
+		// TODO: not intuitive
+		ReduceOptions(
+			common.NewReduceDataOptionsBuilder().
+				Calcs([]string{"lastNotNull"}).Values(false),
+		)
 }

--- a/examples/_go/disk.go
+++ b/examples/_go/disk.go
@@ -1,41 +1,40 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common/tablefooteroptions"
-	table "github.com/grafana/cog/generated/table/panel"
-	timeseries "github.com/grafana/cog/generated/timeseries/panel"
-	common "github.com/grafana/cog/generated/types/common"
-	types "github.com/grafana/cog/generated/types/dashboard"
+	"github.com/grafana/cog/generated/common"
+	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/table"
+	"github.com/grafana/cog/generated/timeseries"
 )
 
-func diskIOTimeseries() *timeseries.Builder {
+func diskIOTimeseries() *timeseries.PanelBuilder {
 	return defaultTimeseries().
 		Title("Disk I/O").
 		FillOpacity(0).
 		Overrides([]struct { // TODO: paaaaaain
-			Matcher    types.MatcherConfig        `json:"matcher"`
-			Properties []types.DynamicConfigValue `json:"properties"`
+			Matcher    dashboard.MatcherConfig        `json:"matcher"`
+			Properties []dashboard.DynamicConfigValue `json:"properties"`
 		}{
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byRegexp",
 					Options: "/ io time/",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "unit", Value: "percentunit"},
 				},
 			},
 		}).
 		Unit("Bps").
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicPrometheusQuery(`rate(node_disk_read_bytes_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} read"),
 			basicPrometheusQuery(`rate(node_disk_written_bytes_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} written"),
 			basicPrometheusQuery(`rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} IO time"),
 		})
 }
 
-func diskSpaceUsageTable() *table.Builder {
-	return table.New().
+func diskSpaceUsageTable() *table.PanelBuilder {
+	return table.NewPanelBuilder().
 		Title("Disk Space Usage").
 		Align(common.FieldTextAlignmentAuto).
 		CellOptions(common.TableCellOptions{
@@ -45,12 +44,12 @@ func diskSpaceUsageTable() *table.Builder {
 		}).
 		Unit("decbytes").
 		CellHeight(common.TableCellHeightSm).
-		Footer(tablefooteroptions.New().CountRows(false).Reducer([]string{"sum"})).
-		Targets([]types.Target{
+		Footer(common.NewTableFooterOptionsBuilder().CountRows(false).Reducer([]string{"sum"})).
+		Targets([]dashboard.Target{
 			tablePrometheusQuery(`max by (mountpoint) (node_filesystem_size_bytes{job="integrations/raspberrypi-node", instance="$instance", fstype!=""})`, "A"),
 			tablePrometheusQuery(`max by (mountpoint) (node_filesystem_avail_bytes{job="integrations/raspberrypi-node", instance="$instance", fstype!=""})`, "B"),
 		}).
-		Transformations([]types.DataTransformerConfig{
+		Transformations([]dashboard.DataTransformerConfig{
 			{
 				Id: "groupBy",
 				Options: map[string]any{
@@ -128,51 +127,51 @@ func diskSpaceUsageTable() *table.Builder {
 			},
 		}).
 		Overrides([]struct { // TODO: paaaaaain
-			Matcher    types.MatcherConfig        `json:"matcher"`
-			Properties []types.DynamicConfigValue `json:"properties"`
+			Matcher    dashboard.MatcherConfig        `json:"matcher"`
+			Properties []dashboard.DynamicConfigValue `json:"properties"`
 		}{
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byName",
 					Options: "Mounted on",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "custom.width", Value: 260},
 				},
 			},
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byName",
 					Options: "Size",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "custom.width", Value: 93},
 				},
 			},
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byName",
 					Options: "Used",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "custom.width", Value: 72},
 				},
 			},
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byName",
 					Options: "Available",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "custom.width", Value: 88},
 				},
 			},
 			{
-				Matcher: types.MatcherConfig{ // TODO: not intuitive
+				Matcher: dashboard.MatcherConfig{ // TODO: not intuitive
 					Id:      "byName",
 					Options: "Used, %",
 				},
-				Properties: []types.DynamicConfigValue{
+				Properties: []dashboard.DynamicConfigValue{
 					{Id: "unit", Value: "percentunit"},
 					{Id: "custom.cellOptions", Value: struct {
 						Mode string `json:"mode"`

--- a/examples/_go/logs.go
+++ b/examples/_go/logs.go
@@ -1,40 +1,40 @@
 package main
 
 import (
-	logs "github.com/grafana/cog/generated/logs/panel"
-	types "github.com/grafana/cog/generated/types/dashboard"
+	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/logs"
 )
 
-func errorsInSystemLogs() *logs.Builder {
+func errorsInSystemLogs() *logs.PanelBuilder {
 	return defaultLogs().
 		Title("Errors in system logs").
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicLokiQuery(`{level=~"err|crit|alert|emerg", job="integrations/raspberrypi-node", instance="$instance"}`),
 			basicLokiQuery(`{filename=~"/var/log/syslog*|/var/log/messages*", job="integrations/raspberrypi-node", instance="$instance"} |~".+(?i)error(?-i).+"`),
 		})
 }
 
-func authLogs() *logs.Builder {
+func authLogs() *logs.PanelBuilder {
 	return defaultLogs().
 		Title("Auth logs").
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicLokiQuery(`{unit="ssh.service", job="integrations/raspberrypi-node", instance="$instance"}`),
 			basicLokiQuery(`{filename=~"/var/log/auth.log|/var/log/secure", job="integrations/raspberrypi-node", instance="$instance"}`),
 		})
 }
 
-func kernelLogs() *logs.Builder {
+func kernelLogs() *logs.PanelBuilder {
 	return defaultLogs().
 		Title("Kernel logs").
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicLokiQuery(`{transport="kernel", job="integrations/raspberrypi-node", instance="$instance"}`),
 			basicLokiQuery(`{filename="/var/log/kern.log", job="integrations/raspberrypi-node", instance="$instance"}`),
 		})
 }
-func allSystemLogs() *logs.Builder {
+func allSystemLogs() *logs.PanelBuilder {
 	return defaultLogs().
 		Title("All system logs").
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicLokiQuery(`{transport!="", job="integrations/raspberrypi-node", instance="$instance"}`),
 			basicLokiQuery(`{filename!="", job="integrations/raspberrypi-node", instance="$instance"}`),
 		})

--- a/examples/_go/main.go
+++ b/examples/_go/main.go
@@ -4,93 +4,89 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/cog/generated/dashboard/dashboard"
-	"github.com/grafana/cog/generated/dashboard/rowpanel"
-	"github.com/grafana/cog/generated/dashboard/timepicker"
-	"github.com/grafana/cog/generated/dashboard/variablemodel"
-	common "github.com/grafana/cog/generated/types/common"
-	types "github.com/grafana/cog/generated/types/dashboard"
+	"github.com/grafana/cog/generated/common"
+	"github.com/grafana/cog/generated/dashboard"
 )
 
 func main() {
-	builder := dashboard.New("[TEST] Node Exporter / Raspberry").
+	builder := dashboard.NewDashboardBuilder("[TEST] Node Exporter / Raspberry").
 		Uid("test-dashboard-raspberry").
 		Tags([]string{"generated", "raspberrypi-node-integration"}).
 		Refresh("30s").
 		Time("now-30m", "now").
 		Timezone(common.TimeZoneBrowser).
 		Timepicker(
-			timepicker.New().
+			dashboard.NewTimePickerBuilder().
 				RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}).
 				TimeOptions([]string{"5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"}),
 		).
-		Tooltip(types.DashboardCursorSyncCrosshair).
+		Tooltip(dashboard.DashboardCursorSyncCrosshair).
 		// TODO: we should have specific builders for every possible variable type
 		// "Data Source" variable
-		WithVariable(variablemodel.New().
-			Type(types.VariableTypeDatasource).
+		WithVariable(dashboard.NewVariableModelBuilder().
+			Type(dashboard.VariableTypeDatasource).
 			Name("datasource").
 			Label("Data Source").
-			Hide(types.VariableHideDontHide).
-			Refresh(types.VariableRefreshOnDashboardLoad).
-			Query(types.StringOrAny{
+			Hide(dashboard.VariableHideDontHide).
+			Refresh(dashboard.VariableRefreshOnDashboardLoad).
+			Query(dashboard.StringOrAny{
 				String: toPtr("prometheus"),
 			}).
-			Datasource(types.DataSourceRef{
+			Datasource(dashboard.DataSourceRef{
 				Type: toPtr("prometheus"),
 				Uid:  toPtr("$datasource"),
 			}).
-			Current(types.VariableOption{
+			Current(dashboard.VariableOption{
 				Selected: toPtr(true),
-				Text:     types.StringOrArrayOfString{String: toPtr("grafanacloud-potatopi-prom")},
-				Value:    types.StringOrArrayOfString{String: toPtr("grafanacloud-prom")},
+				Text:     dashboard.StringOrArrayOfString{String: toPtr("grafanacloud-potatopi-prom")},
+				Value:    dashboard.StringOrArrayOfString{String: toPtr("grafanacloud-prom")},
 			}).
-			Sort(types.VariableSortDisabled),
+			Sort(dashboard.VariableSortDisabled),
 		).
 		// "Instance" variable
-		WithVariable(variablemodel.New().
-			Type(types.VariableTypeQuery).
+		WithVariable(dashboard.NewVariableModelBuilder().
+			Type(dashboard.VariableTypeQuery).
 			Name("instance").
 			Label("Instance").
-			Hide(types.VariableHideDontHide).
-			Refresh(types.VariableRefreshOnTimeRangeChanged).
-			Query(types.StringOrAny{
+			Hide(dashboard.VariableHideDontHide).
+			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).
+			Query(dashboard.StringOrAny{
 				String: toPtr("label_values(node_uname_info{job=\"integrations/raspberrypi-node\", sysname!=\"Darwin\"}, instance)"),
 			}).
-			Datasource(types.DataSourceRef{
+			Datasource(dashboard.DataSourceRef{
 				Type: toPtr("prometheus"),
 				Uid:  toPtr("$datasource"),
 			}).
-			Current(types.VariableOption{
+			Current(dashboard.VariableOption{
 				Selected: toPtr(false),
-				Text:     types.StringOrArrayOfString{String: toPtr("potato")},
-				Value:    types.StringOrArrayOfString{String: toPtr("potato")},
+				Text:     dashboard.StringOrArrayOfString{String: toPtr("potato")},
+				Value:    dashboard.StringOrArrayOfString{String: toPtr("potato")},
 			}).
-			Sort(types.VariableSortDisabled),
+			Sort(dashboard.VariableSortDisabled),
 		).
 		// CPU
-		WithRow(rowpanel.New("CPU").GridPos(types.GridPos{H: 1, W: 24})).
-		WithPanel(cpuUsageTimeseries().GridPos(types.GridPos{H: 7, W: 18})).    // TODO: painful, not intuitive
-		WithPanel(cpuTemperatureGauge().GridPos(types.GridPos{H: 7, W: 6})).    // TODO: painful, not intuitive
-		WithPanel(loadAverageTimeseries().GridPos(types.GridPos{H: 7, W: 18})). // TODO: painful, not intuitive
+		WithRow(dashboard.NewRowPanelBuilder("CPU").GridPos(dashboard.GridPos{H: 1, W: 24})).
+		WithPanel(cpuUsageTimeseries().GridPos(dashboard.GridPos{H: 7, W: 18})).    // TODO: painful, not intuitive
+		WithPanel(cpuTemperatureGauge().GridPos(dashboard.GridPos{H: 7, W: 6})).    // TODO: painful, not intuitive
+		WithPanel(loadAverageTimeseries().GridPos(dashboard.GridPos{H: 7, W: 18})). // TODO: painful, not intuitive
 		// Memory
-		WithRow(rowpanel.New("Memory").GridPos(types.GridPos{H: 1, W: 24})). // TODO: painful, not intuitive
-		WithPanel(memoryUsageTimeseries().GridPos(types.GridPos{H: 7, W: 18})).
-		WithPanel(memoryUsageGauge().GridPos(types.GridPos{H: 7, W: 6})).
+		WithRow(dashboard.NewRowPanelBuilder("Memory").GridPos(dashboard.GridPos{H: 1, W: 24})). // TODO: painful, not intuitive
+		WithPanel(memoryUsageTimeseries().GridPos(dashboard.GridPos{H: 7, W: 18})).
+		WithPanel(memoryUsageGauge().GridPos(dashboard.GridPos{H: 7, W: 6})).
 		// Disk
-		WithRow(rowpanel.New("Disk")).
-		WithPanel(diskIOTimeseries().GridPos(types.GridPos{H: 7, W: 12})).
-		WithPanel(diskSpaceUsageTable().GridPos(types.GridPos{H: 7, W: 12})).
+		WithRow(dashboard.NewRowPanelBuilder("Disk")).
+		WithPanel(diskIOTimeseries().GridPos(dashboard.GridPos{H: 7, W: 12})).
+		WithPanel(diskSpaceUsageTable().GridPos(dashboard.GridPos{H: 7, W: 12})).
 		// Network
-		WithRow(rowpanel.New("Network")).
-		WithPanel(networkReceivedTimeseries().GridPos(types.GridPos{H: 7, W: 12})).
-		WithPanel(networkTransmittedTimeseries().GridPos(types.GridPos{H: 7, W: 12})).
+		WithRow(dashboard.NewRowPanelBuilder("Network")).
+		WithPanel(networkReceivedTimeseries().GridPos(dashboard.GridPos{H: 7, W: 12})).
+		WithPanel(networkTransmittedTimeseries().GridPos(dashboard.GridPos{H: 7, W: 12})).
 		// Logs
-		WithRow(rowpanel.New("Logs")).
-		WithPanel(errorsInSystemLogs().GridPos(types.GridPos{H: 7, W: 24})).
-		WithPanel(authLogs().GridPos(types.GridPos{H: 7, W: 24})).
-		WithPanel(kernelLogs().GridPos(types.GridPos{H: 7, W: 24})).
-		WithPanel(allSystemLogs().GridPos(types.GridPos{H: 7, W: 24}))
+		WithRow(dashboard.NewRowPanelBuilder("Logs")).
+		WithPanel(errorsInSystemLogs().GridPos(dashboard.GridPos{H: 7, W: 24})).
+		WithPanel(authLogs().GridPos(dashboard.GridPos{H: 7, W: 24})).
+		WithPanel(kernelLogs().GridPos(dashboard.GridPos{H: 7, W: 24})).
+		WithPanel(allSystemLogs().GridPos(dashboard.GridPos{H: 7, W: 24}))
 
 	sampleDashboard, err := builder.Build()
 	if err != nil {

--- a/examples/_go/memory.go
+++ b/examples/_go/memory.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common/stackingconfig"
-	"github.com/grafana/cog/generated/dashboard/thresholdsconfig"
-	gauge "github.com/grafana/cog/generated/gauge/panel"
-	timeseries "github.com/grafana/cog/generated/timeseries/panel"
-	common "github.com/grafana/cog/generated/types/common"
-	types "github.com/grafana/cog/generated/types/dashboard"
+	"github.com/grafana/cog/generated/common"
+	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/gauge"
+	"github.com/grafana/cog/generated/timeseries"
 )
 
-func memoryUsageTimeseries() *timeseries.Builder {
+func memoryUsageTimeseries() *timeseries.PanelBuilder {
 	memUsedQuery := `(
   node_memory_MemTotal_bytes{job="integrations/raspberrypi-node", instance="$instance"}
 -
@@ -22,15 +20,19 @@ func memoryUsageTimeseries() *timeseries.Builder {
 
 	return defaultTimeseries().
 		Title("Memory Usage").
-		Stacking(stackingconfig.New().Mode(common.StackingModeNormal)). // TODO: painful, not intuitive
-		Thresholds(thresholdsconfig.New().Mode(types.ThresholdsModeAbsolute).Steps([]types.Threshold{
-			{Value: nil, Color: "green"},
-			{Value: toPtr(80.0), Color: "red"},
-		})).
+		Stacking(common.NewStackingConfigBuilder().Mode(common.StackingModeNormal)). // TODO: painful, not intuitive
+		Thresholds(
+			dashboard.NewThresholdsConfigBuilder().
+				Mode(dashboard.ThresholdsModeAbsolute).
+				Steps([]dashboard.Threshold{
+					{Value: nil, Color: "green"},
+					{Value: toPtr(80.0), Color: "red"},
+				}),
+		).
 		Min(0).
 		Unit("bytes").
 		Decimals(2).
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicPrometheusQuery(memUsedQuery, "Used"),
 			basicPrometheusQuery(`node_memory_Buffers_bytes{job="integrations/raspberrypi-node", instance="$instance"}`, "Buffers"),
 			basicPrometheusQuery(`node_memory_Cached_bytes{job="integrations/raspberrypi-node", instance="$instance"}`, "Cached"),
@@ -38,7 +40,7 @@ func memoryUsageTimeseries() *timeseries.Builder {
 		})
 }
 
-func memoryUsageGauge() *gauge.Builder {
+func memoryUsageGauge() *gauge.PanelBuilder {
 	query := `100 - (
   avg(node_memory_MemAvailable_bytes{job="integrations/raspberrypi-node", instance="$instance"}) /
   avg(node_memory_MemTotal_bytes{job="integrations/raspberrypi-node", instance="$instance"})
@@ -49,12 +51,16 @@ func memoryUsageGauge() *gauge.Builder {
 		Min(30).
 		Max(100).
 		Unit("percent").
-		Thresholds(thresholdsconfig.New().Mode(types.ThresholdsModeAbsolute).Steps([]types.Threshold{
-			{Value: nil, Color: "rgba(50, 172, 45, 0.97)"},
-			{Value: toPtr(80.0), Color: "rgba(237, 129, 40, 0.89)"},
-			{Value: toPtr(90.0), Color: "rgba(245, 54, 54, 0.9)"},
-		})).
-		Targets([]types.Target{
+		Thresholds(
+			dashboard.NewThresholdsConfigBuilder().
+				Mode(dashboard.ThresholdsModeAbsolute).
+				Steps([]dashboard.Threshold{
+					{Value: nil, Color: "rgba(50, 172, 45, 0.97)"},
+					{Value: toPtr(80.0), Color: "rgba(237, 129, 40, 0.89)"},
+					{Value: toPtr(90.0), Color: "rgba(245, 54, 54, 0.9)"},
+				}),
+		).
+		Targets([]dashboard.Target{
 			basicPrometheusQuery(query, ""),
 		})
 }

--- a/examples/_go/network.go
+++ b/examples/_go/network.go
@@ -1,30 +1,30 @@
 package main
 
 import (
-	timeseries "github.com/grafana/cog/generated/timeseries/panel"
-	types "github.com/grafana/cog/generated/types/dashboard"
+	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/timeseries"
 )
 
-func networkReceivedTimeseries() *timeseries.Builder {
+func networkReceivedTimeseries() *timeseries.PanelBuilder {
 	return defaultTimeseries().
 		Title("Network Received").
 		Description("Network received (bits/s)").
 		Min(0).
 		Unit("bps").
 		FillOpacity(0).
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicPrometheusQuery(`rate(node_network_receive_bytes_total{job="integrations/raspberrypi-node", instance="$instance", device!="lo"}[$__rate_interval]) * 8`, "{{ device }}"),
 		})
 }
 
-func networkTransmittedTimeseries() *timeseries.Builder {
+func networkTransmittedTimeseries() *timeseries.PanelBuilder {
 	return defaultTimeseries().
 		Title("Network Transmitted").
 		Description("Network transmitted (bits/s)").
 		Min(0).
 		Unit("bps").
 		FillOpacity(0).
-		Targets([]types.Target{
+		Targets([]dashboard.Target{
 			basicPrometheusQuery(`rate(node_network_transmit_bytes_total{job="integrations/raspberrypi-node", instance="$instance", device!="lo"}[$__rate_interval]) * 8`, "{{ device }}"),
 		})
 }

--- a/internal/ast/compiler/unspec.go
+++ b/internal/ast/compiler/unspec.go
@@ -43,6 +43,8 @@ func (pass *Unspec) processSchema(schema *ast.Schema) (*ast.Schema, error) {
 			if schema.Metadata.Identifier != "" {
 				newObject.Name = schema.Metadata.Identifier
 			}
+
+			newObject.SelfRef.ReferredType = newObject.Name
 		}
 
 		newSchema.Objects = append(newSchema.Objects, newObject)

--- a/internal/jennies/golang/builderinterface.go
+++ b/internal/jennies/golang/builderinterface.go
@@ -15,7 +15,7 @@ func (jenny BuilderInterface) JennyName() string {
 func (jenny BuilderInterface) Generate(_ []*ast.Schema) (*codejen.File, error) {
 	output := jenny.generateFile()
 
-	return codejen.NewFile("types/builder.go", []byte(output), jenny), nil
+	return codejen.NewFile("builder.go", []byte(output), jenny), nil
 }
 
 func (jenny BuilderInterface) generateFile() string {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -27,7 +27,6 @@ func (jenny RawTypes) Generate(schema *ast.Schema) (codejen.Files, error) {
 	}
 
 	filename := filepath.Join(
-		"types",
 		strings.ToLower(schema.Package),
 		"types_gen.go",
 	)
@@ -46,7 +45,7 @@ func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
 			return ""
 		}
 
-		imports.Add(pkg, "github.com/grafana/cog/generated/types/"+pkg)
+		imports.Add(pkg, "github.com/grafana/cog/generated/"+pkg)
 
 		return pkg
 	}
@@ -73,9 +72,9 @@ func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
 		importStatements += "\n\n"
 	}
 
-	return []byte(fmt.Sprintf(`package types
+	return []byte(fmt.Sprintf(`package %[1]s
 
-%[1]s%[2]s`, importStatements, buffer.String())), nil
+%[2]s%[3]s`, strings.ToLower(schema.Package), importStatements, buffer.String())), nil
 }
 
 func (jenny RawTypes) formatObject(def ast.Object, packageMapper pkgMapper) ([]byte, error) {

--- a/testdata/jennies/rawtypes/arrays.txtar
+++ b/testdata/jennies/rawtypes/arrays.txtar
@@ -91,8 +91,8 @@ export type ArrayOfArrayOfNumbers = number[][];
 export const defaultArrayOfArrayOfNumbers = (): ArrayOfArrayOfNumbers => ([]);
 
 -- out/jennies/GoRawTypes --
-== types/arrays/types_gen.go
-package types
+== arrays/types_gen.go
+package arrays
 
 // List of tags, maybe?
 type ArrayOfStrings []string

--- a/testdata/jennies/rawtypes/disjunctions.txtar
+++ b/testdata/jennies/rawtypes/disjunctions.txtar
@@ -212,8 +212,8 @@ export type SeveralRefs = SomeStruct | SomeOtherStruct | YetAnotherStruct;
 export const defaultSeveralRefs = (): SeveralRefs => (defaultSomeStruct());
 
 -- out/jennies/GoRawTypes --
-== types/disjunctions/types_gen.go
-package types
+== disjunctions/types_gen.go
+package disjunctions
 
 // Refresh rate or disabled.
 type RefreshRate StringOrBool

--- a/testdata/jennies/rawtypes/enums.txtar
+++ b/testdata/jennies/rawtypes/enums.txtar
@@ -161,8 +161,8 @@ export enum DashboardCursorSync {
 export const defaultDashboardCursorSync = (): DashboardCursorSync => (DashboardCursorSync.Off);
 
 -- out/jennies/GoRawTypes --
-== types/enums/types_gen.go
-package types
+== enums/types_gen.go
+package enums
 
 // This is a very interesting string enum.
 type Operator string

--- a/testdata/jennies/rawtypes/intersections.txtar
+++ b/testdata/jennies/rawtypes/intersections.txtar
@@ -76,11 +76,11 @@
 }
 
 -- out/jennies/GoRawTypes --
-== types/intersections/types_gen.go
-package types
+== intersections/types_gen.go
+package intersections
 
 import (
-	externalPkg "github.com/grafana/cog/generated/types/externalPkg"
+	externalPkg "github.com/grafana/cog/generated/externalPkg"
 )
 
 type Intersections struct {

--- a/testdata/jennies/rawtypes/maps.txtar
+++ b/testdata/jennies/rawtypes/maps.txtar
@@ -128,8 +128,8 @@ export type MapOfStringToMapOfStringToBool = Record<string, Record<string, boole
 export const defaultMapOfStringToMapOfStringToBool = (): MapOfStringToMapOfStringToBool => ({});
 
 -- out/jennies/GoRawTypes --
-== types/maps/types_gen.go
-package types
+== maps/types_gen.go
+package maps
 
 // String to... something.
 type MapOfStringToAny map[string]any

--- a/testdata/jennies/rawtypes/refs.txtar
+++ b/testdata/jennies/rawtypes/refs.txtar
@@ -58,11 +58,11 @@ export type RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct;
 export const defaultRefToSomeStructFromOtherPackage = (): RefToSomeStructFromOtherPackage => (otherpkg.defaultSomeDistantStruct());
 
 -- out/jennies/GoRawTypes --
-== types/refs/types_gen.go
-package types
+== refs/types_gen.go
+package refs
 
 import (
-	otherpkg "github.com/grafana/cog/generated/types/otherpkg"
+	otherpkg "github.com/grafana/cog/generated/otherpkg"
 )
 
 type SomeStruct struct {

--- a/testdata/jennies/rawtypes/scalars.txtar
+++ b/testdata/jennies/rawtypes/scalars.txtar
@@ -176,8 +176,8 @@ export type ScalarTypeInt64 = number;
 export const defaultScalarTypeInt64 = (): ScalarTypeInt64 => (0);
 
 -- out/jennies/GoRawTypes --
-== types/scalars/types_gen.go
-package types
+== scalars/types_gen.go
+package scalars
 
 const ConstTypeString = "foo"
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -214,8 +214,8 @@ export const defaultSomeOtherStruct = (): SomeOtherStruct => ({
 });
 
 -- out/jennies/GoRawTypes --
-== types/struct_complex_fields/types_gen.go
-package types
+== struct_complex_fields/types_gen.go
+package struct_complex_fields
 
 // This struct does things.
 type SomeStruct struct {

--- a/testdata/jennies/rawtypes/struct_with_defaults.txtar
+++ b/testdata/jennies/rawtypes/struct_with_defaults.txtar
@@ -80,8 +80,8 @@ export const defaultSomeStruct = (): SomeStruct => ({
 });
 
 -- out/jennies/GoRawTypes --
-== types/defaults/types_gen.go
-package types
+== defaults/types_gen.go
+package defaults
 
 type SomeStruct struct {
 	FieldBool bool `json:"fieldBool"`

--- a/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
@@ -133,8 +133,8 @@ export const defaultSomeOtherStruct = (): SomeOtherStruct => ({
 });
 
 -- out/jennies/GoRawTypes --
-== types/struct_optional_fields/types_gen.go
-package types
+== struct_optional_fields/types_gen.go
+package struct_optional_fields
 
 type SomeStruct struct {
 	FieldRef *SomeOtherStruct `json:"FieldRef,omitempty"`

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
@@ -186,8 +186,8 @@ export const defaultSomeStruct = (): SomeStruct => ({
 });
 
 -- out/jennies/GoRawTypes --
-== types/basic/types_gen.go
-package types
+== basic/types_gen.go
+package basic
 
 // This
 // is


### PR DESCRIPTION
This PR tries to alleviate one of the many pain points encountered while using the go builder: finding and importing the correct packages for types + builders was a mess.

Here, we propose a simpler layout for the generated code, grouping types and builders coming from the same schema in a same Go package.