### PR TITLE
Add missing "cog" export in Typescript `package.json`

### DIFF
--- a/package_templates/typescript/package.json
+++ b/package_templates/typescript/package.json
@@ -26,6 +26,10 @@
     "package.json"
   ],
   "exports": {
+    "./cog": {
+      "types": "./dist/cog/index.d.ts",
+      "default": "./dist/cog/index.js"
+    },
 {{- range $i, $pkg := .Packages }}
     "./{{ $pkg }}": {
       "types": "./dist/{{ $pkg }}/index.d.ts",


### PR DESCRIPTION
These need to be exported, to support the definition of builders that aren't natively generated by cog.

For example, one could manually write an `AlertListBuilder` for the `alertlist` panel (for which we don't have a schema)

```typescript
import { Builder } from '@grafana/grafana-foundation-sdk/cog';

export class AlertListBuilder implements Builder<Panel> {
    private readonly internal: Panel;

    constructor() {
        this.internal = defaultPanel();
        this.internal.type = "alertlist";
    }

    build(): Panel {
        return this.internal;
    }

    // Panel title.
    title(title: string): this {
        this.internal.title = title;
        return this;
    }

    maxItems(maxItems: number): this {
        if (!this.internal.fieldConfig) {
            this.internal.fieldConfig = defaultFieldConfigSource();
        }
        if (!this.internal.fieldConfig.defaults) {
            this.internal.fieldConfig.defaults = defaultFieldConfig();
        }
        if (!this.internal.fieldConfig.defaults.custom) {
            this.internal.fieldConfig.defaults.custom = {} as AlertListOptions;
        }
        this.internal.fieldConfig.defaults.custom.maxItems = maxItems;
        return this;
    }
}
```