### PR TITLE
Make Schema.LocateObject() return a boolean to explicitly indicate whether the object was found or not

### DIFF
--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -333,10 +333,13 @@ dataqueryTypeHint = *resource.%[1]s.Type
 func (jenny JSONMarshalling) renderPanelcfgVariantUnmarshal(schema *ast.Schema) (string, error) {
 	jenny.packageMapper("cog/variants")
 
+	_, hasOptions := schema.LocateObject("Options")
+	_, hasFieldConfig := schema.LocateObject("FieldConfig")
+
 	return jenny.renderTemplate("types/variant_panelcfg.json_unmarshal.tmpl", map[string]any{
 		"schema":         schema,
-		"hasOptions":     schema.LocateObject("Options").Name != "",
-		"hasFieldConfig": schema.LocateObject("FieldConfig").Name != "",
+		"hasOptions":     hasOptions,
+		"hasFieldConfig": hasFieldConfig,
 	})
 }
 

--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -21,13 +21,12 @@ func ByObjectName(objectName string) Selector {
 
 func StructGeneratedFromDisjunction() Selector {
 	return func(builder ast.Builder) bool {
-		typeDef := builder.For.Type
-
-		if typeDef.Kind == ast.KindRef {
-			typeDef = builder.Schema.LocateObject(typeDef.AsRef().ReferredType).Type
+		resolved, found := builder.Schema.Resolve(builder.For.Type)
+		if !found {
+			return false
 		}
 
-		return typeDef.IsStructGeneratedFromDisjunction()
+		return resolved.IsStructGeneratedFromDisjunction()
 	}
 }
 

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -78,8 +78,10 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 
 		firstArgType := option.Args[0].Type
 		if firstArgType.Kind == ast.KindRef {
-			referredObject := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
-			firstArgType = referredObject.Type
+			referredObject, found := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
+			if found {
+				firstArgType = referredObject.Type
+			}
 		}
 
 		if firstArgType.Kind != ast.KindStruct {
@@ -168,8 +170,10 @@ func StructFieldsAsOptionsAction(explicitFields ...string) RewriteAction {
 
 		firstArgType := option.Args[0].Type
 		if firstArgType.Kind == ast.KindRef {
-			referredObject := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
-			firstArgType = referredObject.Type
+			referredObject, found := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
+			if found {
+				firstArgType = referredObject.Type
+			}
 		}
 
 		if firstArgType.Kind != ast.KindStruct {
@@ -230,10 +234,8 @@ func DisjunctionAsOptionsAction() RewriteAction {
 		// or maybe a reference to a struct that was created to simulate a disjunction?
 		if firstArgType.Kind == ast.KindRef {
 			// FIXME: we only try to resolve the reference within the same package
-			referredObj := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
-			// Object not found
-			// TODO: LocateObject() should return a "found" boolean
-			if referredObj.Name == "" {
+			referredObj, found := builder.Schema.LocateObject(firstArgType.AsRef().ReferredType)
+			if !found {
 				return []ast.Option{option}
 			}
 


### PR DESCRIPTION
Because explicit is better.