### PR TITLE
Support envelope assignments in Typescript

### DIFF
--- a/config/dashboard.veneers.common.yaml
+++ b/config/dashboard.veneers.common.yaml
@@ -155,9 +155,6 @@ options:
   - rename:
       by_name: Panel.overrides
       as: withOverride
-  # WithOverride(matcher, properties) instead of WithOverride(struct{...})
-  - struct_fields_as_arguments:
-      by_name: Panel.withOverride
 
   # Append a single transformation instead forcing to define all of them at once
   - array_to_append:

--- a/config/dashboard.veneers.go.yaml
+++ b/config/dashboard.veneers.go.yaml
@@ -12,3 +12,11 @@ options:
   # Time(from, to) instead of time(struct {From string `json:"from"`, To string `json:"to"`}{From: "lala", To: "lala})
   - struct_fields_as_arguments:
       by_name: Dashboard.time
+
+  ##############
+  #   Panels   #
+  ##############
+
+  # WithOverride(matcher, properties) instead of WithOverride(struct{...})
+  - struct_fields_as_arguments:
+      by_name: Panel.withOverride

--- a/examples/typescript/disk.ts
+++ b/examples/typescript/disk.ts
@@ -17,12 +17,12 @@ export const diskIOTimeseries = (): TimeseriesPanelBuilder => {
         .withTarget(
             basicPrometheusQuery(`rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} IO time"),
         )
-        .withOverride(
-            {id: "byRegexp", options: "/ io time/"},
-            [
+        .withOverride({
+            matcher: {id: "byRegexp", options: "/ io time/"},
+            properties: [
                 {id: "unit", value: "percentunit"},
             ]
-        );
+        });
 };
 
 export const diskSpaceUsageTable = (): TablePanelBuilder => {
@@ -115,25 +115,25 @@ export const diskSpaceUsageTable = (): TablePanelBuilder => {
         })
 
         // Overrides configuration
-        .withOverride(
-            {id: "byName", options: "Mounted on"},
-            [{id: "custom.width", value: 260}]
-        )
-        .withOverride(
-            {id: "byName", options: "Size"},
-            [{id: "custom.width", value: 93}]
-        )
-        .withOverride(
-            {id: "byName", options: "Used"},
-            [{id: "custom.width", value: 72}]
-        )
-        .withOverride(
-            {id: "byName", options: "Available"},
-            [{id: "custom.width", value: 88}]
-        )
-        .withOverride(
-            {id: "byName", options: "Used, %"},
-            [
+        .withOverride({
+            matcher: {id: "byName", options: "Mounted on"},
+            properties: [{id: "custom.width", value: 260}]
+        })
+        .withOverride({
+            matcher: {id: "byName", options: "Size"},
+            properties: [{id: "custom.width", value: 93}]
+        })
+        .withOverride({
+            matcher: {id: "byName", options: "Used"},
+            properties: [{id: "custom.width", value: 72}]
+        })
+        .withOverride({
+            matcher: {id: "byName", options: "Available"},
+            properties: [{id: "custom.width", value: 88}]
+        })
+        .withOverride({
+            matcher: {id: "byName", options: "Used, %"},
+            properties: [
                 {id: "unit", value: "percentunit"},
                 {
                     id: "custom.cellOptions",
@@ -142,6 +142,6 @@ export const diskSpaceUsageTable = (): TablePanelBuilder => {
                 {id: "max", value: 1},
                 {id: "min", value: 0}
             ]
-        )
+        })
     ;
 };

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -163,9 +163,9 @@ func (jenny *Builder) generatePathInitializationSafeGuard(path ast.Path) string 
 
 	emptyValue := formatValue(jenny.rawTypes.defaultValueForType(valueType, jenny.typeImportMapper))
 
-	return fmt.Sprintf(`		if (!this.internal.%[1]s) {
-			this.internal.%[1]s = %[2]s;
-		}`, fieldPath, emptyValue)
+	return fmt.Sprintf(`        if (!this.internal.%[1]s) {
+            this.internal.%[1]s = %[2]s;
+        }`, fieldPath, emptyValue)
 }
 
 func (jenny *Builder) generateAssignment(assign ast.Assignment) template.Assignment {

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -66,6 +66,19 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
         {{- .Name }}
         {{- end }}
     {{- end }}
+    {{- with .Value.Envelope }}
+        {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
+    {{- end }}
+{{- end }}
+
+
+{{- define "value_envelope" -}}
+    {
+    {{- range .Envelope.Values }}
+        {{- $value := include "assignment_value" (dict "Assignment" $.Assignment "Value" .Value) }}
+        {{ (index .Path 0).Identifier }}: {{ $value }},
+    {{- end }}
+    }
 {{- end }}
 
 {{- define "assignment_method" }}

--- a/internal/txtartest/txtar.go
+++ b/internal/txtartest/txtar.go
@@ -190,7 +190,7 @@ func (t *Test) BuildersContext() common.Context {
 		}
 
 		if err := json.Unmarshal(f.Data, &buildersContext); err != nil {
-			t.Fatal("could not unmarshal test input into context.Context{}")
+			t.Fatal("could not unmarshal test input into context.Context{}", err)
 		}
 
 		return buildersContext

--- a/testdata/jennies/builders/array_append/test.txtar
+++ b/testdata/jennies/builders/array_append/test.txtar
@@ -189,9 +189,9 @@ export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     }
 
     tags(tags: string): this {
-		if (!this.internal.tags) {
-			this.internal.tags = [];
-		}
+        if (!this.internal.tags) {
+            this.internal.tags = [];
+        }
         this.internal.tags.push(tags);
         return this;
     }

--- a/testdata/jennies/builders/envelope_assignment/test.txtar
+++ b/testdata/jennies/builders/envelope_assignment/test.txtar
@@ -1,0 +1,391 @@
+# Envelope assignment.
+-- builders_context.json --
+{
+  "Schemas": [
+    {
+      "Package": "sandbox",
+      "Metadata": {},
+      "Objects": [
+        {
+          "Name": "Dashboard",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "variables",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "sandbox",
+                          "ReferredType": "Variable"
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "sandbox",
+            "ReferredType": "Dashboard"
+          }
+        },
+        {
+          "Name": "Variable",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "name",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "value",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "sandbox",
+            "ReferredType": "Variable"
+          }
+        }
+      ]
+    }
+  ],
+  "Builders": [
+    {
+      "Schema": {
+        "Package": "sandbox",
+        "Metadata": {},
+        "Objects": [
+          {
+            "Name": "Dashboard",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "variables",
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "sandbox",
+                            "ReferredType": "Variable"
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "sandbox",
+              "ReferredType": "Dashboard"
+            }
+          },
+          {
+            "Name": "Variable",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "name",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "value",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "sandbox",
+              "ReferredType": "Variable"
+            }
+          }
+        ]
+      },
+      "For": {
+        "Name": "Dashboard",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "variables",
+                "Type": {
+                  "Kind": "array",
+                  "Nullable": false,
+                  "Array": {
+                    "ValueType": {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "sandbox",
+                        "ReferredType": "Variable"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "sandbox",
+          "ReferredType": "Dashboard"
+        }
+      },
+      "Package": "sandbox",
+      "Name": "Dashboard",
+      "Options": [
+        {
+          "Name": "withVariable",
+          "Args": [
+            {
+              "Name": "name",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            },
+            {
+              "Name": "value",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "variables",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "sandbox",
+                          "ReferredType": "Variable"
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Envelope": {
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "sandbox",
+                      "ReferredType": "Variable"
+                    }
+                  },
+                  "Values": [
+                    {
+                      "Path": [{
+                        "Identifier": "name",
+                        "Type": {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      }],
+                      "Value": {
+                        "Argument": {
+                          "Name": "name",
+                          "Type": {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "Path": [{
+                        "Identifier": "value",
+                        "Type": {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      }],
+                      "Value": {
+                        "Argument": {
+                          "Name": "value",
+                          "Type": {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "Method": "append"
+            }
+          ],
+          "IsConstructorArg": false
+        }
+      ]
+    }
+  ]
+}
+
+-- out/jennies/TypescriptBuilder --
+== src/sandbox/dashboard_builder_gen.ts
+import * as cog from '../cog';
+import * as sandbox from '../sandbox';
+
+export class DashboardBuilder implements cog.Builder<sandbox.Dashboard> {
+    private readonly internal: sandbox.Dashboard;
+
+    constructor() {
+        this.internal = sandbox.defaultDashboard();
+    }
+
+    build(): sandbox.Dashboard {
+        return this.internal;
+    }
+
+    withVariable(name: string,value: string): this {
+        if (!this.internal.variables) {
+            this.internal.variables = [];
+        }
+        this.internal.variables.push({
+        name: name,
+        value: value,
+    });
+        return this;
+    }
+}
+-- out/jennies/GoBuilder --
+== sandbox/dashboard_builder_gen.go
+package sandbox
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
+
+type DashboardBuilder struct {
+    internal *Dashboard
+    errors map[string]cog.BuildErrors
+}
+
+func NewDashboardBuilder() *DashboardBuilder {
+	resource := &Dashboard{}
+	builder := &DashboardBuilder{
+		internal: resource,
+		errors: make(map[string]cog.BuildErrors),
+	}
+
+	builder.applyDefaults()
+
+	return builder
+}
+
+func (builder *DashboardBuilder) Build() (Dashboard, error) {
+	var errs cog.BuildErrors
+
+	for _, err := range builder.errors {
+		errs = append(errs, cog.MakeBuildErrors("Dashboard", err)...)
+	}
+
+	if len(errs) != 0 {
+		return Dashboard{}, errs
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *DashboardBuilder) WithVariable(name string,value string) *DashboardBuilder {
+    builder.internal.Variables = append(builder.internal.Variables, Variable{
+        Name: name,
+        Value: value,
+    })
+
+    return builder
+}
+
+func (builder *DashboardBuilder) applyDefaults() {
+}

--- a/testdata/jennies/builders/known_any/test.txtar
+++ b/testdata/jennies/builders/known_any/test.txtar
@@ -235,9 +235,9 @@ export class SomeStructBuilder implements cog.Builder<known_any.SomeStruct> {
     }
 
     title(title: string): this {
-		if (!this.internal.config) {
-			this.internal.config = known_any.defaultConfig();
-		}
+        if (!this.internal.config) {
+            this.internal.config = known_any.defaultConfig();
+        }
         this.internal.config.title = title;
         return this;
     }

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
@@ -1,4 +1,4 @@
-# Envelope assignment.
+# Struct fields as arguments, with init safeguards but no envelope
 -- builders_context.json --
 {
   "Schemas": [

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/test.txtar
@@ -351,19 +351,19 @@ export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
     }
 
     time(from: string,to: string): this {
-		if (!this.internal.time) {
-			this.internal.time = {
+        if (!this.internal.time) {
+            this.internal.time = {
 	from: "now-6h",
 	to: "now",
 };
-		}
+        }
         this.internal.time.from = from;
-		if (!this.internal.time) {
-			this.internal.time = {
+        if (!this.internal.time) {
+            this.internal.time = {
 	from: "now-6h",
 	to: "now",
 };
-		}
+        }
         this.internal.time.to = to;
         return this;
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-foundation-sdk/issues/18

This problem was caused by a two issues that this PR addresses:
* "*envelope assignments*" were not supported in Typescript. ie: cog didn't generate any code for them.
* a global veneer was applied to `panel.withOverride` but should have been applied to Go only.

ToDo:
* [x] add a txtar test-case for envelope assignments