### PR TITLE
Add a compiler pass to make <10.2.x versions of the googlecloudmonitoring schemas parseable

### DIFF
--- a/internal/ast/compiler/compiler.go
+++ b/internal/ast/compiler/compiler.go
@@ -41,6 +41,7 @@ func CommonPasses() Passes {
 		&DashboardTargetsRewrite{},
 		&DashboardTimePicker{},
 		&Cloudwatch{},
+		&GoogleCloudMonitoring{},
 		&LibraryPanels{},
 		&TestData{},
 	}

--- a/internal/ast/compiler/googlecloudmonitoring.go
+++ b/internal/ast/compiler/googlecloudmonitoring.go
@@ -1,0 +1,117 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*GoogleCloudMonitoring)(nil)
+
+// GoogleCloudMonitoring rewrites a part of the googlecloudmonitoring schema.
+//
+// Older schemas (pre 10.2.x) define `CloudMonitoringQuery.timeSeriesList`
+// as a disjunction that cog can't handle: `timeSeriesList?: #TimeSeriesList | #AnnotationQuery`,
+// where `AnnotationQuery` is a type that extends `TimeSeriesList` to add two
+// fields.
+//
+// This compiler pass checks for the presence of that disjunction, and rewrites
+// it as a reference to `TimeSeriesList`. It also adds the two missing fields
+// to this type if they aren't already defined.
+type GoogleCloudMonitoring struct {
+}
+
+func (pass *GoogleCloudMonitoring) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0, len(schemas))
+
+	for _, schema := range schemas {
+		if schema.Package != "googlecloudmonitoring" {
+			newSchemas = append(newSchemas, schema)
+			continue
+		}
+
+		newSchema, err := pass.processSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+
+		newSchemas = append(newSchemas, newSchema)
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *GoogleCloudMonitoring) processSchema(schema *ast.Schema) (*ast.Schema, error) {
+	newSchema := schema.DeepCopy()
+	newSchema.Objects = nil
+
+	for _, object := range schema.Objects {
+		if object.Name == "CloudMonitoringQuery" {
+			newSchema.Objects = append(newSchema.Objects, pass.processCloudMonitoringQuery(object))
+			continue
+		}
+		if object.Name == "TimeSeriesList" {
+			newSchema.Objects = append(newSchema.Objects, pass.processTimeSeriesList(object))
+			continue
+		}
+
+		newSchema.Objects = append(newSchema.Objects, object)
+	}
+
+	return &newSchema, nil
+}
+
+func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object) ast.Object {
+	if object.Type.Kind != ast.KindStruct {
+		return object
+	}
+
+	structDef := object.Type.AsStruct()
+	fields := make([]ast.StructField, 0, len(structDef.Fields)-1)
+
+	for _, field := range structDef.Fields {
+		if field.Name != "timeSeriesList" {
+			fields = append(fields, field)
+			continue
+		}
+
+		if field.Type.Kind != ast.KindDisjunction {
+			fields = append(fields, field)
+			continue
+		}
+
+		// from `timeSeriesList?: #TimeSeriesList | #AnnotationQuery`
+		// to `timeSeriesList?: #TimeSeriesList`
+		newField := field.DeepCopy()
+		newField.Type = newField.Type.Disjunction.Branches[0]
+
+		fields = append(fields, newField)
+	}
+
+	object.Type.Struct.Fields = fields
+
+	return object
+}
+
+func (pass *GoogleCloudMonitoring) processTimeSeriesList(object ast.Object) ast.Object {
+	if object.Type.Kind != ast.KindStruct {
+		return object
+	}
+
+	structDef := object.Type.AsStruct()
+
+	if _, found := structDef.FieldByName("title"); !found {
+		field := ast.NewStructField("title", ast.String(ast.Nullable()))
+		field.Comments = []string{"Annotation title."}
+
+		structDef.Fields = append(structDef.Fields, field)
+	}
+	if _, found := structDef.FieldByName("text"); !found {
+		field := ast.NewStructField("text", ast.String(ast.Nullable()))
+		field.Comments = []string{"Annotation text."}
+
+		structDef.Fields = append(structDef.Fields, field)
+	}
+
+	object.Type.Struct = &structDef
+
+	return object
+}


### PR DESCRIPTION
`googlecloudmonitoring` schemas before 10.2.x define a disjunction that cog can't handle (it doesn't have a clear discriminator that can be used).

To be able to generate code for versions <10.2.x, I introduced a compiler pass to alter the schema in a way that mimics the changes that were introduced in 10.2.x.

See the comment on the compiler pass for more details on the changes made to google cloud monitoring schemas.

Note: this PR should allow us to generate and release types + builders for Grafana v10.1.x in addition to the already published code for v10.2.x