### PR TITLE
Define veneers for dashboard variables

### DIFF
--- a/config/dashboard.variables.veneers.common.yaml
+++ b/config/dashboard.variables.veneers.common.yaml
@@ -120,10 +120,10 @@ options:
   - omit: { by_builder: DatasourceVariable.options }
   - rename:
       by_builder: DatasourceVariable.query
-      as: datasourceType
-  # DatasourceType("prometheus") instead of explicit DatasourceType(StringOrAny{String: "prometheus"})
+      as: type
+  # Type("prometheus") instead of explicit Type(StringOrAny{String: "prometheus"})
   - struct_fields_as_arguments:
-      by_builder: DatasourceVariable.datasourceType
+      by_builder: DatasourceVariable.type
       fields: [String]
 
   ####################

--- a/config/dashboard.variables.veneers.common.yaml
+++ b/config/dashboard.variables.veneers.common.yaml
@@ -83,9 +83,6 @@ options:
   # QueryVariable #
   #################
   - omit: { by_builder: QueryVariable.skipUrlSync }
-  - rename:
-      by_builder: QueryVariable.query
-      as: value
 
   #################
   # AdHocVariable #

--- a/config/dashboard.variables.veneers.common.yaml
+++ b/config/dashboard.variables.veneers.common.yaml
@@ -1,0 +1,165 @@
+language: all
+
+package: dashboard
+
+builders:
+  #################
+  # VariableModel #
+  #################
+
+  - duplicate:
+      by_name: VariableModel
+      as: QueryVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: QueryVariable
+      set:
+        - { property: type, value: query }
+
+  - duplicate:
+      by_name: VariableModel
+      as: AdHocVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: AdHocVariable
+      set:
+        - { property: type, value: adhoc }
+
+  - duplicate:
+      by_name: VariableModel
+      as: ConstantVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: ConstantVariable
+      set:
+        - { property: type, value: constant }
+
+  - duplicate:
+      by_name: VariableModel
+      as: DatasourceVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: DatasourceVariable
+      set:
+        - { property: type, value: datasource }
+
+  - duplicate:
+      by_name: VariableModel
+      as: IntervalVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: IntervalVariable
+      set:
+        - { property: type, value: interval }
+
+  - duplicate:
+      by_name: VariableModel
+      as: TextBoxVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: TextBoxVariable
+      set:
+        - { property: type, value: textbox }
+
+  - duplicate:
+      by_name: VariableModel
+      as: CustomVariable
+      exclude_options: [type]
+  - initialize:
+      by_name: CustomVariable
+      set:
+        - { property: type, value: custom }
+
+  # We don't need this generic builder anymore
+  - omit: { by_name: VariableModel }
+
+options:
+  #################
+  # VariableModel #
+  #################
+  - promote_to_constructor: { by_name: VariableModel.name }
+
+  #################
+  # QueryVariable #
+  #################
+  - omit: { by_builder: QueryVariable.skipUrlSync }
+  - rename:
+      by_builder: QueryVariable.query
+      as: value
+
+  #################
+  # AdHocVariable #
+  #################
+  - omit: { by_builder: AdHocVariable.skipUrlSync }
+  - omit: { by_builder: AdHocVariable.query }
+  - omit: { by_builder: AdHocVariable.current }
+  - omit: { by_builder: AdHocVariable.multi }
+  - omit: { by_builder: AdHocVariable.options }
+  - omit: { by_builder: AdHocVariable.refresh }
+  - omit: { by_builder: AdHocVariable.sort }
+
+  ####################
+  # ConstantVariable #
+  ####################
+  - omit: { by_builder: ConstantVariable.skipUrlSync }
+  - omit: { by_builder: ConstantVariable.datasource }
+  - omit: { by_builder: ConstantVariable.multi }
+  - omit: { by_builder: ConstantVariable.sort }
+  - omit: { by_builder: ConstantVariable.refresh }
+  - omit: { by_builder: ConstantVariable.options }
+  - omit: { by_builder: ConstantVariable.current }
+  - omit: { by_builder: ConstantVariable.hide }
+  - rename:
+      by_builder: ConstantVariable.query
+      as: value
+
+  ######################
+  # DatasourceVariable #
+  ######################
+  - omit: { by_builder: DatasourceVariable.skipUrlSync }
+  - omit: { by_builder: DatasourceVariable.datasource }
+  - omit: { by_builder: DatasourceVariable.sort }
+  - omit: { by_builder: DatasourceVariable.refresh }
+  - omit: { by_builder: DatasourceVariable.options }
+  - rename:
+      by_builder: DatasourceVariable.query
+      as: datasourceType
+  # DatasourceType("prometheus") instead of explicit DatasourceType(StringOrAny{String: "prometheus"})
+  - struct_fields_as_arguments:
+      by_builder: DatasourceVariable.datasourceType
+      fields: [String]
+
+  ####################
+  # IntervalVariable #
+  ####################
+  - omit: { by_builder: IntervalVariable.skipUrlSync }
+  - omit: { by_builder: IntervalVariable.datasource }
+  - omit: { by_builder: IntervalVariable.multi }
+  - omit: { by_builder: IntervalVariable.sort }
+  - omit: { by_builder: IntervalVariable.refresh }
+  - rename:
+      by_builder: IntervalVariable.query
+      as: values
+
+  ###################
+  # TextBoxVariable #
+  ###################
+  - omit: { by_builder: TextBoxVariable.skipUrlSync }
+  - omit: { by_builder: TextBoxVariable.datasource }
+  - omit: { by_builder: TextBoxVariable.sort }
+  - omit: { by_builder: TextBoxVariable.refresh }
+  - omit: { by_builder: TextBoxVariable.multi }
+  - rename:
+      by_builder: TextBoxVariable.query
+      as: defaultValue
+
+  ##################
+  # CustomVariable #
+  ##################
+  - omit: { by_builder: CustomVariable.skipUrlSync }
+  - omit: { by_builder: CustomVariable.datasource }
+  - omit: { by_builder: CustomVariable.sort }
+  - omit: { by_builder: CustomVariable.refresh }
+  - rename:
+      by_builder: CustomVariable.query
+      as: values

--- a/examples/_go/main.go
+++ b/examples/_go/main.go
@@ -24,26 +24,18 @@ func dashboardBuilder() []byte {
 		Tooltip(dashboard.DashboardCursorSyncCrosshair).
 		// TODO: we should have specific builders for every possible variable type
 		// "Data Source" variable
-		WithVariable(dashboard.NewVariableModelBuilder().
-			Type(dashboard.VariableTypeDatasource).
-			Name("datasource").
+		WithVariable(dashboard.NewDatasourceVariableBuilder("datasource").
 			Label("Data Source").
 			Hide(dashboard.VariableHideDontHide).
-			Refresh(dashboard.VariableRefreshOnDashboardLoad).
-			Query(dashboard.StringOrAny{
-				String: toPtr("prometheus"),
-			}).
+			DatasourceType("prometheus").
 			Current(dashboard.VariableOption{
 				Selected: toPtr(true),
 				Text:     dashboard.StringOrArrayOfString{String: toPtr("grafanacloud-potatopi-prom")},
 				Value:    dashboard.StringOrArrayOfString{String: toPtr("grafanacloud-prom")},
-			}).
-			Sort(dashboard.VariableSortDisabled),
+			}),
 		).
 		// "Instance" variable
-		WithVariable(dashboard.NewVariableModelBuilder().
-			Type(dashboard.VariableTypeQuery).
-			Name("instance").
+		WithVariable(dashboard.NewQueryVariableBuilder("instance").
 			Label("Instance").
 			Hide(dashboard.VariableHideDontHide).
 			Refresh(dashboard.VariableRefreshOnTimeRangeChanged).

--- a/examples/_go/main.go
+++ b/examples/_go/main.go
@@ -27,7 +27,7 @@ func dashboardBuilder() []byte {
 		WithVariable(dashboard.NewDatasourceVariableBuilder("datasource").
 			Label("Data Source").
 			Hide(dashboard.VariableHideDontHide).
-			DatasourceType("prometheus").
+			Type("prometheus").
 			Current(dashboard.VariableOption{
 				Selected: toPtr(true),
 				Text:     dashboard.StringOrArrayOfString{String: toPtr("grafanacloud-potatopi-prom")},

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -1,13 +1,13 @@
 import {
     DashboardBuilder,
     DashboardCursorSync,
+    DatasourceVariableBuilder,
+    QueryVariableBuilder,
     RowBuilder,
     TimePickerBuilder,
     VariableHide,
-    VariableModelBuilder,
     VariableRefresh,
     VariableSort,
-    VariableType
 } from "../../generated/src/dashboard";
 import {cpuTemperatureGauge, cpuUsageTimeseries, loadAverageTimeseries} from "./cpu";
 import {memoryUsageGauge, memoryUsageTimeseries} from "./memory";
@@ -33,24 +33,19 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
 
     // "Data Source" variable
     .withVariable(
-        new VariableModelBuilder()
-            .type(VariableType.Datasource)
-            .name("datasource")
+        new DatasourceVariableBuilder("datasource")
             .label("Data Source")
             .hide(VariableHide.DontHide)
-            .refresh(VariableRefresh.OnDashboardLoad)
-            .query("prometheus")
+            .datasourceType("prometheus")
             .current({
                 selected: true,
                 text: "grafanacloud-potatopi-prom",
                 value: "grafanacloud-prom",
             })
-            .sort(VariableSort.Disabled)
     )
     // "Instance" variable
     .withVariable(
-        new VariableModelBuilder()
-            .type(VariableType.Query)
+        new QueryVariableBuilder("instance")
             .name("instance")
             .label("Instance")
             .hide(VariableHide.DontHide)

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -36,7 +36,7 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
         new DatasourceVariableBuilder("datasource")
             .label("Data Source")
             .hide(VariableHide.DontHide)
-            .datasourceType("prometheus")
+            .type("prometheus")
             .current({
                 selected: true,
                 text: "grafanacloud-potatopi-prom",

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -24,6 +24,34 @@ type Builder struct {
 	VeneerTrail     []string     `json:",omitempty"`
 }
 
+func (builder *Builder) DeepCopy() Builder {
+	clone := Builder{
+		Schema:          builder.Schema,
+		For:             builder.For,
+		Package:         builder.Package,
+		Name:            builder.Name,
+		Properties:      make([]StructField, 0, len(builder.Properties)),
+		Options:         make([]Option, 0, len(builder.Options)),
+		Initializations: make([]Assignment, 0, len(builder.Initializations)),
+		VeneerTrail:     make([]string, 0, len(builder.VeneerTrail)),
+	}
+
+	for _, property := range builder.Properties {
+		clone.Properties = append(clone.Properties, property.DeepCopy())
+	}
+	for _, opt := range builder.Options {
+		clone.Options = append(clone.Options, opt.DeepCopy())
+	}
+	for _, init := range builder.Initializations {
+		clone.Initializations = append(clone.Initializations, init.DeepCopy())
+	}
+	for _, veneer := range builder.VeneerTrail {
+		clone.VeneerTrail = append(clone.VeneerTrail, veneer)
+	}
+
+	return clone
+}
+
 func (builder *Builder) AddToVeneerTrail(veneerName string) {
 	builder.VeneerTrail = append(builder.VeneerTrail, veneerName)
 }
@@ -99,6 +127,28 @@ type Option struct {
 	IsConstructorArg bool
 }
 
+func (opt *Option) DeepCopy() Option {
+	clone := Option{
+		Name:             opt.Name,
+		Comments:         make([]string, 0, len(opt.Comments)),
+		VeneerTrail:      make([]string, 0, len(opt.VeneerTrail)),
+		Args:             make([]Argument, 0, len(opt.Args)),
+		Assignments:      make([]Assignment, 0, len(opt.Assignments)),
+		IsConstructorArg: opt.IsConstructorArg,
+	}
+
+	clone.Comments = append(clone.Comments, opt.Comments...)
+	clone.VeneerTrail = append(clone.VeneerTrail, opt.VeneerTrail...)
+	for _, arg := range opt.Args {
+		clone.Args = append(clone.Args, arg.DeepCopy())
+	}
+	for _, assignment := range opt.Assignments {
+		clone.Assignments = append(clone.Assignments, assignment.DeepCopy())
+	}
+
+	return clone
+}
+
 func (opt *Option) AddToVeneerTrail(veneerName string) {
 	opt.VeneerTrail = append(opt.VeneerTrail, veneerName)
 }
@@ -112,6 +162,13 @@ type Argument struct {
 	Type Type
 }
 
+func (arg *Argument) DeepCopy() Argument {
+	return Argument{
+		Name: arg.Name,
+		Type: arg.Type.DeepCopy(),
+	}
+}
+
 type PathItem struct {
 	Identifier string
 	Type       Type // any
@@ -120,7 +177,31 @@ type PathItem struct {
 	TypeHint *Type `json:",omitempty"`
 }
 
+func (item PathItem) DeepCopy() PathItem {
+	clone := PathItem{
+		Identifier: item.Identifier,
+		Type:       item.Type.DeepCopy(),
+	}
+
+	if item.TypeHint != nil {
+		hint := item.TypeHint.DeepCopy()
+		clone.TypeHint = &hint
+	}
+
+	return clone
+}
+
 type Path []PathItem
+
+func (path Path) DeepCopy() Path {
+	clone := make([]PathItem, 0, len(path))
+
+	for _, item := range path {
+		clone = append(clone, item.DeepCopy())
+	}
+
+	return clone
+}
 
 func PathFromStructField(field StructField) Path {
 	return Path{
@@ -154,15 +235,53 @@ type EnvelopeFieldValue struct {
 	Value AssignmentValue // what to assign
 }
 
+func (value *EnvelopeFieldValue) DeepCopy() EnvelopeFieldValue {
+	return EnvelopeFieldValue{
+		Path:  value.Path.DeepCopy(),
+		Value: value.Value.DeepCopy(),
+	}
+}
+
 type AssignmentEnvelope struct {
 	Type   Type // Should be a ref or a struct only
 	Values []EnvelopeFieldValue
+}
+
+func (envelope *AssignmentEnvelope) DeepCopy() AssignmentEnvelope {
+	clone := AssignmentEnvelope{
+		Type:   envelope.Type.DeepCopy(),
+		Values: make([]EnvelopeFieldValue, 0, len(envelope.Values)),
+	}
+
+	for _, value := range envelope.Values {
+		clone.Values = append(clone.Values, value.DeepCopy())
+	}
+
+	return clone
 }
 
 type AssignmentValue struct {
 	Argument *Argument           `json:",omitempty"`
 	Constant any                 `json:",omitempty"`
 	Envelope *AssignmentEnvelope `json:",omitempty"`
+}
+
+func (value *AssignmentValue) DeepCopy() AssignmentValue {
+	clone := AssignmentValue{
+		Constant: value.Constant,
+	}
+
+	if value.Argument != nil {
+		arg := value.Argument.DeepCopy()
+		clone.Argument = &arg
+	}
+
+	if value.Envelope != nil {
+		envelope := value.Envelope.DeepCopy()
+		clone.Envelope = &envelope
+	}
+
+	return clone
 }
 
 type AssignmentMethod string
@@ -183,6 +302,21 @@ type Assignment struct {
 	Method AssignmentMethod
 
 	Constraints []TypeConstraint `json:",omitempty"`
+}
+
+func (assignment *Assignment) DeepCopy() Assignment {
+	clone := Assignment{
+		Path:        assignment.Path.DeepCopy(),
+		Value:       assignment.Value.DeepCopy(),
+		Method:      assignment.Method,
+		Constraints: make([]TypeConstraint, 0, len(assignment.Constraints)),
+	}
+
+	for _, constraint := range assignment.Constraints {
+		clone.Constraints = append(clone.Constraints, constraint.DeepCopy())
+	}
+
+	return clone
 }
 
 type AssignmentOpt func(assignment *Assignment)

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -36,6 +36,8 @@ func (builder *Builder) DeepCopy() Builder {
 		VeneerTrail:     make([]string, 0, len(builder.VeneerTrail)),
 	}
 
+	clone.VeneerTrail = append(clone.VeneerTrail, builder.VeneerTrail...)
+
 	for _, property := range builder.Properties {
 		clone.Properties = append(clone.Properties, property.DeepCopy())
 	}
@@ -44,9 +46,6 @@ func (builder *Builder) DeepCopy() Builder {
 	}
 	for _, init := range builder.Initializations {
 		clone.Initializations = append(clone.Initializations, init.DeepCopy())
-	}
-	for _, veneer := range builder.VeneerTrail {
-		clone.VeneerTrail = append(clone.VeneerTrail, veneer)
 	}
 
 	return clone

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -117,12 +117,20 @@ func (t Type) HasHint(hintName string) bool {
 	return found
 }
 
+func (t Type) IsRef() bool {
+	return t.Kind == KindRef
+}
+
 func (t Type) IsStructOrRef() bool {
 	return t.Kind == KindStruct || t.Kind == KindRef
 }
 
 func (t Type) IsArray() bool {
 	return t.Kind == KindArray
+}
+
+func (t Type) IsEnum() bool {
+	return t.Kind == KindEnum
 }
 
 func (t Type) IsStructGeneratedFromDisjunction() bool {

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -34,7 +34,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 
 		filename := filepath.Join(
 			strings.ToLower(builder.Package),
-			fmt.Sprintf("%s_builder_gen.go", strings.ToLower(builder.For.Name)),
+			fmt.Sprintf("%s_builder_gen.go", strings.ToLower(builder.Name)),
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -40,7 +40,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 		filename := filepath.Join(
 			"src",
 			strings.ToLower(builder.Package),
-			fmt.Sprintf("%s_builder_gen.ts", strings.ToLower(builder.For.Name)),
+			fmt.Sprintf("%s_builder_gen.ts", strings.ToLower(builder.Name)),
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -83,6 +83,16 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 			"defaultValueForType": func(typeDef ast.Type) string {
 				return formatValue(jenny.rawTypes.defaultValueForType(typeDef, jenny.typeImportMapper))
 			},
+			"formatValue": func(destinationType ast.Type, value any) string {
+				if destinationType.IsRef() {
+					referredObj, found := context.LocateObject(destinationType.AsRef().ReferredPkg, destinationType.AsRef().ReferredType)
+					if found && referredObj.Type.IsEnum() {
+						return jenny.typeFormatter.formatEnumValue(referredObj, value)
+					}
+				}
+
+				return formatValue(value)
+			},
 		}).
 		ExecuteTemplate(&buffer, "builder.tmpl", template.Builder{
 			BuilderName:          builder.Name,

--- a/internal/jennies/typescript/index.go
+++ b/internal/jennies/typescript/index.go
@@ -29,7 +29,7 @@ func (jenny Index) Generate(context common.Context) (codejen.Files, error) {
 
 	if jenny.Targets.Builders {
 		for _, builder := range context.Builders {
-			packages[builder.Package] = append(packages[builder.Package], fmt.Sprintf("%s_builder_gen", strings.ToLower(builder.For.Name)))
+			packages[builder.Package] = append(packages[builder.Package], fmt.Sprintf("%s_builder_gen", strings.ToLower(builder.Name)))
 		}
 	}
 

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -14,7 +14,7 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
         this.internal = {{ .ImportAlias }}.default{{ .ObjectName | upperCamelCase }}();
         {{- range $arg := .Constructor.Assignments }}
         {{- template "constraints" $arg.Constraints }}
-        this.internal.{{ $arg.Path }} = {{ template "assignment_value" $arg }};
+        this.internal.{{ $arg.Path }} = {{ template "assignment_value" (dict "Assignment" $arg "Value" $arg.Value) }};
         {{- end }}
     }
 
@@ -57,7 +57,7 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
 
 {{- define "assignment_value" }}
     {{- if not (eq .Value.Constant nil) }}
-        {{- formatScalar .Value.Constant }}
+        {{- formatValue .Assignment.Path.Last.Type .Value.Constant }}
     {{- end }}
     {{- with .Value.Argument }}
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}

--- a/internal/jennies/typescript/tmpl.go
+++ b/internal/jennies/typescript/tmpl.go
@@ -31,9 +31,9 @@ func init() {
 			"defaultValueForType": func(_ ast.Type) string {
 				panic("defaultValueForType() needs to be overridden by a jenny")
 			},
-		}).
-		Funcs(template.FuncMap{
-			"formatScalar": formatScalar,
+			"formatValue": func(destinationType ast.Type, value any) string {
+				panic("formatValue() needs to be overridden by a jenny")
+			},
 		})
 	templates = template.Must(cogtemplate.FindAndParseTemplates(templatesFS, base, "templates"))
 }

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -250,7 +250,7 @@ func Duplicate(selector Selector, duplicateName string, excludeOptions []string)
 
 			duplicatedBuilder := builder.DeepCopy()
 			duplicatedBuilder.Name = duplicateName
-			duplicatedBuilder.AddToVeneerTrail("Duplicate")
+			duplicatedBuilder.AddToVeneerTrail(fmt.Sprintf("Duplicate[%s.%s]", builder.Package, builder.Name))
 
 			if len(excludeOptions) != 0 {
 				duplicatedBuilder.Options = tools.Filter(duplicatedBuilder.Options, func(option ast.Option) bool {
@@ -277,6 +277,7 @@ func Initialize(selector Selector, statements []Initialization) RewriteRule {
 				continue
 			}
 
+			veneerDebug := make([]string, 0, len(statements))
 			for _, statement := range statements {
 				path, err := builders[i].MakePath(builders, statement.PropertyPath)
 				if err != nil {
@@ -284,8 +285,9 @@ func Initialize(selector Selector, statements []Initialization) RewriteRule {
 				}
 
 				builders[i].Initializations = append(builders[i].Initializations, ast.ConstantAssignment(path, statement.Value))
+				veneerDebug = append(veneerDebug, fmt.Sprintf("%s = %v", statement.PropertyPath, statement.Value))
 			}
-			builders[i].AddToVeneerTrail("Initialize")
+			builders[i].AddToVeneerTrail(fmt.Sprintf("Initialize[%s]", strings.Join(veneerDebug, ", ")))
 		}
 
 		return builders, nil

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -239,7 +239,7 @@ func Properties(selector Selector, properties []ast.StructField) RewriteRule {
 	}
 }
 
-func Duplicate(selector Selector, duplicateName string) RewriteRule {
+func Duplicate(selector Selector, duplicateName string, excludeOptions []string) RewriteRule {
 	return func(builders ast.Builders) (ast.Builders, error) {
 		var newBuilders ast.Builders
 
@@ -251,6 +251,12 @@ func Duplicate(selector Selector, duplicateName string) RewriteRule {
 			duplicatedBuilder := builder.DeepCopy()
 			duplicatedBuilder.Name = duplicateName
 			duplicatedBuilder.AddToVeneerTrail("Duplicate")
+
+			if len(excludeOptions) != 0 {
+				duplicatedBuilder.Options = tools.Filter(duplicatedBuilder.Options, func(option ast.Option) bool {
+					return !tools.StringInListEqualFold(option.Name, excludeOptions)
+				})
+			}
 
 			newBuilders = append(newBuilders, duplicatedBuilder)
 		}

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -264,3 +264,30 @@ func Duplicate(selector Selector, duplicateName string, excludeOptions []string)
 		return append(builders, newBuilders...), nil
 	}
 }
+
+type Initialization struct {
+	PropertyPath string
+	Value        any
+}
+
+func Initialize(selector Selector, statements []Initialization) RewriteRule {
+	return func(builders ast.Builders) (ast.Builders, error) {
+		for i, builder := range builders {
+			if !selector(builder) {
+				continue
+			}
+
+			for _, statement := range statements {
+				path, err := builders[i].MakePath(builders, statement.PropertyPath)
+				if err != nil {
+					return nil, err
+				}
+
+				builders[i].Initializations = append(builders[i].Initializations, ast.ConstantAssignment(path, statement.Value))
+			}
+			builders[i].AddToVeneerTrail("Initialize")
+		}
+
+		return builders, nil
+	}
+}

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -238,3 +238,23 @@ func Properties(selector Selector, properties []ast.StructField) RewriteRule {
 		return builders, nil
 	}
 }
+
+func Duplicate(selector Selector, duplicateName string) RewriteRule {
+	return func(builders ast.Builders) (ast.Builders, error) {
+		var newBuilders ast.Builders
+
+		for _, builder := range builders {
+			if !selector(builder) {
+				continue
+			}
+
+			duplicatedBuilder := builder.DeepCopy()
+			duplicatedBuilder.Name = duplicateName
+			duplicatedBuilder.AddToVeneerTrail("Duplicate")
+
+			newBuilders = append(newBuilders, duplicatedBuilder)
+		}
+
+		return append(builders, newBuilders...), nil
+	}
+}

--- a/internal/veneers/builder/rules_test.go
+++ b/internal/veneers/builder/rules_test.go
@@ -1,0 +1,99 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicate(t *testing.T) {
+	req := require.New(t)
+
+	originalObject := ast.NewObject("pkg", "Dashboard", ast.NewStruct(
+		ast.NewStructField("name", ast.String()),
+	))
+	argument := ast.Argument{Name: "title", Type: ast.String()}
+	originalBuilders := ast.Builders{
+		{
+			Schema: &ast.Schema{
+				Package: "pkg",
+				Objects: []ast.Object{originalObject},
+			},
+			For:     originalObject,
+			Package: "pkg",
+			Name:    "Dashboard",
+			Options: []ast.Option{
+				{
+					Name: "name",
+					Args: []ast.Argument{argument},
+					Assignments: []ast.Assignment{
+						ast.ArgumentAssignment(ast.PathFromStructField(originalObject.Type.Struct.Fields[0]), argument),
+					},
+				},
+			},
+		},
+	}
+
+	rule := Duplicate(ByName("pkg", "Dashboard"), "NewDashboard", nil)
+	updatedBuilders, err := rule(originalBuilders)
+	req.NoError(err)
+
+	req.Len(updatedBuilders, 2)
+	req.Equal(originalBuilders[0], updatedBuilders[0])
+
+	req.Equal("NewDashboard", updatedBuilders[1].Name)
+	req.Equal([]string{"Duplicate[pkg.Dashboard]"}, updatedBuilders[1].VeneerTrail)
+}
+
+func TestInitialize(t *testing.T) {
+	req := require.New(t)
+
+	originalObject := ast.NewObject("pkg", "Dashboard", ast.NewStruct(
+		ast.NewStructField("name", ast.String()),
+	))
+	argument := ast.Argument{Name: "title", Type: ast.String()}
+	originalBuilders := ast.Builders{
+		{
+			Schema: &ast.Schema{
+				Package: "pkg",
+				Objects: []ast.Object{originalObject},
+			},
+			For:     originalObject,
+			Package: "pkg",
+			Name:    "Dashboard",
+			Options: []ast.Option{
+				{
+					Name: "name",
+					Args: []ast.Argument{argument},
+					Assignments: []ast.Assignment{
+						ast.ArgumentAssignment(ast.PathFromStructField(originalObject.Type.Struct.Fields[0]), argument),
+					},
+				},
+			},
+		},
+	}
+
+	rule := Initialize(
+		ByName("pkg", "Dashboard"),
+		[]Initialization{
+			{
+				PropertyPath: "name",
+				Value:        "great name, isn't it?",
+			},
+		},
+	)
+	updatedBuilders, err := rule(originalBuilders)
+	req.NoError(err)
+
+	expectedAssignments := []ast.Assignment{
+		{
+			Path:   ast.Path{{Identifier: "name", Type: ast.String()}},
+			Value:  ast.AssignmentValue{Constant: "great name, isn't it?"},
+			Method: ast.DirectAssignment,
+		},
+	}
+
+	req.Len(updatedBuilders, 1)
+	req.Equal(expectedAssignments, updatedBuilders[0].Initializations)
+}

--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -18,6 +18,15 @@ func ByObjectName(pkg string, objectName string) Selector {
 	}
 }
 
+// ByName matches builders for the given name.
+// Note: the comparison on builder name is case-insensitive.
+func ByName(pkg string, builderName string) Selector {
+	return func(builder ast.Builder) bool {
+		return builder.For.SelfRef.ReferredPkg == pkg &&
+			strings.EqualFold(builder.Name, builderName)
+	}
+}
+
 // StructGeneratedFromDisjunction matches builders for structs that were
 // generated from a disjunction (see the Disjunction compiler pass).
 func StructGeneratedFromDisjunction() Selector {

--- a/internal/veneers/builder/selectors_test.go
+++ b/internal/veneers/builder/selectors_test.go
@@ -1,0 +1,34 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByObjectName(t *testing.T) {
+	req := require.New(t)
+
+	dashboardBuilder := ast.Builder{
+		Name: "EmptyDashboard",
+		For:  ast.NewObject("dashboard", "Dashboard", ast.NewStruct()),
+	}
+
+	req.True(ByObjectName("dashboard", "Dashboard")(dashboardBuilder))
+	req.True(ByObjectName("dashboard", "dashboard")(dashboardBuilder))
+	req.False(ByObjectName("dashboard", "EmptyDashboard")(dashboardBuilder))
+}
+
+func TestByBuilder(t *testing.T) {
+	req := require.New(t)
+
+	dashboardBuilder := ast.Builder{
+		Name: "EmptyDashboard",
+		For:  ast.NewObject("dashboard", "Dashboard", ast.NewStruct()),
+	}
+
+	req.True(ByName("dashboard", "EmptyDashboard")(dashboardBuilder))
+	req.True(ByName("dashboard", "emptydashboard")(dashboardBuilder))
+	req.False(ByName("dashboard", "Dashboard")(dashboardBuilder))
+}

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -1,6 +1,8 @@
 package option
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -10,8 +12,9 @@ type RewriteAction func(builder ast.Builder, option ast.Option) []ast.Option
 // RenameAction renames an option.
 func RenameAction(newName string) RewriteAction {
 	return func(_ ast.Builder, option ast.Option) []ast.Option {
+		oldName := option.Name
 		option.Name = newName
-		option.AddToVeneerTrail("Rename")
+		option.AddToVeneerTrail(fmt.Sprintf("Rename[%s → %s]", oldName, newName))
 
 		return []ast.Option{option}
 	}

--- a/internal/veneers/option/selectors.go
+++ b/internal/veneers/option/selectors.go
@@ -19,3 +19,13 @@ func ByName(pkg string, objectName string, optionNames ...string) Selector {
 			tools.StringInListEqualFold(option.Name, optionNames)
 	}
 }
+
+// ByBuilder matches options by their name and the name of the builder containing them..
+// Note: the comparison on builder and options names is case-insensitive.
+func ByBuilder(pkg string, builderName string, optionNames ...string) Selector {
+	return func(builder ast.Builder, option ast.Option) bool {
+		return builder.For.SelfRef.ReferredPkg == pkg &&
+			strings.EqualFold(builder.Name, builderName) &&
+			tools.StringInListEqualFold(option.Name, optionNames)
+	}
+}

--- a/internal/veneers/option/selectors_test.go
+++ b/internal/veneers/option/selectors_test.go
@@ -68,6 +68,29 @@ func TestByName_withSeveralOptions(t *testing.T) {
 	req.Equal("Editable", selectedForDashboardWithNotFound[0].Name)
 }
 
+func TestByBuilder(t *testing.T) {
+	req := require.New(t)
+
+	dashboardBuilder := ast.Builder{
+		Name: "EmptyDashboard",
+		For:  ast.NewObject("dashboard", "Dashboard", ast.NewStruct()),
+	}
+	options := []ast.Option{
+		{Name: "Editable"},
+		{Name: "Refresh"},
+		{Name: "TimePicker"},
+	}
+
+	singleSelector := ByBuilder("dashboard", "EmptyDashboard", "Refresh")
+	notFoundSelector := ByBuilder("dashboard", "Dashboard", "Refresh")
+
+	selectedForDashboard := filter(singleSelector, dashboardBuilder, options)
+	req.Len(selectedForDashboard, 1)
+	req.Equal("Refresh", selectedForDashboard[0].Name)
+
+	req.Len(filter(notFoundSelector, dashboardBuilder, options), 0)
+}
+
 func filter(selector Selector, builder ast.Builder, opts []ast.Option) []ast.Option {
 	var selected []ast.Option
 

--- a/internal/veneers/rewrite/rewrite_test.go
+++ b/internal/veneers/rewrite/rewrite_test.go
@@ -85,7 +85,7 @@ func testData() []rewriteTestCase {
 									ast.Argument{Name: "type", Type: ast.String()},
 								),
 							},
-							VeneerTrail: []string{"Rename"},
+							VeneerTrail: []string{"Rename[type → kind]"},
 						},
 					},
 				},

--- a/internal/veneers/yaml/builder.go
+++ b/internal/veneers/yaml/builder.go
@@ -116,7 +116,8 @@ func (rule Properties) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 type Duplicate struct {
 	BuilderSelector `yaml:",inline"`
-	As              string `yaml:"as"`
+	As              string   `yaml:"as"`
+	ExcludeOptions  []string `yaml:"exclude_options"`
 }
 
 func (rule Duplicate) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
@@ -128,6 +129,7 @@ func (rule Duplicate) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	return builder.Duplicate(
 		selector,
 		rule.As,
+		rule.ExcludeOptions,
 	), nil
 }
 

--- a/internal/veneers/yaml/builder.go
+++ b/internal/veneers/yaml/builder.go
@@ -17,6 +17,7 @@ type BuilderRule struct {
 	MergeInto             *MergeInto             `yaml:"merge_into"`
 	ComposeDashboardPanel *ComposeDashboardPanel `yaml:"compose_dashboard_panel"`
 	Properties            *Properties            `yaml:"properties"`
+	Duplicate             *Duplicate             `yaml:"duplicate"`
 }
 
 func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
@@ -43,6 +44,10 @@ func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 	if rule.Properties != nil {
 		return rule.Properties.AsRewriteRule(pkg)
+	}
+
+	if rule.Duplicate != nil {
+		return rule.Duplicate.AsRewriteRule(pkg)
 	}
 
 	return nil, fmt.Errorf("empty rule")
@@ -106,6 +111,23 @@ func (rule Properties) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	return builder.Properties(
 		selector,
 		rule.Set,
+	), nil
+}
+
+type Duplicate struct {
+	BuilderSelector `yaml:",inline"`
+	As              string `yaml:"as"`
+}
+
+func (rule Duplicate) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.Duplicate(
+		selector,
+		rule.As,
 	), nil
 }
 

--- a/internal/veneers/yaml/option.go
+++ b/internal/veneers/yaml/option.go
@@ -164,6 +164,11 @@ type OptionSelector struct {
 	// objectName.optionName
 	ByName *string `yaml:"by_name"`
 
+	// builderName.optionName
+	// TODO: ByName should be called ByObject
+	// and ByBuilder should be called ByName
+	ByBuilder *string `yaml:"by_builder"`
+
 	ByNames *ByNamesSelector `yaml:"by_names"`
 }
 
@@ -175,6 +180,15 @@ func (selector OptionSelector) AsSelector(pkg string) (option.Selector, error) {
 		}
 
 		return option.ByName(pkg, objectName, optionName), nil
+	}
+
+	if selector.ByBuilder != nil {
+		builderName, optionName, found := strings.Cut(*selector.ByBuilder, ".")
+		if !found {
+			return nil, fmt.Errorf("option name '%s' is incorrect: no builder name found", *selector.ByBuilder)
+		}
+
+		return option.ByBuilder(pkg, builderName, optionName), nil
 	}
 
 	if selector.ByNames != nil {

--- a/internal/veneers/yaml/veneers.go
+++ b/internal/veneers/yaml/veneers.go
@@ -65,13 +65,10 @@ func (loader *Loader) Load(reader io.Reader) (rewrite.LanguageRules, error) {
 
 	veneers := &Veneers{}
 
-	// read and parse the input file
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return rewrite.LanguageRules{}, err
-	}
+	decoder := yaml.NewDecoder(reader)
+	decoder.KnownFields(true)
 
-	if err := yaml.Unmarshal(data, &veneers); err != nil {
+	if err := decoder.Decode(&veneers); err != nil {
 		return rewrite.LanguageRules{}, err
 	}
 

--- a/testdata/jennies/builders/composable_slot/test.txtar
+++ b/testdata/jennies/builders/composable_slot/test.txtar
@@ -264,7 +264,7 @@
 }
 
 -- out/jennies/TypescriptBuilder --
-== src/composable_slot/dashboard_builder_gen.ts
+== src/composable_slot/lokibuilder_builder_gen.ts
 import * as cog from '../cog';
 import * as composable_slot from '../composable_slot';
 
@@ -292,7 +292,7 @@ export class LokiBuilderBuilder implements cog.Builder<composable_slot.Dashboard
     }
 }
 -- out/jennies/GoBuilder --
-== composable_slot/dashboard_builder_gen.go
+== composable_slot/lokibuilder_builder_gen.go
 package composable_slot
 
 import (

--- a/testdata/jennies/builders/constructor_initializations/test.txtar
+++ b/testdata/jennies/builders/constructor_initializations/test.txtar
@@ -35,6 +35,15 @@
                     }
                   },
                   "Required": true
+                },
+                {
+                  "Name": "cursor",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {"ReferredPkg": "constructor_initializations", "ReferredType": "CursorMode"}
+                  },
+                  "Required": true
                 }
               ]
             }
@@ -42,6 +51,44 @@
           "SelfRef": {
             "ReferredPkg": "constructor_initializations",
             "ReferredType": "SomePanel"
+          }
+        },
+        {
+          "Name": "CursorMode",
+          "Type": {
+            "Kind": "enum",
+            "Enum": {
+              "Values": [
+                {
+                  "Name": "Off",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Scalar": {"ScalarKind": "string"}
+                  },
+                  "Value": "off"
+                },
+                {
+                  "Name": "Tooltip",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Scalar": {"ScalarKind": "string"}
+                  },
+                  "Value": "tooltip"
+                },
+                {
+                  "Name": "Crosshair",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Scalar": {"ScalarKind": "string"}
+                  },
+                  "Value": "crosshair"
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "constructor_initializations",
+            "ReferredType": "CursorMode"
           }
         }
       ]
@@ -80,6 +127,15 @@
                       "Scalar": {
                         "ScalarKind": "string"
                       }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "cursor",
+                    "Type": {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {"ReferredPkg": "constructor_initializations", "ReferredType": "CursorMode"}
                     },
                     "Required": true
                   }
@@ -122,6 +178,15 @@
                   }
                 },
                 "Required": true
+              },
+              {
+                "Name": "cursor",
+                "Type": {
+                  "Kind": "ref",
+                  "Nullable": false,
+                  "Ref": {"ReferredPkg": "constructor_initializations", "ReferredType": "CursorMode"}
+                },
+                "Required": true
               }
             ]
           }
@@ -151,6 +216,20 @@
           "Value": {
             "Constant": "panel_type"
           },
+          "Method": "direct"
+        },
+        {
+          "Path": [
+            {
+              "Identifier": "cursor",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {"ReferredPkg": "constructor_initializations", "ReferredType": "CursorMode"}
+              }
+            }
+          ],
+          "Value": {"Constant": "tooltip"},
           "Method": "direct"
         }
       ],
@@ -216,6 +295,7 @@ export class SomePanelBuilder implements cog.Builder<constructor_initializations
     constructor() {
         this.internal = constructor_initializations.defaultSomePanel();
         this.internal.type = "panel_type";
+        this.internal.cursor = constructor_initializations.CursorMode.Tooltip;
     }
 
     build(): constructor_initializations.SomePanel {
@@ -251,6 +331,7 @@ func NewSomePanelBuilder() *SomePanelBuilder {
 
 	builder.applyDefaults()
     builder.internal.Type = "panel_type"
+    builder.internal.Cursor = "tooltip"
 
 	return builder
 }

--- a/testdata/jennies/builders/dataquery_variant_builder/test.txtar
+++ b/testdata/jennies/builders/dataquery_variant_builder/test.txtar
@@ -158,7 +158,7 @@
 }
 
 -- out/jennies/TypescriptBuilder --
-== src/dataquery_variant_builder/loki_builder_gen.ts
+== src/dataquery_variant_builder/lokibuilder_builder_gen.ts
 import * as cog from '../cog';
 import * as dataquery_variant_builder from '../dataquery_variant_builder';
 
@@ -179,7 +179,7 @@ export class LokiBuilderBuilder implements cog.Builder<cog.Dataquery> {
     }
 }
 -- out/jennies/GoBuilder --
-== dataquery_variant_builder/loki_builder_gen.go
+== dataquery_variant_builder/lokibuilder_builder_gen.go
 package dataquery_variant_builder
 
 import (

--- a/testdata/jennies/builders/foreign_builder/test.txtar
+++ b/testdata/jennies/builders/foreign_builder/test.txtar
@@ -150,7 +150,7 @@
 }
 
 -- out/jennies/TypescriptBuilder --
-== src/builder_pkg/somestruct_builder_gen.ts
+== src/builder_pkg/somenicebuilder_builder_gen.ts
 import * as cog from '../cog';
 import * as some_pkg from '../some_pkg';
 
@@ -171,7 +171,7 @@ export class SomeNiceBuilderBuilder implements cog.Builder<some_pkg.SomeStruct> 
     }
 }
 -- out/jennies/GoBuilder --
-== builder_pkg/somestruct_builder_gen.go
+== builder_pkg/somenicebuilder_builder_gen.go
 package builder_pkg
 
 import (

--- a/testdata/jennies/rawtypes/enums.txtar
+++ b/testdata/jennies/rawtypes/enums.txtar
@@ -28,6 +28,10 @@
                         }
                     ]
                 }
+            },
+            "SelfRef": {
+                "ReferredPkg": "enums",
+                "ReferredType": "Operator"
             }
         },
 
@@ -55,6 +59,10 @@
                         }
                     ]
                 }
+            },
+            "SelfRef": {
+                "ReferredPkg": "enums",
+                "ReferredType": "TableSortOrder"
             }
         },
         {
@@ -81,6 +89,10 @@
                         }
                     ]
                 }
+            },
+            "SelfRef": {
+                "ReferredPkg": "enums",
+                "ReferredType": "LogsSortOrder"
             }
         },
 
@@ -121,6 +133,10 @@
                         }
                     ]
                 }
+            },
+            "SelfRef": {
+                "ReferredPkg": "enums",
+                "ReferredType": "DashboardCursorSync"
             }
         }
     ]


### PR DESCRIPTION
This PR configures a few veneers to improve the API around dashboard variables.

These variables are described by a single model in the schemas, even though different variable types actually use a subset of the fields in that model.

I use veneers to generate a builder per variable type exposed by the schema, and I restrict the options generated for each builder to what Grafana allows us to configure.