### PR TITLE
Add a comment header on generated files

### DIFF
--- a/internal/jennies/common/codejen.go
+++ b/internal/jennies/common/codejen.go
@@ -1,6 +1,11 @@
 package common
 
 import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
 	"github.com/grafana/codejen"
 )
 
@@ -21,4 +26,43 @@ func If[Input any](condition bool, innerJenny codejen.OneToMany[Input]) codejen.
 	}
 
 	return innerJenny
+}
+
+// GeneratedCommentHeader produces a FileMapper that injects a comment header onto
+// a [codejen.File] indicating  the jenny or jennies that constructed the
+// file.
+func GeneratedCommentHeader() codejen.FileMapper {
+	genHeader := `// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+{{- range .Using }}
+//     {{ .JennyName }}
+{{- end }}
+
+`
+
+	tmpl, err := template.New("cog").Parse(genHeader)
+	if err != nil {
+		// not ideal, but also not a big deal: this statement is only reachable when the template is invalid.
+		panic(err)
+	}
+
+	return func(f codejen.File) (codejen.File, error) {
+		// Never inject on certain filetypes, it's never valid
+		switch filepath.Ext(f.RelativePath) {
+		case ".json", ".yml", ".yaml", ".md":
+			return f, nil
+		default:
+			buf := new(bytes.Buffer)
+			if err := tmpl.Execute(buf, map[string]any{
+				"Using": f.From,
+			}); err != nil {
+				return codejen.File{}, fmt.Errorf("failed executing GeneratedCommentHeader() template: %w", err)
+			}
+			buf.Write(f.Data)
+
+			f.Data = buf.Bytes()
+		}
+		return f, nil
+	}
 }

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -50,7 +50,7 @@ func (language *Language) Jennies(targets common.Targets) *codejen.JennyList[com
 
 		common.If[common.Context](targets.Builders, &Builder{Config: language.config}),
 	)
-	jenny.AddPostprocessors(PostProcessFile)
+	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader())
 
 	return jenny
 }

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -31,6 +31,7 @@ func (language *Language) Jennies(targets common.Targets) *codejen.JennyList[com
 
 		Index{Targets: targets},
 	)
+	jenny.AddPostprocessors(common.GeneratedCommentHeader())
 
 	return jenny
 }


### PR DESCRIPTION
This PR backports a feature from `grok`, where a comment header is added to every generated file, clearly marking them as such.