### PR TITLE
Support constant values in `struct_fields_as_arguments`

### DIFF
--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -195,9 +195,15 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 
 				newAssignments = append(newAssignments, newAssignment)
 			} else {
+				var assignmentValue ast.AssignmentValue
+				if isConstant {
+					assignmentValue = ast.AssignmentValue{Constant: field.Type.AsScalar().Value}
+				} else {
+					assignmentValue = ast.AssignmentValue{Argument: &newArg}
+				}
 				valuesForEnvelope = append(valuesForEnvelope, ast.EnvelopeFieldValue{
 					Path:  ast.PathFromStructField(field),
-					Value: ast.AssignmentValue{Argument: &newArg},
+					Value: assignmentValue,
 				})
 			}
 		}

--- a/internal/veneers/option/actions_test.go
+++ b/internal/veneers/option/actions_test.go
@@ -351,3 +351,69 @@ func TestStructFieldsAsArgumentsAction_withStructArgument(t *testing.T) {
 
 	req.Equal([]ast.Option{expectedOption}, modifiedOpts)
 }
+
+func TestStructFieldsAsArgumentsAction_withArrayOfStructArgument(t *testing.T) {
+	req := require.New(t)
+
+	structType := ast.NewStruct(
+		ast.NewStructField("from", ast.String()),
+		ast.NewStructField("to", ast.String()),
+		ast.NewStructField("type", ast.String(ast.Value("time"))),
+	)
+
+	// input
+	option := ast.Option{
+		Args: []ast.Argument{
+			{Name: "time", Type: structType},
+		},
+		Assignments: []ast.Assignment{
+			ast.ArgumentAssignment(ast.Path{
+				{Identifier: "time", Type: ast.NewArray(structType)},
+			}, ast.Argument{Name: "time", Type: structType}),
+		},
+	}
+
+	// expected
+	expectedOption := ast.Option{
+		Args: []ast.Argument{
+			{Name: "from", Type: ast.String()},
+			{Name: "to", Type: ast.String()},
+		},
+		Assignments: []ast.Assignment{
+			{
+				Method: ast.AppendAssignment,
+				Path:   ast.Path{{Identifier: "time", Type: ast.NewArray(structType)}},
+				Value: ast.AssignmentValue{
+					Envelope: &ast.AssignmentEnvelope{
+						Type: structType,
+						Values: []ast.EnvelopeFieldValue{
+							{
+								Path: ast.Path{{Identifier: "from", Type: ast.String()}},
+								Value: ast.AssignmentValue{Argument: &ast.Argument{
+									Name: "from",
+									Type: ast.String(),
+								}},
+							},
+							{
+								Path: ast.Path{{Identifier: "to", Type: ast.String()}},
+								Value: ast.AssignmentValue{Argument: &ast.Argument{
+									Name: "to",
+									Type: ast.String(),
+								}},
+							},
+							{
+								Path:  ast.Path{{Identifier: "type", Type: ast.String(ast.Value("time"))}},
+								Value: ast.AssignmentValue{Constant: "time"},
+							},
+						},
+					},
+				},
+			},
+		},
+		VeneerTrail: []string{"StructFieldsAsArguments"},
+	}
+
+	modifiedOpts := StructFieldsAsArgumentsAction()(ast.Builder{}, option)
+
+	req.Equal([]ast.Option{expectedOption}, modifiedOpts)
+}


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/164

As the issue describes, when a constant value field is marked to be used as an arg, it is ignored and assigned its value instead