### PR TITLE
Support dynamically injecting the language name in the output directory

### DIFF
--- a/internal/jennies/common/codejen.go
+++ b/internal/jennies/common/codejen.go
@@ -32,12 +32,12 @@ func If[Input any](condition bool, innerJenny codejen.OneToMany[Input]) codejen.
 // a [codejen.File] indicating  the jenny or jennies that constructed the
 // file.
 func GeneratedCommentHeader(config Config) codejen.FileMapper {
-	genHeader := `// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+	genHeader := `{{ .Leader }} Code generated - EDITING IS FUTILE. DO NOT EDIT.
 {{- with .Using }}
-//
-// Using jennies:
+{{ $.Leader }}
+{{ $.Leader }} Using jennies:
 {{- range . }}
-//     {{ .JennyName }}
+{{ $.Leader }}     {{ .JennyName }}
 {{- end }}
 {{- end }}
 
@@ -50,26 +50,45 @@ func GeneratedCommentHeader(config Config) codejen.FileMapper {
 	}
 
 	return func(f codejen.File) (codejen.File, error) {
-		// Never inject on certain filetypes, it's never valid
+		var leader string
 		switch filepath.Ext(f.RelativePath) {
-		case ".json", ".yml", ".yaml", ".md":
-			return f, nil
+		case ".ts", ".go":
+			leader = "//"
+		case ".yml", ".yaml", ".py":
+			leader = "#"
 		default:
-			var from []codejen.NamedJenny
-			if config.Debug {
-				from = f.From
-			}
-
-			buf := new(bytes.Buffer)
-			if err := tmpl.Execute(buf, map[string]any{
-				"Using": from,
-			}); err != nil {
-				return codejen.File{}, fmt.Errorf("failed executing GeneratedCommentHeader() template: %w", err)
-			}
-			buf.Write(f.Data)
-
-			f.Data = buf.Bytes()
+			leader = ""
 		}
+
+		if leader == "" {
+			return f, nil
+		}
+
+		var from []codejen.NamedJenny
+		if config.Debug {
+			from = f.From
+		}
+
+		buf := new(bytes.Buffer)
+		if err := tmpl.Execute(buf, map[string]any{
+			"Using":  from,
+			"Leader": leader,
+		}); err != nil {
+			return codejen.File{}, fmt.Errorf("failed executing GeneratedCommentHeader() template: %w", err)
+		}
+		buf.Write(f.Data)
+
+		f.Data = buf.Bytes()
+
+		return f, nil
+	}
+}
+
+// PathPrefixer returns a FileMapper that injects the provided path prefix to files
+// passed through it.
+func PathPrefixer(prefix string) codejen.FileMapper {
+	return func(f codejen.File) (codejen.File, error) {
+		f.RelativePath = filepath.Join(prefix, f.RelativePath)
 		return f, nil
 	}
 }

--- a/internal/jennies/common/codejen_test.go
+++ b/internal/jennies/common/codejen_test.go
@@ -1,0 +1,135 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/codejen"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeNamedJenny struct {
+	Name string
+}
+
+func (jenny fakeNamedJenny) JennyName() string {
+	return jenny.Name
+}
+
+func TestPrefixer(t *testing.T) {
+	req := require.New(t)
+	fileContent := []byte("with content")
+	inputFile := codejen.NewFile("some.file", fileContent)
+
+	resultFile, err := PathPrefixer("/the/prefix")(*inputFile)
+	req.NoError(err)
+
+	req.Equal("/the/prefix/some.file", resultFile.RelativePath)
+	req.Equal(fileContent, resultFile.Data)
+}
+
+func TestSlashHeaderMapper(t *testing.T) {
+	markdownContent := `# A document title
+
+With some content`
+
+	jsonContent := `{
+  "status": "all green"
+}`
+
+	yamlContent := `status: "all green"`
+	expectedYamlContent := fmt.Sprintf(`# Code generated - EDITING IS FUTILE. DO NOT EDIT.
+#
+# Using jennies:
+#     SomeJenny
+
+%s`, yamlContent)
+
+	goContent := `type SomeType struct {
+	Foo string
+}`
+	expectedGoContent := fmt.Sprintf(`// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     SomeJenny
+
+%s`, goContent)
+
+	tsContent := `export interface SomeType {
+	foo: string;
+}`
+	expectedTSContent := fmt.Sprintf(`// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     SomeJenny
+
+%s`, tsContent)
+	expectedTSContentNoDebug := fmt.Sprintf(`// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+%s`, tsContent)
+
+	namedJennies := []codejen.NamedJenny{
+		fakeNamedJenny{Name: "SomeJenny"},
+	}
+
+	testCases := []struct {
+		name            string
+		inputFile       *codejen.File
+		debug           bool
+		expectedContent string
+	}{
+		{
+			name:            "markdown file",
+			inputFile:       codejen.NewFile("./dir/README.md", []byte(markdownContent), namedJennies...),
+			expectedContent: markdownContent,
+		},
+		{
+			name:            "json file",
+			inputFile:       codejen.NewFile("./dir/data.json", []byte(jsonContent), namedJennies...),
+			expectedContent: jsonContent,
+		},
+		{
+			name:            "yaml file",
+			debug:           true,
+			inputFile:       codejen.NewFile("./dir/data.yaml", []byte(yamlContent), namedJennies...),
+			expectedContent: expectedYamlContent,
+		},
+		{
+			name:            "yml file",
+			debug:           true,
+			inputFile:       codejen.NewFile("./dir/data.yml", []byte(yamlContent), namedJennies...),
+			expectedContent: expectedYamlContent,
+		},
+		{
+			name:            "go file",
+			debug:           true,
+			inputFile:       codejen.NewFile("./dir/main.go", []byte(goContent), namedJennies...),
+			expectedContent: expectedGoContent,
+		},
+		{
+			name:            "ts type",
+			debug:           true,
+			inputFile:       codejen.NewFile("./dir/main.ts", []byte(tsContent), namedJennies...),
+			expectedContent: expectedTSContent,
+		},
+		{
+			name:            "ts type",
+			debug:           false,
+			inputFile:       codejen.NewFile("./dir/main.ts", []byte(tsContent), namedJennies...),
+			expectedContent: expectedTSContentNoDebug,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+
+		t.Run(tc.name, func(t *testing.T) {
+			req := require.New(t)
+
+			resultFile, err := GeneratedCommentHeader(Config{Debug: tc.debug})(*tc.inputFile)
+			req.NoError(err)
+
+			req.Equal(tc.expectedContent, string(resultFile.Data))
+		})
+	}
+}


### PR DESCRIPTION
This PR makes the output flag a bit more useful: by expanding a `%l` variable whenever present in the path with the current language name, we can easily generate code for each language in dedicated folders.

Example usage:

```console
go run cmd/cli/main.go generate \
    --output './generated/%l' \
    --kind-registry ../kind-registry \
    --cue ./schemas/cue/common \
    --include-cue-import ./schemas/cue/common:github.com/grafana/grafana/packages/grafana-schema/src/common \
    --veneers ./config
```

Will generate:

```
generated
├── go
│   ├── accesspolicy
│   ├── alertgroups
│   ├── annotationslist
│   ├── azuremonitor
│   ├── barchart
│   ├── bargauge
│   ├── candlestick
│   ├── canvas
│   ├── cloudwatch
│   ├── cog
│   ├── common
│   ├── dashboard
│   ├── dashboardlist
│   ├── datagrid
│   ├── debug
│   ├── elasticsearch
│   ├── folder
│   ├── gauge
│   ├── geomap
│   ├── googlecloudmonitoring
│   ├── grafanapyroscope
│   ├── heatmap
│   ├── histogram
│   ├── librarypanel
│   ├── logs
│   ├── loki
│   ├── news
│   ├── nodegraph
│   ├── parca
│   ├── piechart
│   ├── preferences
│   ├── prometheus
│   ├── publicdashboard
│   ├── role
│   ├── rolebinding
│   ├── stat
│   ├── statetimeline
│   ├── statushistory
│   ├── table
│   ├── team
│   ├── tempo
│   ├── testdata
│   ├── text
│   ├── timeseries
│   ├── trend
│   └── xychart
└── typescript
    ├── accesspolicy
    ├── alertgroups
    ├── annotationslist
    ├── azuremonitor
    ├── barchart
    ├── bargauge
    ├── candlestick
    ├── canvas
    ├── cloudwatch
    ├── cog
    ├── common
    ├── dashboard
    ├── dashboardlist
    ├── datagrid
    ├── debug
    ├── elasticsearch
    ├── folder
    ├── gauge
    ├── geomap
    ├── googlecloudmonitoring
    ├── grafanapyroscope
    ├── heatmap
    ├── histogram
    ├── librarypanel
    ├── logs
    ├── loki
    ├── news
    ├── nodegraph
    ├── parca
    ├── piechart
    ├── preferences
    ├── prometheus
    ├── publicdashboard
    ├── role
    ├── rolebinding
    ├── stat
    ├── statetimeline
    ├── statushistory
    ├── table
    ├── team
    ├── tempo
    ├── testdata
    ├── text
    ├── timeseries
    ├── trend
    └── xychart

95 directories, 0 files
```