### PR TITLE
Remove stutter in Typescript enum members

### DIFF
--- a/examples/typescript/common.ts
+++ b/examples/typescript/common.ts
@@ -30,7 +30,7 @@ export const tablePrometheusQuery = (query: string, ref: string): prometheus.Dat
     return new prometheus.DataqueryBuilder()
         .expr(query)
         .instant(true)
-        .format(PromQueryFormat.PromQueryFormatTable)
+        .format(PromQueryFormat.Table)
         .refId(ref);
 };
 
@@ -38,13 +38,13 @@ export const defaultTimeseries = (): TimeseriesPanelBuilder => {
     return new TimeseriesPanelBuilder()
         .lineWidth(1)
         .fillOpacity(10)
-        .drawStyle(GraphDrawStyle.GraphDrawStyleLine)
-        .showPoints(VisibilityMode.VisibilityModeNever)
+        .drawStyle(GraphDrawStyle.Line)
+        .showPoints(VisibilityMode.Never)
         .legend(
             new VizLegendOptionsBuilder()
                 .showLegend(true)
-                .placement(LegendPlacement.LegendPlacementBottom)
-                .displayMode(LegendDisplayMode.LegendDisplayModeList)
+                .placement(LegendPlacement.Bottom)
+                .displayMode(LegendDisplayMode.List)
         );
 };
 
@@ -56,13 +56,13 @@ export const defaultLogs = (): LogsPanelBuilder => {
         })
         .showTime(true)
         .enableLogDetails(true)
-        .sortOrder(LogsSortOrder.LogsSortOrderDescending)
+        .sortOrder(LogsSortOrder.Descending)
         .wrapLogMessage(true);
 };
 
 export const defaultGauge = (): GaugePanelBuilder => {
     return new GaugePanelBuilder()
-        .orientation(VizOrientation.VizOrientationAuto)
+        .orientation(VizOrientation.Auto)
         .reduceOptions(
             new ReduceDataOptionsBuilder()
                 .calcs(["lastNotNull"])

--- a/examples/typescript/cpu.ts
+++ b/examples/typescript/cpu.ts
@@ -13,10 +13,10 @@ export const cpuUsageTimeseries = (): TimeseriesPanelBuilder => {
 
     return defaultTimeseries()
         .title("CPU Usage")
-        .stacking(new StackingConfigBuilder().mode(StackingMode.StackingModeNormal))
+        .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
         .thresholds(
             new ThresholdsConfigBuilder()
-                .mode(ThresholdsMode.ThresholdsModeAbsolute)
+                .mode(ThresholdsMode.Absolute)
                 .steps([
                     {value: null, color: "green"},
                     {value: 80.0, color: "red"},
@@ -31,10 +31,10 @@ export const cpuUsageTimeseries = (): TimeseriesPanelBuilder => {
 export const loadAverageTimeseries = (): TimeseriesPanelBuilder => {
     return defaultTimeseries()
         .title("Load Average")
-        .stacking(new StackingConfigBuilder().mode(StackingMode.StackingModeNormal))
+        .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
         .thresholds(
             new ThresholdsConfigBuilder()
-                .mode(ThresholdsMode.ThresholdsModeAbsolute)
+                .mode(ThresholdsMode.Absolute)
                 .steps([
                     {value: null, color: "green"},
                     {value: 80.0, color: "red"},
@@ -64,7 +64,7 @@ export const cpuTemperatureGauge = (): GaugePanelBuilder => {
         .unit("celsius")
         .thresholds(
             new ThresholdsConfigBuilder()
-                .mode(ThresholdsMode.ThresholdsModeAbsolute)
+                .mode(ThresholdsMode.Absolute)
                 .steps([
                     {value: null, color: "rgba(50, 172, 45, 0.97)"},
                     {value: 65.0, color: "rgba(237, 129, 40, 0.89)"},

--- a/examples/typescript/disk.ts
+++ b/examples/typescript/disk.ts
@@ -28,9 +28,9 @@ export const diskIOTimeseries = (): TimeseriesPanelBuilder => {
 export const diskSpaceUsageTable = (): TablePanelBuilder => {
     return new TablePanelBuilder()
         .title("Disk Space Usage")
-        .align(FieldTextAlignment.FieldTextAlignmentAuto)
+        .align(FieldTextAlignment.Auto)
         .cellOptions({type: "auto"})
-        .cellHeight(TableCellHeight.TableCellHeightSm)
+        .cellHeight(TableCellHeight.Sm)
         .footer(new TableFooterOptionsBuilder().countRows(false).reducer(["sum"]))
         .unit("decbytes")
         .withTarget(

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -29,32 +29,32 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
             .time_options(["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]),
     )
 
-    .tooltip(DashboardCursorSync.DashboardCursorSyncCrosshair)
+    .tooltip(DashboardCursorSync.Crosshair)
 
     // "Data Source" variable
     .withVariable(
         new VariableModelBuilder()
-            .type(VariableType.VariableTypeDatasource)
+            .type(VariableType.Datasource)
             .name("datasource")
             .label("Data Source")
-            .hide(VariableHide.VariableHideDontHide)
-            .refresh(VariableRefresh.VariableRefreshOnDashboardLoad)
+            .hide(VariableHide.DontHide)
+            .refresh(VariableRefresh.OnDashboardLoad)
             .query("prometheus")
             .current({
                 selected: true,
                 text: "grafanacloud-potatopi-prom",
                 value: "grafanacloud-prom",
             })
-            .sort(VariableSort.VariableSortDisabled)
+            .sort(VariableSort.Disabled)
     )
     // "Instance" variable
     .withVariable(
         new VariableModelBuilder()
-            .type(VariableType.VariableTypeQuery)
+            .type(VariableType.Query)
             .name("instance")
             .label("Instance")
-            .hide(VariableHide.VariableHideDontHide)
-            .refresh(VariableRefresh.VariableRefreshOnTimeRangeChanged)
+            .hide(VariableHide.DontHide)
+            .refresh(VariableRefresh.OnTimeRangeChanged)
             .query('label_values(node_uname_info{job="integrations/raspberrypi-node", sysname!="Darwin"}, instance)')
             .datasource({
                 "type": "prometheus",
@@ -65,7 +65,7 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
                 text: "potato",
                 value: "potato"
             })
-            .sort(VariableSort.VariableSortDisabled)
+            .sort(VariableSort.Disabled)
     )
 
     .withRow(new RowBuilder("CPU").gridPos({h: 1, w: 24, x: 0, y: 0}))

--- a/examples/typescript/memory.ts
+++ b/examples/typescript/memory.ts
@@ -17,10 +17,10 @@ export const memoryUsageTimeseries = (): TimeseriesPanelBuilder => {
 
     return defaultTimeseries()
         .title("Memory Usage")
-        .stacking(new StackingConfigBuilder().mode(StackingMode.StackingModeNormal))
+        .stacking(new StackingConfigBuilder().mode(StackingMode.Normal))
         .thresholds(
             new ThresholdsConfigBuilder()
-                .mode(ThresholdsMode.ThresholdsModeAbsolute)
+                .mode(ThresholdsMode.Absolute)
                 .steps([
                     {value: null, color: "green"},
                     {value: 80.0, color: "red"},
@@ -53,7 +53,7 @@ export const memoryUsageGauge = (): GaugePanelBuilder => {
         .unit("percent")
         .thresholds(
             new ThresholdsConfigBuilder()
-                .mode(ThresholdsMode.ThresholdsModeAbsolute)
+                .mode(ThresholdsMode.Absolute)
                 .steps([
                     {value: null, color: "rgba(50, 172, 45, 0.97)"},
                     {value: 80.0, color: "rgba(237, 129, 40, 0.89)"},

--- a/internal/ast/compiler/rename_numeric_enum_values.go
+++ b/internal/ast/compiler/rename_numeric_enum_values.go
@@ -1,0 +1,73 @@
+package compiler
+
+import (
+	"strconv"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
+)
+
+var _ Pass = (*RenameNumericEnumValues)(nil)
+
+type RenameNumericEnumValues struct {
+}
+
+func (pass *RenameNumericEnumValues) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0, len(schemas))
+
+	for _, schema := range schemas {
+		newSchema, err := pass.processSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+
+		newSchemas = append(newSchemas, newSchema)
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *RenameNumericEnumValues) processSchema(schema *ast.Schema) (*ast.Schema, error) {
+	processedObjects := make([]ast.Object, 0, len(schema.Objects))
+	for _, object := range schema.Objects {
+		newObject := object
+		newObject.Type = pass.processType(object.Type)
+
+		processedObjects = append(processedObjects, newObject)
+	}
+
+	newSchema := schema.DeepCopy()
+	newSchema.Objects = processedObjects
+
+	return &newSchema, nil
+}
+
+func (pass *RenameNumericEnumValues) processType(def ast.Type) ast.Type {
+	if def.Kind != ast.KindEnum {
+		return def
+	}
+
+	return pass.processEnum(def)
+}
+
+func (pass *RenameNumericEnumValues) processEnum(def ast.Type) ast.Type {
+	newType := def
+
+	values := make([]ast.EnumValue, 0, len(def.AsEnum().Values))
+	for _, val := range def.AsEnum().Values {
+		if _, err := strconv.Atoi(val.Name); err != nil {
+			values = append(values, val)
+			continue
+		}
+
+		values = append(values, ast.EnumValue{
+			Type:  val.Type,
+			Name:  "N" + tools.UpperCamelCase(val.Name),
+			Value: val.Value,
+		})
+	}
+
+	newType.Enum.Values = values
+
+	return newType
+}

--- a/internal/ast/compiler/rename_numeric_enum_values_test.go
+++ b/internal/ast/compiler/rename_numeric_enum_values_test.go
@@ -1,0 +1,93 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenameNumericEnumValues(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("pkg", "NotAnEnumStruct", ast.String()),
+
+		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "1",
+				Value: 1,
+			},
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "2",
+				Value: 2,
+			},
+		})),
+
+		ast.NewObject("pkg", "AnEnumWithNoNumericValues", ast.NewEnum([]ast.EnumValue{
+			{
+				Type:  ast.String(),
+				Name:  "Hide",
+				Value: "hide",
+			},
+			{
+				Type:  ast.String(),
+				Name:  "DontHide",
+				Value: "dont_hide",
+			},
+		})),
+	}
+
+	// Prepare expected output
+	expected := []ast.Object{
+		ast.NewObject("pkg", "NotAnEnumStruct", ast.String()),
+
+		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "N1",
+				Value: 1,
+			},
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "N2",
+				Value: 2,
+			},
+		})),
+
+		ast.NewObject("pkg", "AnEnumWithNoNumericValues", ast.NewEnum([]ast.EnumValue{
+			{
+				Type:  ast.String(),
+				Name:  "Hide",
+				Value: "hide",
+			},
+			{
+				Type:  ast.String(),
+				Name:  "DontHide",
+				Value: "dont_hide",
+			},
+		})),
+	}
+
+	// Run the compiler pass
+	runRenameNumericEnumValuesPass(t, objects, expected)
+}
+
+func runRenameNumericEnumValuesPass(t *testing.T, input []ast.Object, expectedOutput []ast.Object) {
+	t.Helper()
+
+	req := require.New(t)
+
+	compilerPass := &RenameNumericEnumValues{}
+	processedFiles, err := compilerPass.Process([]*ast.Schema{
+		{
+			Package: "test",
+			Objects: input,
+		},
+	})
+	req.NoError(err)
+	req.Len(processedFiles, 1)
+	req.Empty(cmp.Diff(expectedOutput, processedFiles[0].Objects))
+}

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -24,6 +24,6 @@ func Jennies() *codejen.JennyList[context.Builders] {
 
 func CompilerPasses() []compiler.Pass {
 	return []compiler.Pass{
-		&compiler.PrefixEnumValues{},
+		&compiler.RenameNumericEnumValues{},
 	}
 }

--- a/testdata/jennies/rawtypes/enums.txtar
+++ b/testdata/jennies/rawtypes/enums.txtar
@@ -129,36 +129,36 @@
 == enums/types_gen.ts
 // This is a very interesting string enum.
 export enum Operator {
-	OperatorGreaterThan = ">",
-	OperatorLessThan = "<",
+	GreaterThan = ">",
+	LessThan = "<",
 }
 
-export const defaultOperator = (): Operator => (Operator.OperatorGreaterThan);
+export const defaultOperator = (): Operator => (Operator.GreaterThan);
 
 export enum TableSortOrder {
-	TableSortOrderAsc = "asc",
-	TableSortOrderDesc = "desc",
+	Asc = "asc",
+	Desc = "desc",
 }
 
-export const defaultTableSortOrder = (): TableSortOrder => (TableSortOrder.TableSortOrderAsc);
+export const defaultTableSortOrder = (): TableSortOrder => (TableSortOrder.Asc);
 
 export enum LogsSortOrder {
-	LogsSortOrderAsc = "time_asc",
-	LogsSortOrderDesc = "time_desc",
+	Asc = "time_asc",
+	Desc = "time_desc",
 }
 
-export const defaultLogsSortOrder = (): LogsSortOrder => (LogsSortOrder.LogsSortOrderAsc);
+export const defaultLogsSortOrder = (): LogsSortOrder => (LogsSortOrder.Asc);
 
 // 0 for no shared crosshair or tooltip (default).
 // 1 for shared crosshair.
 // 2 for shared crosshair AND shared tooltip.
 export enum DashboardCursorSync {
-	DashboardCursorSyncOff = 0,
-	DashboardCursorSyncCrosshair = 1,
-	DashboardCursorSyncTooltip = 2,
+	Off = 0,
+	Crosshair = 1,
+	Tooltip = 2,
 }
 
-export const defaultDashboardCursorSync = (): DashboardCursorSync => (DashboardCursorSync.DashboardCursorSyncOff);
+export const defaultDashboardCursorSync = (): DashboardCursorSync => (DashboardCursorSync.Off);
 
 -- out/jennies/GoRawTypes --
 == enums/types_gen.go


### PR DESCRIPTION
Typescript was using the `PrefixEnumValues` compiler pass, that prefixes all enum members with the name of the enum type.

While this compiler pass is useful for languages as Go where enum members are defined as constants in a package scope, Typescript enums work differently.

See:

```ts
export enum VariableRefresh {
	Never = 0,
	OnDashboardLoad = 1,
	OnTimeRangeChanged = 2,
}
```

Enum members are local to the enum type that defines them, and as such prefixing them with the name of that type introduces a *stuttering* when referencing these members: `.refresh(VariableRefresh.VariableRefreshOnTimeRangeChanged)` instead of the cleaner `.refresh(VariableRefresh.OnTimeRangeChanged)`

This PR fixes that stutter.

To also guard from enums defined as follows, we introduce a `RenameNumericEnumValues` compiler pass.

```json
{
  "type": "integer",
  "enum": [1, 2, 3]
}
```