### PR TITLE
Typescript: rename the cog.OptionsBuilder interface to cog.Builder

### DIFF
--- a/internal/jennies/typescript/runtime.go
+++ b/internal/jennies/typescript/runtime.go
@@ -15,14 +15,14 @@ func (jenny Runtime) JennyName() string {
 func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
 	return codejen.Files{
 		*codejen.NewFile("cog/variants_gen.ts", []byte(jenny.generateVariantsFile()), jenny),
-		*codejen.NewFile("cog/options_builder_gen.ts", []byte(jenny.generateOptionsBuilderFile()), jenny),
+		*codejen.NewFile("cog/builder_gen.ts", []byte(jenny.generateOptionsBuilderFile()), jenny),
 		*codejen.NewFile("cog/index.ts", []byte(jenny.generateIndexFile()), jenny),
 	}, nil
 }
 
 func (jenny Runtime) generateIndexFile() string {
 	return `export * from './variants_gen';
-export * from './options_builder_gen';
+export * from './builder_gen';
 `
 }
 
@@ -35,7 +35,7 @@ func (jenny Runtime) generateVariantsFile() string {
 }
 
 func (jenny Runtime) generateOptionsBuilderFile() string {
-	return `export interface OptionsBuilder<T> {
+	return `export interface Builder<T> {
   build: () => T;
 }
 `

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -4,7 +4,7 @@
 {{- range .Comments }}
 // {{ . }}
 {{- end }}
-export class {{ .BuilderName|upperCamelCase }}Builder implements cog.OptionsBuilder<{{ .BuilderSignatureType }}> {
+export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ .BuilderSignatureType }}> {
     private readonly internal: {{ .ImportAlias }}.{{ .ObjectName }};
     {{- range .Properties }}
     private {{ .Name }}: {{ .Type | formatType }} = {{ .Type | defaultValueForType }};

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -56,7 +56,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 		if resolveBuilders && formatter.context.ResolveToBuilder(def) {
 			cogAlias := formatter.packageMapper("cog")
 
-			return fmt.Sprintf("%s.OptionsBuilder<%s>", cogAlias, formatted)
+			return fmt.Sprintf("%s.Builder<%s>", cogAlias, formatted)
 		}
 
 		return formatted
@@ -86,7 +86,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 
 		cogAlias := formatter.packageMapper("cog")
 
-		return fmt.Sprintf("%s.OptionsBuilder<%s>", cogAlias, formatted)
+		return fmt.Sprintf("%s.Builder<%s>", cogAlias, formatted)
 	default:
 		return string(def.Kind)
 	}

--- a/testdata/jennies/builders/anonymous_struct/test.txtar
+++ b/testdata/jennies/builders/anonymous_struct/test.txtar
@@ -303,7 +303,7 @@
 import * as cog from '../cog';
 import * as anonymous_struct from '../anonymous_struct';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<anonymous_struct.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<anonymous_struct.SomeStruct> {
     private readonly internal: anonymous_struct.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/array_append/test.txtar
+++ b/testdata/jennies/builders/array_append/test.txtar
@@ -177,7 +177,7 @@
 import * as cog from '../cog';
 import * as sandbox from '../sandbox';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<sandbox.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     private readonly internal: sandbox.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/basic_struct/test.txtar
+++ b/testdata/jennies/builders/basic_struct/test.txtar
@@ -462,7 +462,7 @@ import * as cog from '../cog';
 import * as basic_struct from '../basic_struct';
 
 // SomeStruct, to hold data.
-export class SomeStructBuilder implements cog.OptionsBuilder<basic_struct.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<basic_struct.SomeStruct> {
     private readonly internal: basic_struct.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/basic_struct_defaults/test.txtar
+++ b/testdata/jennies/builders/basic_struct_defaults/test.txtar
@@ -488,7 +488,7 @@
 import * as cog from '../cog';
 import * as basic_struct_defaults from '../basic_struct_defaults';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<basic_struct_defaults.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<basic_struct_defaults.SomeStruct> {
     private readonly internal: basic_struct_defaults.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/builder_delegation/test.txtar
+++ b/testdata/jennies/builders/builder_delegation/test.txtar
@@ -753,7 +753,7 @@
 import * as cog from '../cog';
 import * as builder_delegation from '../builder_delegation';
 
-export class DashboardLinkBuilder implements cog.OptionsBuilder<builder_delegation.DashboardLink> {
+export class DashboardLinkBuilder implements cog.Builder<builder_delegation.DashboardLink> {
     private readonly internal: builder_delegation.DashboardLink;
 
     constructor() {
@@ -778,7 +778,7 @@ export class DashboardLinkBuilder implements cog.OptionsBuilder<builder_delegati
 import * as cog from '../cog';
 import * as builder_delegation from '../builder_delegation';
 
-export class DashboardBuilder implements cog.OptionsBuilder<builder_delegation.Dashboard> {
+export class DashboardBuilder implements cog.Builder<builder_delegation.Dashboard> {
     private readonly internal: builder_delegation.Dashboard;
 
     constructor() {
@@ -799,13 +799,13 @@ export class DashboardBuilder implements cog.OptionsBuilder<builder_delegation.D
         return this;
     }
 
-    links(links: cog.OptionsBuilder<builder_delegation.DashboardLink>[]): this {
+    links(links: cog.Builder<builder_delegation.DashboardLink>[]): this {
         const linksResources = links.map(builder => builder.build());
         this.internal.links = linksResources;
         return this;
     }
 
-    singleLink(singleLink: cog.OptionsBuilder<builder_delegation.DashboardLink>): this {
+    singleLink(singleLink: cog.Builder<builder_delegation.DashboardLink>): this {
         const singleLinkResource = singleLink.build();
         this.internal.singleLink = singleLinkResource;
         return this;

--- a/testdata/jennies/builders/composable_slot/test.txtar
+++ b/testdata/jennies/builders/composable_slot/test.txtar
@@ -268,7 +268,7 @@
 import * as cog from '../cog';
 import * as composable_slot from '../composable_slot';
 
-export class LokiBuilderBuilder implements cog.OptionsBuilder<composable_slot.Dashboard> {
+export class LokiBuilderBuilder implements cog.Builder<composable_slot.Dashboard> {
     private readonly internal: composable_slot.Dashboard;
 
     constructor() {
@@ -279,13 +279,13 @@ export class LokiBuilderBuilder implements cog.OptionsBuilder<composable_slot.Da
         return this.internal;
     }
 
-    target(target: cog.OptionsBuilder<cog.Dataquery>): this {
+    target(target: cog.Builder<cog.Dataquery>): this {
         const targetResource = target.build();
         this.internal.target = targetResource;
         return this;
     }
 
-    targets(targets: cog.OptionsBuilder<cog.Dataquery>[]): this {
+    targets(targets: cog.Builder<cog.Dataquery>[]): this {
         const targetsResources = targets.map(builder => builder.build());
         this.internal.targets = targetsResources;
         return this;

--- a/testdata/jennies/builders/constant_assignment/test.txtar
+++ b/testdata/jennies/builders/constant_assignment/test.txtar
@@ -241,7 +241,7 @@
 import * as cog from '../cog';
 import * as sandbox from '../sandbox';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<sandbox.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     private readonly internal: sandbox.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/constraints/test.txtar
+++ b/testdata/jennies/builders/constraints/test.txtar
@@ -386,7 +386,7 @@
 import * as cog from '../cog';
 import * as constraints from '../constraints';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<constraints.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<constraints.SomeStruct> {
     private readonly internal: constraints.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/constructor_argument/test.txtar
+++ b/testdata/jennies/builders/constructor_argument/test.txtar
@@ -153,7 +153,7 @@
 import * as cog from '../cog';
 import * as sandbox from '../sandbox';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<sandbox.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     private readonly internal: sandbox.SomeStruct;
 
     constructor(title: string) {

--- a/testdata/jennies/builders/constructor_initializations/test.txtar
+++ b/testdata/jennies/builders/constructor_initializations/test.txtar
@@ -210,7 +210,7 @@
 import * as cog from '../cog';
 import * as constructor_initializations from '../constructor_initializations';
 
-export class SomePanelBuilder implements cog.OptionsBuilder<constructor_initializations.SomePanel> {
+export class SomePanelBuilder implements cog.Builder<constructor_initializations.SomePanel> {
     private readonly internal: constructor_initializations.SomePanel;
 
     constructor() {

--- a/testdata/jennies/builders/dataquery_variant_builder/test.txtar
+++ b/testdata/jennies/builders/dataquery_variant_builder/test.txtar
@@ -162,7 +162,7 @@
 import * as cog from '../cog';
 import * as dataquery_variant_builder from '../dataquery_variant_builder';
 
-export class LokiBuilderBuilder implements cog.OptionsBuilder<cog.Dataquery> {
+export class LokiBuilderBuilder implements cog.Builder<cog.Dataquery> {
     private readonly internal: dataquery_variant_builder.Loki;
 
     constructor() {

--- a/testdata/jennies/builders/foreign_builder/test.txtar
+++ b/testdata/jennies/builders/foreign_builder/test.txtar
@@ -154,7 +154,7 @@
 import * as cog from '../cog';
 import * as some_pkg from '../some_pkg';
 
-export class SomeNiceBuilderBuilder implements cog.OptionsBuilder<some_pkg.SomeStruct> {
+export class SomeNiceBuilderBuilder implements cog.Builder<some_pkg.SomeStruct> {
     private readonly internal: some_pkg.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/known_any/test.txtar
+++ b/testdata/jennies/builders/known_any/test.txtar
@@ -223,7 +223,7 @@
 import * as cog from '../cog';
 import * as known_any from '../known_any';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<known_any.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<known_any.SomeStruct> {
     private readonly internal: known_any.SomeStruct;
 
     constructor() {

--- a/testdata/jennies/builders/properties/test.txtar
+++ b/testdata/jennies/builders/properties/test.txtar
@@ -166,7 +166,7 @@
 import * as cog from '../cog';
 import * as properties from '../properties';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<properties.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<properties.SomeStruct> {
     private readonly internal: properties.SomeStruct;
     private someBuilderProperty: string = "";
 

--- a/testdata/jennies/builders/references/test.txtar
+++ b/testdata/jennies/builders/references/test.txtar
@@ -201,7 +201,7 @@ import * as cog from '../cog';
 import * as some_pkg from '../some_pkg';
 import * as other_pkg from '../other_pkg';
 
-export class PersonBuilder implements cog.OptionsBuilder<some_pkg.Person> {
+export class PersonBuilder implements cog.Builder<some_pkg.Person> {
     private readonly internal: some_pkg.Person;
 
     constructor() {

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
@@ -339,7 +339,7 @@
 import * as cog from '../cog';
 import * as sandbox from '../sandbox';
 
-export class SomeStructBuilder implements cog.OptionsBuilder<sandbox.SomeStruct> {
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     private readonly internal: sandbox.SomeStruct;
 
     constructor() {


### PR DESCRIPTION
Because it's consistent with Go, and it looks better.