### PR TITLE
[PoC] Record a trail of applied compiler passes

### DIFF
--- a/internal/ast/compiler/dashboardpanels.go
+++ b/internal/ast/compiler/dashboardpanels.go
@@ -65,14 +65,17 @@ func (pass *DashboardPanelsRewrite) processSchema(schema *ast.Schema) (*ast.Sche
 				"row":                     dashboardRowPanelObject,
 				ast.DiscriminatorCatchAll: dashboardPanelObject,
 			}
+			disjunction.AddCompilerPassTrail("DashboardPanelsRewrite")
 
 			newPanelsFieldType := ast.NewArray(disjunction)
+			newPanelsFieldType.AddCompilerPassTrail("DashboardPanelsRewrite")
 
 			newSchema.Objects = append(newSchema.Objects, pass.overwritePanelsFieldType(object, newPanelsFieldType))
 			continue
 		}
 		if object.Name == dashboardRowPanelObject {
 			newPanelsFieldType := ast.NewArray(ast.NewRef(schema.Package, "Panel"))
+			newPanelsFieldType.AddCompilerPassTrail("DashboardPanelsRewrite")
 
 			newSchema.Objects = append(newSchema.Objects, pass.overwritePanelsFieldType(object, newPanelsFieldType))
 			continue
@@ -94,6 +97,7 @@ func (pass *DashboardPanelsRewrite) overwritePanelsFieldType(object ast.Object, 
 
 		newField := field
 		newField.Type = newPanelsFieldType
+		newField.Type.AddCompilerPassTrail("DashboardPanelsRewrite")
 
 		newFields[i] = newField
 	}

--- a/internal/ast/compiler/dashboardtargets.go
+++ b/internal/ast/compiler/dashboardtargets.go
@@ -89,6 +89,7 @@ func (pass *DashboardTargetsRewrite) processType(def ast.Type) ast.Type {
 		newDef.ComposableSlot = &ast.ComposableSlotType{
 			Variant: ast.SchemaVariantDataQuery,
 		}
+		newDef.AddCompilerPassTrail("DashboardTargetsRewrite")
 
 		return newDef
 	}

--- a/internal/ast/compiler/dashboardtimepicker.go
+++ b/internal/ast/compiler/dashboardtimepicker.go
@@ -89,7 +89,10 @@ func (pass *DashboardTimePicker) processDashboard(object ast.Object) (ast.Object
 		}
 
 		timepickerObject = ast.NewObject(pkg, dashboardTimepickerObject, field.Type)
+		field.Type.AddCompilerPassTrail("DashboardTimePicker")
+
 		object.Type.AsStruct().Fields[i].Type = ast.NewRef(pkg, dashboardTimepickerObject)
+		object.Type.AsStruct().Fields[i].Type.AddCompilerPassTrail("DashboardTimePicker")
 	}
 
 	return object, timepickerObject

--- a/internal/ast/compiler/dataquery_identification.go
+++ b/internal/ast/compiler/dataquery_identification.go
@@ -47,6 +47,7 @@ func (pass *DataqueryIdentification) processObject(object ast.Object, commonData
 
 	if pass.structsIntersect(typeDef, commonDataquery.Type) {
 		object.Type.Hints[ast.HintImplementsVariant] = string(ast.SchemaVariantDataQuery)
+		object.Type.AddCompilerPassTrail("DataqueryIdentification")
 	}
 
 	return object

--- a/internal/ast/compiler/librarypanels.go
+++ b/internal/ast/compiler/librarypanels.go
@@ -96,5 +96,8 @@ func (pass *LibraryPanels) buildModelType(dashboardPanel ast.Object) ast.Type {
 		fields = append(fields, panelField)
 	}
 
-	return ast.NewStruct(fields...)
+	newStruct := ast.NewStruct(fields...)
+	newStruct.AddCompilerPassTrail("LibraryPanels")
+
+	return newStruct
 }

--- a/internal/ast/compiler/not_required_as_nullable.go
+++ b/internal/ast/compiler/not_required_as_nullable.go
@@ -83,6 +83,7 @@ func (pass *NotRequiredFieldAsNullableType) processStruct(def ast.Type) ast.Type
 		def.Struct.Fields[i].Type = pass.processType(field.Type)
 		if !field.Required {
 			def.Struct.Fields[i].Type.Nullable = true
+			def.Struct.Fields[i].Type.AddCompilerPassTrail("NotRequiredFieldAsNullableType")
 		}
 	}
 

--- a/internal/ast/compiler/prefix_enum_values.go
+++ b/internal/ast/compiler/prefix_enum_values.go
@@ -59,6 +59,7 @@ func (pass *PrefixEnumValues) processEnum(parentName string, def ast.Type) ast.T
 	}
 
 	def.Enum.Values = values
+	def.AddCompilerPassTrail("PrefixEnumValues")
 
 	return def
 }

--- a/internal/ast/compiler/prefix_enum_values_test.go
+++ b/internal/ast/compiler/prefix_enum_values_test.go
@@ -22,7 +22,7 @@ func TestPrefixEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "VariableRefresh", ast.NewEnum([]ast.EnumValue{
 			{Name: "VariableRefreshNever", Value: "never", Type: ast.String()},
 			{Name: "VariableRefreshAlways", Value: "always", Type: ast.String()},
-		})),
+		}, ast.Hints(ast.JenniesHints{ast.HintCompilerPassTrail: []string{"PrefixEnumValues"}}))),
 
 		ast.NewObject("pkg", "SomeType", ast.String()),
 	}

--- a/internal/ast/compiler/rename_numeric_enum_values.go
+++ b/internal/ast/compiler/rename_numeric_enum_values.go
@@ -50,12 +50,18 @@ func (pass *RenameNumericEnumValues) processType(def ast.Type) ast.Type {
 }
 
 func (pass *RenameNumericEnumValues) processEnum(def ast.Type) ast.Type {
+	modified := false
 	for i, val := range def.AsEnum().Values {
 		if _, err := strconv.Atoi(val.Name); err != nil {
 			continue
 		}
 
+		modified = true
 		def.AsEnum().Values[i].Name = "N" + tools.UpperCamelCase(val.Name)
+	}
+
+	if modified {
+		def.AddCompilerPassTrail("RenameNumericEnumValues")
 	}
 
 	return def

--- a/internal/ast/compiler/unspec.go
+++ b/internal/ast/compiler/unspec.go
@@ -40,6 +40,7 @@ func (pass *Unspec) processSchema(schema *ast.Schema) *ast.Schema {
 			}
 
 			newObject.SelfRef.ReferredType = newObject.Name
+			newObject.Type.AddCompilerPassTrail("Unspec")
 		}
 
 		newSchema.Objects = append(newSchema.Objects, newObject)

--- a/internal/ast/hints.go
+++ b/internal/ast/hints.go
@@ -19,6 +19,8 @@ const (
 	// HintSkipVariantPluginRegistration preserves the variant hint on a type, but
 	// tells the jennies to not register it as a plugin.
 	HintSkipVariantPluginRegistration = "skip_variant_plugin_registration"
+
+	HintCompilerPassTrail = "compiler_pass_trail"
 )
 
 const DiscriminatorCatchAll = "cog_discriminator_catch_all"

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -99,6 +99,14 @@ type Type struct {
 	Hints JenniesHints `json:",omitempty"`
 }
 
+func (t Type) AddCompilerPassTrail(compilerPassName string) {
+	if t.Hints[HintCompilerPassTrail] == nil {
+		t.Hints[HintCompilerPassTrail] = make([]string, 0)
+	}
+
+	t.Hints[HintCompilerPassTrail] = append(t.Hints[HintCompilerPassTrail].([]string), compilerPassName)
+}
+
 func (t Type) ImplementsVariant() bool {
 	return t.HasHint(HintImplementsVariant)
 }
@@ -109,6 +117,14 @@ func (t Type) ImplementedVariant() string {
 	}
 
 	return t.Hints[HintImplementsVariant].(string)
+}
+
+func (t Type) CompilerPassTrail() []string {
+	if !t.HasHint(HintCompilerPassTrail) {
+		return nil
+	}
+
+	return t.Hints[HintCompilerPassTrail].([]string)
 }
 
 func (t Type) HasHint(hintName string) bool {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -82,6 +82,10 @@ func (jenny RawTypes) formatObject(def ast.Object) ([]byte, error) {
 		buffer.WriteString(fmt.Sprintf("// %s\n", commentLine))
 	}
 
+	if len(def.Type.CompilerPassTrail()) != 0 {
+		buffer.WriteString(fmt.Sprintf("// Altered by compiler passes: %s\n", strings.Join(def.Type.CompilerPassTrail(), ", ")))
+	}
+
 	switch def.Type.Kind {
 	case ast.KindEnum:
 		buffer.WriteString(jenny.formatEnumDef(def))


### PR DESCRIPTION
Because/thanks to compiler passes, generated types can be different from the schemas they come from.

To help us understand what cog is doing, we could (behind a `debug` flag) inject some kind of trail telling us explicitly where a compiler pass modified something:

![Screenshot from 2023-11-21 17-30-30](https://github.com/grafana/cog/assets/66958/dfed7163-ac98-4dd1-8171-6f1501581f85)

This is a quick PoC, just to get feedback/opinions on the idea :)
