### PR TITLE
Bootstrap support for Python

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,7 @@ linters:
     - gomnd
     - tagliatelle
     - nlreturn
+    - gocyclo
     # deprecated
     - deadcode
     - scopelint

--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -1,0 +1,122 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
+)
+
+var _ Pass = (*AnonymousStructsToNamed)(nil)
+
+// AnonymousStructsToNamed turns "anonymous structs" into a named object.
+//
+// Example:
+//
+//	```
+//	Panel struct {
+//		Options struct {
+//			Title string
+//		}
+//	}
+//	```
+//
+// Will become:
+//
+//	```
+//	Panel struct {
+//		Options PanelOptions
+//	}
+//
+//	PanelOptions struct {
+//		Title string
+//	}
+//	```
+type AnonymousStructsToNamed struct {
+	newObjects []ast.Object
+}
+
+func (pass *AnonymousStructsToNamed) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0, len(schemas))
+	for _, schema := range schemas {
+		newSchemas = append(newSchemas, pass.processSchema(schema))
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *AnonymousStructsToNamed) processSchema(schema *ast.Schema) *ast.Schema {
+	pass.newObjects = make([]ast.Object, 0, len(schema.Objects))
+	for _, object := range schema.Objects {
+		newObj := pass.processObject(object)
+		pass.newObjects = append(pass.newObjects, newObj)
+	}
+
+	schema.Objects = pass.newObjects
+
+	return schema
+}
+
+func (pass *AnonymousStructsToNamed) processObject(object ast.Object) ast.Object {
+	newObject := object
+	pkg := object.SelfRef.ReferredPkg
+	parentName := tools.UpperCamelCase(pkg) + tools.UpperCamelCase(object.Name)
+
+	if object.Type.IsAnyOf(ast.KindArray, ast.KindMap, ast.KindDisjunction) {
+		newObject.Type = pass.processType(pkg, parentName, object.Type)
+	}
+
+	if object.Type.IsStruct() {
+		for i, field := range object.Type.AsStruct().Fields {
+			name := parentName + tools.UpperCamelCase(field.Name)
+			object.Type.Struct.Fields[i].Type = pass.processType(pkg, name, field.Type)
+		}
+	}
+
+	return newObject
+}
+
+func (pass *AnonymousStructsToNamed) processType(pkg string, parentName string, def ast.Type) ast.Type {
+	if def.Kind == ast.KindArray {
+		return pass.processArray(pkg, parentName, def)
+	}
+
+	if def.Kind == ast.KindMap {
+		return pass.processMap(pkg, parentName, def)
+	}
+
+	if def.Kind == ast.KindDisjunction {
+		return pass.processDisjunction(pkg, parentName, def)
+	}
+
+	if def.Kind == ast.KindStruct {
+		return pass.processStruct(pkg, parentName, def)
+	}
+
+	return def
+}
+
+func (pass *AnonymousStructsToNamed) processArray(pkg string, parentName string, def ast.Type) ast.Type {
+	def.Array.ValueType = pass.processType(pkg, parentName, def.Array.ValueType)
+
+	return def
+}
+
+func (pass *AnonymousStructsToNamed) processMap(pkg string, parentName string, def ast.Type) ast.Type {
+	def.Map.IndexType = pass.processType(pkg, parentName, def.Map.IndexType)
+	def.Map.ValueType = pass.processType(pkg, parentName, def.Map.ValueType)
+
+	return def
+}
+
+func (pass *AnonymousStructsToNamed) processDisjunction(pkg string, parentName string, def ast.Type) ast.Type {
+	for i, branch := range def.Disjunction.Branches {
+		def.Disjunction.Branches[i] = pass.processType(pkg, parentName, branch)
+	}
+
+	return def
+}
+
+func (pass *AnonymousStructsToNamed) processStruct(pkg string, parentName string, def ast.Type) ast.Type {
+	pass.newObjects = append(pass.newObjects, ast.NewObject(pkg, parentName, def))
+
+	return ast.NewRef(pkg, parentName)
+}

--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -118,5 +118,8 @@ func (pass *AnonymousStructsToNamed) processDisjunction(pkg string, parentName s
 func (pass *AnonymousStructsToNamed) processStruct(pkg string, parentName string, def ast.Type) ast.Type {
 	pass.newObjects = append(pass.newObjects, ast.NewObject(pkg, parentName, def))
 
-	return ast.NewRef(pkg, parentName)
+	ref := ast.NewRef(pkg, parentName)
+	ref.Nullable = def.Nullable
+
+	return ref
 }

--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -16,9 +16,6 @@ var ErrCanNotInferDiscriminator = errors.New("can not infer discriminator mappin
 // DisjunctionToType transforms disjunction into a struct, mapping disjunction branches to
 // an optional and nullable field in that struct.
 //
-// This compiler pass also simplifies disjunction of two branches, where one is `null`. For those,
-// it transforms `type | null` into `*type` (optional, nullable reference to `type`).
-//
 // Example:
 //
 //		```
@@ -38,7 +35,7 @@ var ErrCanNotInferDiscriminator = errors.New("can not infer discriminator mappin
 //
 // Will become:
 //
-//	```
+//		```
 //		SomeType: {
 //			type: "some-type"
 //	 	}
@@ -59,7 +56,7 @@ var ErrCanNotInferDiscriminator = errors.New("can not infer discriminator mappin
 //		OtherStruct: {
 //			bar: SomeTypeOrSomeOtherType
 //		}
-//	```
+//		```
 //
 // Note: for disjunctions of `Ref`s, the pass attempts to infer a discriminator field and mapping. See https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
 type DisjunctionToType struct {
@@ -196,14 +193,6 @@ func (pass *DisjunctionToType) processStruct(schema *ast.Schema, def ast.Type) (
 
 func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Type) (ast.Type, error) {
 	disjunction := def.AsDisjunction()
-
-	// Ex: type | null
-	if len(disjunction.Branches) == 2 && disjunction.Branches.HasNullType() {
-		finalType := disjunction.Branches.NonNullTypes()[0]
-		finalType.Nullable = true
-
-		return finalType, nil
-	}
 
 	// Ex: "some concrete value" | "some other value" | string
 	if pass.hasOnlySingleTypeScalars(schema, disjunction) {

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -35,58 +35,6 @@ func TestDisjunctionToType_WithNonDisjunctionObjects_HasNoImpact(t *testing.T) {
 	runPassOnObjects(t, &DisjunctionToType{}, objects, objects)
 }
 
-func TestDisjunctionToType_WithDisjunctionOfTypeAndNull_AsAnObject(t *testing.T) {
-	// Prepare test input
-	objects := []ast.Object{
-		ast.NewObject("test", "ScalarWithNull", ast.NewDisjunction([]ast.Type{
-			ast.String(),
-			ast.Null(),
-		})),
-		ast.NewObject("test", "RefWithNull", ast.NewDisjunction([]ast.Type{
-			ast.NewRef("test", "SomeType"),
-			ast.Null(),
-		})),
-	}
-
-	expectedObjects := []ast.Object{
-		ast.NewObject("test", "ScalarWithNull", ast.String(ast.Nullable())),
-		ast.NewObject("test", "RefWithNull", ast.NewRef("test", "SomeType", ast.Nullable())),
-	}
-
-	// Call the compiler pass
-	runPassOnObjects(t, &DisjunctionToType{}, objects, expectedObjects)
-}
-
-func TestDisjunctionToType_WithDisjunctionOfTypeAndNull_AsAStructField(t *testing.T) {
-	// Prepare test input
-	objects := []ast.Object{
-		ast.NewObject("test", "StructWithScalarWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.NewDisjunction([]ast.Type{
-				ast.String(),
-				ast.Null(),
-			})),
-		)),
-		ast.NewObject("test", "StructWithRefWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.NewDisjunction([]ast.Type{
-				ast.NewRef("test", "SomeType"),
-				ast.Null(),
-			})),
-		)),
-	}
-
-	expectedObjects := []ast.Object{
-		ast.NewObject("test", "StructWithScalarWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.String(ast.Nullable())),
-		)),
-		ast.NewObject("test", "StructWithRefWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.NewRef("test", "SomeType", ast.Nullable())),
-		)),
-	}
-
-	// Call the compiler pass
-	runPassOnObjects(t, &DisjunctionToType{}, objects, expectedObjects)
-}
-
 func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnObject(t *testing.T) {
 	// Prepare test input
 	objects := []ast.Object{

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -1,0 +1,110 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*DisjunctionWithNullToOptional)(nil)
+
+// DisjunctionWithNullToOptional simplifies disjunctions with two branches, where one is `null`. For those,
+// it transforms `type | null` into `*type` (optional, nullable reference to `type`).
+//
+// Example:
+//
+//	```
+//	MaybeString: string | null
+//	```
+//
+// Will become:
+//
+//	```
+//	MaybeString?: string
+//	```
+type DisjunctionWithNullToOptional struct {
+	newObjects map[string]ast.Object
+}
+
+func (pass *DisjunctionWithNullToOptional) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0, len(schemas))
+
+	for _, schema := range schemas {
+		newSchema, err := pass.processSchema(schema)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] %w", schema.Package, err)
+		}
+
+		newSchemas = append(newSchemas, newSchema)
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *DisjunctionWithNullToOptional) processSchema(schema *ast.Schema) (*ast.Schema, error) {
+	for i, object := range schema.Objects {
+		schema.Objects[i] = pass.processObject(object)
+	}
+
+	return schema, nil
+}
+
+func (pass *DisjunctionWithNullToOptional) processObject(object ast.Object) ast.Object {
+	object.Type = pass.processType(object.Type)
+
+	return object
+}
+
+func (pass *DisjunctionWithNullToOptional) processType(def ast.Type) ast.Type {
+	if def.Kind == ast.KindArray {
+		return pass.processArray(def)
+	}
+
+	if def.Kind == ast.KindMap {
+		return pass.processMap(def)
+	}
+
+	if def.Kind == ast.KindStruct {
+		return pass.processStruct(def)
+	}
+
+	if def.Kind == ast.KindDisjunction {
+		return pass.processDisjunction(def)
+	}
+
+	return def
+}
+
+func (pass *DisjunctionWithNullToOptional) processArray(def ast.Type) ast.Type {
+	def.Array.ValueType = pass.processType(def.AsArray().ValueType)
+
+	return def
+}
+
+func (pass *DisjunctionWithNullToOptional) processMap(def ast.Type) ast.Type {
+	def.Map.ValueType = pass.processType(def.AsMap().ValueType)
+
+	return def
+}
+
+func (pass *DisjunctionWithNullToOptional) processStruct(def ast.Type) ast.Type {
+	for i, field := range def.AsStruct().Fields {
+		def.Struct.Fields[i].Type = pass.processType(field.Type)
+	}
+
+	return def
+}
+
+func (pass *DisjunctionWithNullToOptional) processDisjunction(def ast.Type) ast.Type {
+	disjunction := def.AsDisjunction()
+
+	// type | null
+	if len(disjunction.Branches) == 2 && disjunction.Branches.HasNullType() {
+		finalType := disjunction.Branches.NonNullTypes()[0]
+		finalType.Nullable = true
+
+		return finalType
+	}
+
+	return def
+}

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -23,7 +23,6 @@ var _ Pass = (*DisjunctionWithNullToOptional)(nil)
 //	MaybeString?: string
 //	```
 type DisjunctionWithNullToOptional struct {
-	newObjects map[string]ast.Object
 }
 
 func (pass *DisjunctionWithNullToOptional) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {

--- a/internal/ast/compiler/disjunctions_with_null_to_optional_test.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional_test.go
@@ -1,0 +1,59 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+func TestDisjunctionWithNullToOptional_WithDisjunctionOfTypeAndNull_AsAnObject(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "ScalarWithNull", ast.NewDisjunction([]ast.Type{
+			ast.String(),
+			ast.Null(),
+		})),
+		ast.NewObject("test", "RefWithNull", ast.NewDisjunction([]ast.Type{
+			ast.NewRef("test", "SomeType"),
+			ast.Null(),
+		})),
+	}
+
+	expectedObjects := []ast.Object{
+		ast.NewObject("test", "ScalarWithNull", ast.String(ast.Nullable())),
+		ast.NewObject("test", "RefWithNull", ast.NewRef("test", "SomeType", ast.Nullable())),
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionWithNullToOptional{}, objects, expectedObjects)
+}
+
+func TestDisjunctionWithNullToOptional_WithDisjunctionOfTypeAndNull_AsAStructField(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "StructWithScalarWithNull", ast.NewStruct(
+			ast.NewStructField("Field", ast.NewDisjunction([]ast.Type{
+				ast.String(),
+				ast.Null(),
+			})),
+		)),
+		ast.NewObject("test", "StructWithRefWithNull", ast.NewStruct(
+			ast.NewStructField("Field", ast.NewDisjunction([]ast.Type{
+				ast.NewRef("test", "SomeType"),
+				ast.Null(),
+			})),
+		)),
+	}
+
+	expectedObjects := []ast.Object{
+		ast.NewObject("test", "StructWithScalarWithNull", ast.NewStruct(
+			ast.NewStructField("Field", ast.String(ast.Nullable())),
+		)),
+		ast.NewObject("test", "StructWithRefWithNull", ast.NewStruct(
+			ast.NewStructField("Field", ast.NewRef("test", "SomeType", ast.Nullable())),
+		)),
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionWithNullToOptional{}, objects, expectedObjects)
+}

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -99,6 +99,16 @@ type Type struct {
 	Hints JenniesHints `json:",omitempty"`
 }
 
+func (t Type) IsAnyOf(kinds ...Kind) bool {
+	for _, kind := range kinds {
+		if t.Kind == kind {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (t Type) ImplementsVariant() bool {
 	return t.HasHint(HintImplementsVariant)
 }
@@ -125,8 +135,20 @@ func (t Type) IsStructOrRef() bool {
 	return t.Kind == KindStruct || t.Kind == KindRef
 }
 
+func (t Type) IsStruct() bool {
+	return t.Kind == KindStruct
+}
+
+func (t Type) IsScalar() bool {
+	return t.Kind == KindScalar
+}
+
 func (t Type) IsArray() bool {
 	return t.Kind == KindArray
+}
+
+func (t Type) IsMap() bool {
+	return t.Kind == KindMap
 }
 
 func (t Type) IsEnum() bool {

--- a/internal/jennies/all.go
+++ b/internal/jennies/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/golang"
+	"github.com/grafana/cog/internal/jennies/python"
 	"github.com/grafana/cog/internal/jennies/typescript"
 	"github.com/spf13/cobra"
 )
@@ -48,6 +49,7 @@ func (languageJennies LanguageJennies) AsLanguageRefs() []string {
 func All() LanguageJennies {
 	return LanguageJennies{
 		golang.LanguageRef:     golang.New(),
+		python.LanguageRef:     python.New(),
 		typescript.LanguageRef: typescript.New(),
 	}
 }

--- a/internal/jennies/common/importmap.go
+++ b/internal/jennies/common/importmap.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/cog/internal/orderedmap"
 )
 
-func noopSanitizer(s string) string { return s }
+func NoopImportSanitizer(s string) string { return s }
 
 type ImportMapConfig[M any] struct {
 	Formatter           func(importMap M) string
@@ -38,8 +38,8 @@ func NewDirectImportMap(opts ...ImportMapOption[DirectImportMap]) *DirectImportM
 		Formatter: func(importMap DirectImportMap) string {
 			return fmt.Sprintf("%#v\n", importMap.Imports)
 		},
-		AliasSanitizer:      noopSanitizer,
-		ImportPathSanitizer: noopSanitizer,
+		AliasSanitizer:      NoopImportSanitizer,
+		ImportPathSanitizer: NoopImportSanitizer,
 	}
 
 	for _, opt := range opts {

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -79,6 +79,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.PrefixEnumValues{},
 		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.FlattenDisjunctions{},
+		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.DisjunctionToType{},
 	}
 }

--- a/internal/jennies/python/imports.go
+++ b/internal/jennies/python/imports.go
@@ -1,0 +1,99 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/orderedmap"
+)
+
+func NewImportMap() *ModuleImportMap {
+	return NewModuleImportMap(
+		common.WithAliasSanitizer[ModuleImportMap](func(alias string) string {
+			return strings.ReplaceAll(alias, "/", "")
+		}),
+		common.WithFormatter(func(importMap ModuleImportMap) string {
+			if importMap.Imports.Len() == 0 {
+				return ""
+			}
+
+			statements := make([]string, 0, importMap.Imports.Len())
+			importMap.Imports.Iterate(func(alias string, stmt ImportStmt) {
+				var importStmt string
+				if stmt.Module == "" {
+					if stmt.Package == alias {
+						importStmt = fmt.Sprintf(`import %s`, stmt.Package)
+					} else {
+						importStmt = fmt.Sprintf(`import %s as %s`, stmt.Package, alias)
+					}
+				} else {
+					if stmt.Module == alias {
+						importStmt = fmt.Sprintf(`from %s import %s`, stmt.Package, stmt.Module)
+					} else {
+						importStmt = fmt.Sprintf(`from %s import %s as %s`, stmt.Package, stmt.Module, alias)
+					}
+				}
+
+				statements = append(statements, importStmt)
+			})
+
+			return strings.Join(statements, "\n")
+		}),
+	)
+}
+
+type ImportStmt struct {
+	Package string
+	Module  string
+}
+
+type ModuleImportMap struct {
+	// alias → ImportStmt
+	Imports *orderedmap.Map[string, ImportStmt]
+	config  common.ImportMapConfig[ModuleImportMap]
+}
+
+func NewModuleImportMap(opts ...common.ImportMapOption[ModuleImportMap]) *ModuleImportMap {
+	config := common.ImportMapConfig[ModuleImportMap]{
+		Formatter: func(importMap ModuleImportMap) string {
+			return fmt.Sprintf("%#v\n", importMap.Imports)
+		},
+		AliasSanitizer:      common.NoopImportSanitizer,
+		ImportPathSanitizer: common.NoopImportSanitizer,
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	return &ModuleImportMap{
+		Imports: orderedmap.New[string, ImportStmt](),
+		config:  config,
+	}
+}
+
+func (im ModuleImportMap) AddPackage(alias string, pkg string) string {
+	sanitizedAlias := im.config.AliasSanitizer(alias)
+
+	im.Imports.Set(sanitizedAlias, ImportStmt{
+		Package: pkg,
+	})
+
+	return sanitizedAlias
+}
+
+func (im ModuleImportMap) AddModule(alias string, pkg string, module string) string {
+	sanitizedAlias := im.config.AliasSanitizer(alias)
+
+	im.Imports.Set(sanitizedAlias, ImportStmt{
+		Package: pkg,
+		Module:  module,
+	})
+
+	return sanitizedAlias
+}
+
+func (im ModuleImportMap) String() string {
+	return im.config.Formatter(im)
+}

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -36,6 +36,8 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 
 func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
+		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.AnonymousStructsToNamed{},
 	}
 }

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -24,6 +24,9 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
+		ModuleInit{},
+		Runtime{},
+
 		common.If[common.Context](globalConfig.Types, RawTypes{}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
@@ -32,5 +35,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 }
 
 func (language *Language) CompilerPasses() compiler.Passes {
-	return compiler.Passes{}
+	return compiler.Passes{
+		&compiler.AnonymousStructsToNamed{},
+	}
 }

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -1,0 +1,36 @@
+package python
+
+import (
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/spf13/cobra"
+)
+
+const LanguageRef = "python"
+
+type Language struct {
+}
+
+func New() *Language {
+	return &Language{}
+}
+
+func (language *Language) RegisterCliFlags(_ *cobra.Command) {
+}
+
+func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+		return LanguageRef
+	})
+	jenny.AppendOneToMany(
+		common.If[common.Context](globalConfig.Types, RawTypes{}),
+	)
+	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+
+	return jenny
+}
+
+func (language *Language) CompilerPasses() compiler.Passes {
+	return compiler.Passes{}
+}

--- a/internal/jennies/python/module_init.go
+++ b/internal/jennies/python/module_init.go
@@ -1,0 +1,30 @@
+package python
+
+import (
+	"fmt"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/jennies/common"
+)
+
+type ModuleInit struct {
+}
+
+func (jenny ModuleInit) JennyName() string {
+	return "PythonModuleInit"
+}
+
+func (jenny ModuleInit) Generate(context common.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0, len(context.Schemas)+2)
+
+	files = append(files, *codejen.NewFile("__init__.py", jenny.module("root"), jenny))
+	files = append(files, *codejen.NewFile("models/__init__.py", jenny.module("models"), jenny))
+	files = append(files, *codejen.NewFile("runtime/__init__.py", jenny.module("runtime"), jenny))
+
+	return files, nil
+}
+
+func (jenny ModuleInit) module(name string) []byte {
+	return []byte(fmt.Sprintf(`"""%s module"""
+`, name))
+}

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -1,0 +1,42 @@
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+)
+
+type RawTypes struct {
+}
+
+func (jenny RawTypes) JennyName() string {
+	return "PythonRawTypes"
+}
+
+func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0, len(context.Schemas))
+
+	for _, schema := range context.Schemas {
+		output, err := jenny.generateSchema(context, schema)
+		if err != nil {
+			return nil, err
+		}
+
+		filename := filepath.Join("models", schema.Package+".py")
+
+		files = append(files, *codejen.NewFile(filename, output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny RawTypes) generateSchema(_ common.Context, _ *ast.Schema) ([]byte, error) {
+	var buffer strings.Builder
+
+	buffer.WriteString("# TODO")
+
+	return []byte(buffer.String()), nil
+}

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -11,7 +11,7 @@ import (
 
 type RawTypes struct {
 	typeFormatter *typeFormatter
-	importModule  func(alias string, pkg string, module string) string
+	importModule  moduleImporter
 }
 
 func (jenny RawTypes) JennyName() string {
@@ -60,7 +60,7 @@ func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
 			return nil, err
 		}
 
-		buffer.Write([]byte(objectOutput))
+		buffer.WriteString(objectOutput)
 
 		// we want two blank lines between objects, except at the end of the file
 		if i != len(schema.Objects)-1 {

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -13,6 +13,9 @@ func TestRawTypes_Generate(t *testing.T) {
 	test := txtartest.TxTarTest{
 		Root: "../../../testdata/jennies/rawtypes",
 		Name: "jennies/PythonRawTypes",
+		Skip: map[string]string{
+			"jennies/rawtypes/intersections": "Intersections are not implemented",
+		},
 	}
 
 	jenny := RawTypes{}

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -1,0 +1,37 @@
+package python
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/txtartest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawTypes_Generate(t *testing.T) {
+	test := txtartest.TxTarTest{
+		Root: "../../../testdata/jennies/rawtypes",
+		Name: "jennies/PythonRawTypes",
+	}
+
+	jenny := RawTypes{}
+	compilerPasses := New().CompilerPasses()
+
+	test.Run(t, func(tc *txtartest.Test) {
+		req := require.New(tc)
+
+		// We run the compiler passes defined fo Python since without them, we
+		// might not be able to translate some of the IR's semantics into Python.
+		// Example: anonymous objects.
+		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		req.NoError(err)
+
+		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
+
+		files, err := jenny.Generate(common.Context{Schemas: processedAsts})
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/python/runtime.go
+++ b/internal/jennies/python/runtime.go
@@ -1,0 +1,24 @@
+package python
+
+import (
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/jennies/common"
+)
+
+type Runtime struct {
+}
+
+func (jenny Runtime) JennyName() string {
+	return "PythonRuntime"
+}
+
+func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
+	models, err := renderTemplate("runtime/variant_models.tmpl", map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+
+	return codejen.Files{
+		*codejen.NewFile("cog/variants.py", []byte(models), jenny),
+	}, nil
+}

--- a/internal/jennies/python/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/python/templates/runtime/variant_models.tmpl
@@ -1,0 +1,5 @@
+from abc import ABC
+
+ 
+class Dataquery(ABC):
+    pass

--- a/internal/jennies/python/tmpl.go
+++ b/internal/jennies/python/tmpl.go
@@ -1,0 +1,38 @@
+package python
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	cogtemplate "github.com/grafana/cog/internal/jennies/template"
+)
+
+//nolint:gochecknoglobals
+var templates *template.Template
+
+//go:embed templates/*/*.tmpl
+//nolint:gochecknoglobals
+var veneersFS embed.FS
+
+//nolint:gochecknoinits
+func init() {
+	base := template.New("python")
+	base.
+		Option("missingkey=error").
+		Funcs(sprig.FuncMap()).
+		Funcs(cogtemplate.Helpers(base))
+
+	templates = template.Must(cogtemplate.FindAndParseTemplates(veneersFS, base, "templates"))
+}
+
+func renderTemplate(templateFile string, data map[string]any) (string, error) {
+	buf := bytes.Buffer{}
+	if err := templates.ExecuteTemplate(&buf, templateFile, data); err != nil {
+		return "", fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/internal/jennies/python/tools.go
+++ b/internal/jennies/python/tools.go
@@ -1,0 +1,85 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+)
+
+type raw string
+
+func formatValue(val any) string {
+	if val == nil {
+		return "None"
+	}
+
+	if rawVal, ok := val.(raw); ok {
+		return string(rawVal)
+	}
+
+	if asBool, ok := val.(bool); ok {
+		if asBool {
+			return "True"
+		}
+
+		return "False"
+	}
+
+	if list, ok := val.([]any); ok {
+		items := make([]string, 0, len(list))
+
+		for _, item := range list {
+			items = append(items, formatValue(item))
+		}
+
+		return fmt.Sprintf("[%s]", strings.Join(items, ", "))
+	}
+
+	return fmt.Sprintf("%#v", val)
+}
+
+func escapeFieldName(name string) string {
+	if isReservedPythonKeyword(name) {
+		return name + "_val"
+	}
+
+	return name
+}
+
+func isReservedPythonKeyword(input string) bool {
+	// see: https://docs.python.org/3/reference/lexical_analysis.html#keywords
+	return input == "False" ||
+		input == "await" ||
+		input == "else" ||
+		input == "import" ||
+		input == "pass" ||
+		input == "None" ||
+		input == "break" ||
+		input == "except" ||
+		input == "in" ||
+		input == "raise" ||
+		input == "True" ||
+		input == "class" ||
+		input == "finally" ||
+		input == "is" ||
+		input == "return" ||
+		input == "and" ||
+		input == "continue" ||
+		input == "for" ||
+		input == "lambda" ||
+		input == "try" ||
+		input == "as" ||
+		input == "def" ||
+		input == "from" ||
+		input == "nonlocal" ||
+		input == "while" ||
+		input == "assert" ||
+		input == "del" ||
+		input == "global" ||
+		input == "not" ||
+		input == "with" ||
+		input == "async" ||
+		input == "elif" ||
+		input == "if" ||
+		input == "or" ||
+		input == "yield"
+}

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -1,0 +1,304 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/tools"
+)
+
+type typeFormatter struct {
+	importPkg    func(alias string, pkg string) string
+	importModule func(alias string, pkg string, module string) string
+
+	forBuilder bool
+	context    common.Context
+}
+
+func defaultTypeFormatter(importPkg func(alias string, pkg string) string, importModule func(alias string, pkg string, module string) string) *typeFormatter {
+	return &typeFormatter{
+		importPkg:    importPkg,
+		importModule: importModule,
+	}
+}
+
+func builderTypeFormatter(context common.Context, importPkg func(alias string, pkg string) string, importModule func(alias string, pkg string, module string) string) *typeFormatter {
+	return &typeFormatter{
+		importPkg:    importPkg,
+		importModule: importModule,
+		forBuilder:   true,
+		context:      context,
+	}
+}
+
+func (formatter *typeFormatter) formatObject(def ast.Object) (string, error) {
+	var buffer strings.Builder
+
+	defName := tools.UpperCamelCase(def.Name)
+
+	if !def.Type.IsAnyOf(ast.KindStruct, ast.KindEnum) {
+		buffer.WriteString(formatter.formatComments(def.Comments))
+	}
+
+	switch def.Type.Kind {
+	case ast.KindEnum:
+		buffer.WriteString(formatter.formatEnum(def))
+	case ast.KindStruct:
+		return formatter.formatStruct(def), nil
+	case ast.KindScalar:
+		scalarType := def.Type.AsScalar()
+
+		var value string
+		if scalarType.IsConcrete() {
+			value = formatValue(scalarType.Value)
+		} else {
+			value = formatter.formatType(def.Type)
+		}
+
+		buffer.WriteString(fmt.Sprintf("%s = %s", defName, value))
+	case ast.KindMap, ast.KindRef, ast.KindArray, ast.KindIntersection, ast.KindDisjunction:
+		buffer.WriteString(fmt.Sprintf("%s = %s", defName, formatter.formatType(def.Type)))
+	default:
+		return "", fmt.Errorf("unhandled object of kind: %s", def.Type.Kind)
+	}
+
+	return buffer.String(), nil
+}
+
+func (formatter *typeFormatter) formatType(def ast.Type) string {
+	result := "unknown"
+
+	if def.Kind == ast.KindComposableSlot {
+		formatted := tools.UpperCamelCase(string(def.AsComposableSlot().Variant))
+		cogVariants := formatter.importModule("cogvariants", "..cog", "variants")
+
+		result = fmt.Sprintf("%s.%s", cogVariants, formatted)
+	}
+
+	if def.IsArray() {
+		result = formatter.formatArray(def.AsArray())
+	}
+
+	if def.IsMap() {
+		result = formatter.formatMap(def.AsMap())
+	}
+
+	if def.IsScalar() {
+		// This scalar actually refers to a constant
+		if def.AsScalar().IsConcrete() {
+			typingPkg := formatter.importPkg("typing", "typing")
+			result = fmt.Sprintf("%s.Literal[%s]", typingPkg, formatValue(def.AsScalar().Value))
+		} else {
+			result = formatter.formatScalarKind(def.AsScalar().ScalarKind)
+		}
+	}
+
+	if def.IsRef() {
+		result = formatter.formatRef(def.AsRef())
+	}
+
+	// anonymous enum
+	if def.IsEnum() {
+		result = formatter.formatAnonymousEnum(def)
+	}
+
+	if def.Kind == ast.KindIntersection {
+		panic("formatting intersection type is not implemented for python")
+	}
+
+	if def.Kind == ast.KindDisjunction {
+		result = formatter.formatDisjunction(def.AsDisjunction())
+	}
+
+	if formatter.forBuilder && (def.Kind == ast.KindComposableSlot || (def.Kind == ast.KindRef && formatter.context.ResolveToBuilder(def))) {
+		cogBuilder := formatter.importModule("cogbuilder", "..cog", "builder")
+		result = fmt.Sprintf("%s.Builder[%s]", cogBuilder, result)
+	} else if def.Nullable {
+		result = fmt.Sprintf("%s | None", result)
+	}
+
+	return result
+}
+
+func (formatter *typeFormatter) formatEnum(def ast.Object) string {
+	var buffer strings.Builder
+
+	enumPkg := formatter.importPkg("enum", "enum")
+
+	enumName := tools.UpperCamelCase(def.Name)
+	enumType := def.Type.AsEnum()
+
+	enumKind := enumPkg + ".IntEnum"
+	if enumType.Values[0].Type.AsScalar().ScalarKind == ast.KindString {
+		enumKind = enumPkg + ".StrEnum"
+	}
+	buffer.WriteString(fmt.Sprintf("class %s(%s):\n", enumName, enumKind))
+	buffer.WriteString(formatter.formatClassComments(def.Comments))
+
+	for i, val := range enumType.Values {
+		memberName := tools.UpperSnakeCase(val.Name)
+		buffer.WriteString(fmt.Sprintf("    %s = %#v", memberName, val.Value))
+
+		if i != len(enumType.Values)-1 {
+			buffer.WriteString("\n")
+		}
+	}
+
+	return buffer.String()
+}
+
+func (formatter *typeFormatter) formatAnonymousEnum(typeDef ast.Type) string {
+	typingPkg := formatter.importPkg("typing", "typing")
+	literalValues := tools.Map(typeDef.AsEnum().Values, func(val ast.EnumValue) string {
+		return formatValue(val.Value)
+	})
+
+	return fmt.Sprintf("%s.Literal[%s]", typingPkg, strings.Join(literalValues, ", "))
+}
+
+func (formatter *typeFormatter) formatStruct(def ast.Object) string {
+	var buffer strings.Builder
+
+	classBases := ""
+	if def.Type.Kind == ast.KindStruct && def.Type.ImplementsVariant() {
+		cogVariants := formatter.importModule("cogvariants", "..cog", "variants")
+		variant := tools.UpperCamelCase(def.Type.ImplementedVariant())
+
+		classBases = fmt.Sprintf("(%s.%s)", cogVariants, variant)
+	}
+
+	buffer.WriteString(fmt.Sprintf("class %s%s:\n", tools.UpperCamelCase(def.Name), classBases))
+	buffer.WriteString(formatter.formatClassComments(def.Comments))
+
+	fields := def.Type.AsStruct().Fields
+
+	// shouldn't happen, but we never know.
+	if len(fields) == 0 {
+		buffer.WriteString("    pass")
+	}
+
+	for i, fieldDef := range def.Type.AsStruct().Fields {
+		buffer.WriteString(formatter.formatStructField(fieldDef))
+
+		if i != len(fields)-1 {
+			buffer.WriteString("\n")
+		}
+	}
+
+	return buffer.String()
+}
+
+func (formatter *typeFormatter) formatStructField(def ast.StructField) string {
+	var buffer strings.Builder
+
+	for _, commentLine := range def.Comments {
+		buffer.WriteString(fmt.Sprintf("    # %s\n", commentLine))
+	}
+
+	field := formatter.formatType(def.Type)
+
+	if !def.Required {
+		typingPkg := formatter.importPkg("typing", "typing")
+		field = fmt.Sprintf("%s.Optional[%s]", typingPkg, field)
+	}
+
+	buffer.WriteString(fmt.Sprintf("    %s: %s", escapeFieldName(def.Name), field))
+
+	return buffer.String()
+}
+
+func (formatter *typeFormatter) formatArray(def ast.ArrayType) string {
+	return fmt.Sprintf("list[%s]", formatter.formatType(def.ValueType))
+}
+
+func (formatter *typeFormatter) formatMap(def ast.MapType) string {
+	keyTypeString := formatter.formatType(def.IndexType)
+	valueTypeString := formatter.formatType(def.ValueType)
+
+	return fmt.Sprintf("dict[%s, %s]", keyTypeString, valueTypeString)
+}
+
+func (formatter *typeFormatter) formatRef(def ast.RefType) string {
+	formatted := tools.UpperCamelCase(def.ReferredType)
+
+	referredPkg := def.ReferredPkg
+	referredPkg = formatter.importModule(referredPkg, "..models", referredPkg)
+	if referredPkg != "" {
+		formatted = referredPkg + "." + formatted
+	}
+
+	if formatter.forBuilder || referredPkg != "" {
+		return formatted
+	}
+
+	// The quotes are important to allow for forward-references.
+	return fmt.Sprintf("'%s'", formatted)
+}
+
+func (formatter *typeFormatter) formatDisjunction(def ast.DisjunctionType) string {
+	typingPkg := formatter.importPkg("typing", "typing")
+	branches := tools.Map(def.Branches, func(branch ast.Type) string {
+		return formatter.formatType(branch)
+	})
+
+	return fmt.Sprintf("%s.Union[%s]", typingPkg, strings.Join(branches, ", "))
+}
+
+func (formatter *typeFormatter) formatScalarKind(kind ast.ScalarKind) string {
+	switch kind {
+	case ast.KindNull:
+		return "None"
+	case ast.KindAny:
+		typingPkg := formatter.importPkg("typing", "typing")
+		return typingPkg + ".Any"
+
+	case ast.KindBytes:
+		return "bytes"
+	case ast.KindString:
+		return "str"
+
+	case ast.KindFloat32, ast.KindFloat64:
+		return "float"
+	case ast.KindUint8, ast.KindUint16, ast.KindUint32, ast.KindUint64:
+		return "int"
+	case ast.KindInt8, ast.KindInt16, ast.KindInt32, ast.KindInt64:
+		return "int"
+
+	case ast.KindBool:
+		return "bool"
+	default:
+		return string(kind)
+	}
+}
+
+func (formatter *typeFormatter) formatClassComments(comments []string) string {
+	if len(comments) == 0 {
+		return ""
+	}
+
+	var buffer strings.Builder
+
+	buffer.WriteString(`    """` + "\n")
+	for _, commentLine := range comments {
+		buffer.WriteString(fmt.Sprintf("    %s\n", commentLine))
+	}
+	buffer.WriteString(`    """` + "\n\n")
+
+	return buffer.String()
+}
+
+func (formatter *typeFormatter) formatComments(comments []string) string {
+	if len(comments) == 0 {
+		return ""
+	}
+
+	var buffer strings.Builder
+
+	for _, commentLine := range comments {
+		buffer.WriteString(strings.TrimRight(fmt.Sprintf("# %s\n", commentLine), " "))
+	}
+
+	return buffer.String()
+}

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -240,8 +240,7 @@ func (formatter *typeFormatter) formatScalarKind(kind ast.ScalarKind) string {
 	case ast.KindNull:
 		return "None"
 	case ast.KindAny:
-		typingPkg := formatter.importPkg("typing", "typing")
-		return typingPkg + ".Any"
+		return "object"
 
 	case ast.KindBytes:
 		return "bytes"

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -9,27 +9,21 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
+type pkgImporter func(alias string, pkg string) string
+type moduleImporter func(alias string, pkg string, module string) string
+
 type typeFormatter struct {
-	importPkg    func(alias string, pkg string) string
-	importModule func(alias string, pkg string, module string) string
+	importPkg    pkgImporter
+	importModule moduleImporter
 
 	forBuilder bool
 	context    common.Context
 }
 
-func defaultTypeFormatter(importPkg func(alias string, pkg string) string, importModule func(alias string, pkg string, module string) string) *typeFormatter {
+func defaultTypeFormatter(importPkg pkgImporter, importModule moduleImporter) *typeFormatter {
 	return &typeFormatter{
 		importPkg:    importPkg,
 		importModule: importModule,
-	}
-}
-
-func builderTypeFormatter(context common.Context, importPkg func(alias string, pkg string) string, importModule func(alias string, pkg string, module string) string) *typeFormatter {
-	return &typeFormatter{
-		importPkg:    importPkg,
-		importModule: importModule,
-		forBuilder:   true,
-		context:      context,
 	}
 }
 

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -107,6 +107,9 @@ func (formatter *typeFormatter) formatType(def ast.Type) string {
 	if formatter.forBuilder && (def.Kind == ast.KindComposableSlot || (def.Kind == ast.KindRef && formatter.context.ResolveToBuilder(def))) {
 		cogBuilder := formatter.importModule("cogbuilder", "..cog", "builder")
 		result = fmt.Sprintf("%s.Builder[%s]", cogBuilder, result)
+	} else if def.Nullable {
+		typingPkg := formatter.importPkg("typing", "typing")
+		result = fmt.Sprintf("%s.Optional[%s]", typingPkg, result)
 	}
 
 	return result
@@ -188,11 +191,6 @@ func (formatter *typeFormatter) formatStructField(def ast.StructField) string {
 	}
 
 	field := formatter.formatType(def.Type)
-
-	if !def.Required || def.Type.Nullable {
-		typingPkg := formatter.importPkg("typing", "typing")
-		field = fmt.Sprintf("%s.Optional[%s]", typingPkg, field)
-	}
 
 	buffer.WriteString(fmt.Sprintf("    %s: %s", escapeFieldName(def.Name), field))
 

--- a/internal/tools/strings.go
+++ b/internal/tools/strings.go
@@ -4,9 +4,14 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/huandu/xstrings"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
+
+func UpperSnakeCase(s string) string {
+	return strings.ToUpper(xstrings.ToSnakeCase(s))
+}
 
 func UpperCamelCase(s string) string {
 	s = LowerCamelCase(s)

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -69,7 +69,9 @@ function run_codegen() {
     --package-templates ./package_templates \
     --templates-data "${templates_data}" \
     --go-mod \
-    --go-package-root github.com/grafana/grafana-foundation-sdk/go
+    --go-package-root github.com/grafana/grafana-foundation-sdk/go \
+    --language go \
+    --language typescript
 }
 
 function gh_run() (

--- a/testdata/jennies/rawtypes/arrays.txtar
+++ b/testdata/jennies/rawtypes/arrays.txtar
@@ -105,3 +105,17 @@ type ArrayOfRefs []SomeStruct
 
 type ArrayOfArrayOfNumbers [][]int64
 
+-- out/jennies/PythonRawTypes --
+== models/arrays.py
+# List of tags, maybe?
+ArrayOfStrings = list[str]
+
+
+class SomeStruct:
+    FieldAny: object
+
+
+ArrayOfRefs = list['SomeStruct']
+
+
+ArrayOfArrayOfNumbers = list[list[int]]

--- a/testdata/jennies/rawtypes/disjunctions.txtar
+++ b/testdata/jennies/rawtypes/disjunctions.txtar
@@ -360,3 +360,34 @@ func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
 	return errors.Join(errList...)
 }
 
+-- out/jennies/PythonRawTypes --
+== models/disjunctions.py
+import typing
+
+
+# Refresh rate or disabled.
+RefreshRate = typing.Union[str | bool]
+
+
+StringOrNull = typing.Optional[str]
+
+
+class SomeStruct:
+    Type: typing.Literal["some-struct"]
+    FieldAny: object
+
+
+BoolOrRef = typing.Union[bool | 'SomeStruct']
+
+
+class SomeOtherStruct:
+    Type: typing.Literal["some-other-struct"]
+    Foo: bytes
+
+
+class YetAnotherStruct:
+    Type: typing.Literal["yet-another-struct"]
+    Bar: int
+
+
+SeveralRefs = typing.Union['SomeStruct' | 'SomeOtherStruct' | 'YetAnotherStruct']

--- a/testdata/jennies/rawtypes/enums.txtar
+++ b/testdata/jennies/rawtypes/enums.txtar
@@ -213,3 +213,37 @@ const (
 )
 
 
+-- out/jennies/PythonRawTypes --
+== models/enums.py
+import enum
+
+
+class Operator(enum.StrEnum):
+    """
+    This is a very interesting string enum.
+    """
+
+    GREATER_THAN = ">"
+    LESS_THAN = "<"
+
+
+class TableSortOrder(enum.StrEnum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class LogsSortOrder(enum.StrEnum):
+    ASC = "time_asc"
+    DESC = "time_desc"
+
+
+class DashboardCursorSync(enum.IntEnum):
+    """
+    0 for no shared crosshair or tooltip (default).
+    1 for shared crosshair.
+    2 for shared crosshair AND shared tooltip.
+    """
+
+    OFF = 0
+    CROSSHAIR = 1
+    TOOLTIP = 2

--- a/testdata/jennies/rawtypes/maps.txtar
+++ b/testdata/jennies/rawtypes/maps.txtar
@@ -144,3 +144,20 @@ type MapOfStringToRef map[string]SomeStruct
 
 type MapOfStringToMapOfStringToBool map[string]map[string]bool
 
+-- out/jennies/PythonRawTypes --
+== models/maps.py
+# String to... something.
+MapOfStringToAny = dict[str, object]
+
+
+MapOfStringToString = dict[str, str]
+
+
+class SomeStruct:
+    FieldAny: object
+
+
+MapOfStringToRef = dict[str, 'SomeStruct']
+
+
+MapOfStringToMapOfStringToBool = dict[str, dict[str, bool]]

--- a/testdata/jennies/rawtypes/refs.txtar
+++ b/testdata/jennies/rawtypes/refs.txtar
@@ -74,3 +74,16 @@ type RefToSomeStruct SomeStruct
 
 type RefToSomeStructFromOtherPackage otherpkg.SomeDistantStruct
 
+-- out/jennies/PythonRawTypes --
+== models/refs.py
+from ..models import otherpkg
+
+
+class SomeStruct:
+    FieldAny: object
+
+
+RefToSomeStruct = 'SomeStruct'
+
+
+RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct

--- a/testdata/jennies/rawtypes/scalars.txtar
+++ b/testdata/jennies/rawtypes/scalars.txtar
@@ -209,3 +209,51 @@ type ScalarTypeInt32 int32
 
 type ScalarTypeInt64 int64
 
+-- out/jennies/PythonRawTypes --
+== models/scalars.py
+import typing
+
+
+ConstTypeString = typing.Literal["foo"]
+
+
+ScalarTypeAny = object
+
+
+ScalarTypeBool = bool
+
+
+ScalarTypeBytes = bytes
+
+
+ScalarTypeString = str
+
+
+ScalarTypeFloat32 = float
+
+
+ScalarTypeFloat64 = float
+
+
+ScalarTypeUint8 = int
+
+
+ScalarTypeUint16 = int
+
+
+ScalarTypeUint32 = int
+
+
+ScalarTypeUint64 = int
+
+
+ScalarTypeInt8 = int
+
+
+ScalarTypeInt16 = int
+
+
+ScalarTypeInt32 = int
+
+
+ScalarTypeInt64 = int

--- a/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields.txtar
@@ -5,6 +5,7 @@
     "Objects": [
         {
             "Name": "SomeStruct",
+            "SelfRef": {"ReferredPkg": "struct_complex_fields", "ReferredType": "SomeStruct"},
             "Comments": ["This struct does things."],
             "Type": {
                 "Kind": "struct",
@@ -158,6 +159,7 @@
 
         {
             "Name": "SomeOtherStruct",
+            "SelfRef": {"ReferredPkg": "struct_complex_fields", "ReferredType": "SomeOtherStruct"},
             "Type": {
                 "Kind": "struct",
                 "Struct": {
@@ -297,3 +299,29 @@ func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
 	return errors.Join(errList...)
 }
 
+-- out/jennies/PythonRawTypes --
+== models/struct_complex_fields.py
+import typing
+
+
+class StructComplexFieldsSomeStructFieldAnonymousStruct:
+    FieldAny: object
+
+
+class SomeStruct:
+    """
+    This struct does things.
+    """
+
+    FieldRef: 'SomeOtherStruct'
+    FieldDisjunctionOfScalars: str | bool
+    FieldMixedDisjunction: str | 'SomeOtherStruct'
+    FieldDisjunctionWithNull: typing.Optional[str]
+    Operator: typing.Literal[">", "<"]
+    FieldArrayOfStrings: list[str]
+    FieldMapOfStringToString: dict[str, str]
+    FieldAnonymousStruct: 'StructComplexFieldsSomeStructFieldAnonymousStruct'
+
+
+class SomeOtherStruct:
+    FieldAny: object

--- a/testdata/jennies/rawtypes/struct_with_defaults.txtar
+++ b/testdata/jennies/rawtypes/struct_with_defaults.txtar
@@ -91,3 +91,14 @@ type SomeStruct struct {
 	FieldInt32 int32 `json:"FieldInt32"`
 }
 
+-- out/jennies/PythonRawTypes --
+== models/defaults.py
+import typing
+
+
+class SomeStruct:
+    fieldBool: bool
+    fieldString: str
+    FieldStringWithConstantValue: typing.Literal["auto"]
+    FieldFloat32: float
+    FieldInt32: int

--- a/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields.txtar
@@ -5,6 +5,7 @@
     "Objects": [
         {
             "Name": "SomeStruct",
+            "SelfRef": {"ReferredPkg": "struct_optional_fields", "ReferredType": "SomeStruct"},
             "Type": {
                 "Kind": "struct",
                 "Struct": {
@@ -91,6 +92,7 @@
 
         {
             "Name": "SomeOtherStruct",
+            "SelfRef": {"ReferredPkg": "struct_optional_fields", "ReferredType": "SomeOtherStruct"},
             "Type": {
                 "Kind": "struct",
                 "Struct": {
@@ -157,3 +159,22 @@ const (
 )
 
 
+-- out/jennies/PythonRawTypes --
+== models/struct_optional_fields.py
+import typing
+
+
+class StructOptionalFieldsSomeStructFieldAnonymousStruct:
+    FieldAny: object
+
+
+class SomeStruct:
+    FieldRef: typing.Optional['SomeOtherStruct']
+    FieldString: typing.Optional[str]
+    Operator: typing.Optional[typing.Literal[">", "<"]]
+    FieldArrayOfStrings: typing.Optional[list[str]]
+    FieldAnonymousStruct: typing.Optional['StructOptionalFieldsSomeStructFieldAnonymousStruct']
+
+
+class SomeOtherStruct:
+    FieldAny: object

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields.txtar
@@ -213,3 +213,33 @@ FieldAny any `json:"FieldAny"`
 	FieldInt64 int64 `json:"FieldInt64"`
 }
 
+-- out/jennies/PythonRawTypes --
+== models/basic.py
+import typing
+
+
+class SomeStruct:
+    """
+    This
+    is
+    a
+    comment
+    """
+
+    # Anything can go in there.
+    # Really, anything.
+    FieldAny: object
+    FieldBool: bool
+    FieldBytes: bytes
+    FieldString: str
+    FieldStringWithConstantValue: typing.Literal["auto"]
+    FieldFloat32: float
+    FieldFloat64: float
+    FieldUint8: int
+    FieldUint16: int
+    FieldUint32: int
+    FieldUint64: int
+    FieldInt8: int
+    FieldInt16: int
+    FieldInt32: int
+    FieldInt64: int


### PR DESCRIPTION
This PR bootstraps types generation in Python.

It's the initial pass, not everything is implemented (even just for types). Most notably:

* no handling of default values
* no constructor is generated for the types
* no support for (de)serialization

My apologies for the big PR, I got carried away once more :|
Exploring it commit by commit should help. Most of the interesting code lives in `internal/jennies/python/rawtypes.go` and `internal/jennies/python/types.go`

But on the bright side, when running this branch on `kind-registry`, [`mypy`](https://mypy.readthedocs.io/) seems to be happy with what we generate :)