### PR TITLE
Fix configuration and execution of heatmap-related veneers

### DIFF
--- a/config/heatmap.veneers.common.yaml
+++ b/config/heatmap.veneers.common.yaml
@@ -8,16 +8,16 @@ options:
     # ExemplarsColor(color: string) instead of Exemplars(exemplarsConfig: ExemplarConfig)
     # ExemplarConfig only includes (color: string) field.
   - struct_fields_as_arguments:
-      by_name: Options.exemplars
+      by_builder: Panel.exemplars
   - rename:
-      by_name: Options.exemplars
+      by_builder: Panel.exemplars
       as: exemplarsColor
 
     # ShowLegend/HideLegends instead of Legend(show: bool)
   - struct_fields_as_arguments:
-      by_name: Options.legend
+      by_builder: Panel.legend
   - unfold_boolean:
-      by_name: Options.legend
+      by_builder: Panel.legend
       true_as: showLegend
       false_as: hideLegend
 
@@ -25,12 +25,12 @@ options:
     # - ShowTooltip/HideTooltip
     # - ShowYHistogram/HideYHistogram
   - struct_fields_as_options:
-      by_name: Options.tooltip
+      by_builder: Panel.tooltip
   - unfold_boolean:
-      by_name: Options.show
+      by_builder: Panel.show
       true_as: showTooltip
       false_as: hideTooltip
   - unfold_boolean:
-      by_name: Options.yHistogram
+      by_builder: Panel.yHistogram
       true_as: showYHistogram
       false_as: hideYHistogram

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -494,6 +494,7 @@ func UnfoldBooleanAction(unfoldOpts BooleanUnfold) RewriteAction {
 				Assignments: []ast.Assignment{
 					ast.ConstantAssignment(option.Assignments[0].Path, true),
 				},
+				VeneerTrail: append([]string{}, option.VeneerTrail...),
 			},
 
 			{
@@ -502,6 +503,7 @@ func UnfoldBooleanAction(unfoldOpts BooleanUnfold) RewriteAction {
 				Assignments: []ast.Assignment{
 					ast.ConstantAssignment(option.Assignments[0].Path, false),
 				},
+				VeneerTrail: append([]string{}, option.VeneerTrail...),
 			},
 		}
 

--- a/internal/veneers/option/selectors.go
+++ b/internal/veneers/option/selectors.go
@@ -24,7 +24,7 @@ func ByName(pkg string, objectName string, optionNames ...string) Selector {
 // Note: the comparison on builder and options names is case-insensitive.
 func ByBuilder(pkg string, builderName string, optionNames ...string) Selector {
 	return func(builder ast.Builder, option ast.Option) bool {
-		return builder.For.SelfRef.ReferredPkg == pkg &&
+		return builder.Package == pkg &&
 			strings.EqualFold(builder.Name, builderName) &&
 			tools.StringInListEqualFold(option.Name, optionNames)
 	}

--- a/internal/veneers/option/selectors_test.go
+++ b/internal/veneers/option/selectors_test.go
@@ -72,8 +72,9 @@ func TestByBuilder(t *testing.T) {
 	req := require.New(t)
 
 	dashboardBuilder := ast.Builder{
-		Name: "EmptyDashboard",
-		For:  ast.NewObject("dashboard", "Dashboard", ast.NewStruct()),
+		Name:    "Panel",
+		Package: "heatmap",
+		For:     ast.NewObject("dashboard", "Panel", ast.NewStruct()),
 	}
 	options := []ast.Option{
 		{Name: "Editable"},
@@ -81,8 +82,8 @@ func TestByBuilder(t *testing.T) {
 		{Name: "TimePicker"},
 	}
 
-	singleSelector := ByBuilder("dashboard", "EmptyDashboard", "Refresh")
-	notFoundSelector := ByBuilder("dashboard", "Dashboard", "Refresh")
+	singleSelector := ByBuilder("heatmap", "Panel", "Refresh")
+	notFoundSelector := ByBuilder("dashboard", "Panel", "Refresh")
 
 	selectedForDashboard := filter(singleSelector, dashboardBuilder, options)
 	req.Len(selectedForDashboard, 1)


### PR DESCRIPTION
Because of a slight misconfiguration, veneers configured for the Heatmap panel were not applied. This PR fixes that and makes the `by_builder` selector behave in a more intuitive way.