### PR TITLE
Split the disjunction discriminator and mapping inference code in a standalone compiler pass

### DIFF
--- a/internal/ast/compiler/disjunctions_infer_mapping.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping.go
@@ -1,0 +1,261 @@
+package compiler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*DisjunctionInferMapping)(nil)
+
+var ErrCanNotInferDiscriminator = errors.New("can not infer discriminator mapping")
+
+// DisjunctionInferMapping infers the discriminator field and mapping used to
+// describe a disjunction of references.
+// See https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+type DisjunctionInferMapping struct {
+}
+
+func (pass *DisjunctionInferMapping) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0, len(schemas))
+
+	for _, schema := range schemas {
+		newSchema, err := pass.processSchema(schema)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] %w", schema.Package, err)
+		}
+
+		newSchemas = append(newSchemas, newSchema)
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *DisjunctionInferMapping) processSchema(schema *ast.Schema) (*ast.Schema, error) {
+	var err error
+
+	for i, object := range schema.Objects {
+		schema.Objects[i], err = pass.processObject(schema, object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return schema, nil
+}
+
+func (pass *DisjunctionInferMapping) processObject(schema *ast.Schema, object ast.Object) (ast.Object, error) {
+	var err error
+
+	object.Type, err = pass.processType(schema, object.Type)
+	if err != nil {
+		return object, errors.Join(
+			fmt.Errorf("could not process object '%s'", object.Name),
+			err,
+		)
+	}
+
+	return object, nil
+}
+
+func (pass *DisjunctionInferMapping) processType(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if def.Kind == ast.KindArray {
+		return pass.processArray(schema, def)
+	}
+
+	if def.Kind == ast.KindMap {
+		return pass.processMap(schema, def)
+	}
+
+	if def.Kind == ast.KindStruct {
+		return pass.processStruct(schema, def)
+	}
+
+	if def.Kind == ast.KindDisjunction {
+		return pass.processDisjunction(schema, def)
+	}
+
+	return def, nil
+}
+
+func (pass *DisjunctionInferMapping) processArray(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	var err error
+
+	def.Array.ValueType, err = pass.processType(schema, def.AsArray().ValueType)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	return def, nil
+}
+
+func (pass *DisjunctionInferMapping) processMap(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	var err error
+
+	def.Map.ValueType, err = pass.processType(schema, def.AsMap().ValueType)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	return def, nil
+}
+
+func (pass *DisjunctionInferMapping) processStruct(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	var err error
+
+	for i, field := range def.Struct.Fields {
+		def.Struct.Fields[i].Type, err = pass.processType(schema, field.Type)
+		if err != nil {
+			return ast.Type{}, errors.Join(
+				fmt.Errorf("could not process struct field '%s'", field.Name),
+				err,
+			)
+		}
+	}
+
+	return def, nil
+}
+
+func (pass *DisjunctionInferMapping) processDisjunction(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	var err error
+
+	if !def.Disjunction.Branches.HasOnlyRefs() {
+		return def, nil
+	}
+
+	def.Disjunction, err = pass.ensureDiscriminator(schema, def.Disjunction)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	return def, nil
+}
+
+func (pass *DisjunctionInferMapping) ensureDiscriminator(schema *ast.Schema, def *ast.DisjunctionType) (*ast.DisjunctionType, error) {
+	// discriminator-related data was set during parsing: nothing to do.
+	if def.Discriminator != "" && len(def.DiscriminatorMapping) != 0 {
+		return def, nil
+	}
+
+	if def.Discriminator == "" {
+		def.Discriminator = pass.inferDiscriminatorField(schema, def)
+	}
+
+	if len(def.DiscriminatorMapping) == 0 {
+		mapping, err := pass.buildDiscriminatorMapping(schema, def)
+		if err != nil {
+			return def, err
+		}
+
+		def.DiscriminatorMapping = mapping
+	}
+
+	return def, nil
+}
+
+// inferDiscriminatorField tries to identify a field that might be used
+// as a way to distinguish between the types in the disjunction branches.
+// Such a field must:
+//   - exist in all structs referred by the disjunction
+//   - have a concrete, scalar value
+//
+// Note: this function assumes a disjunction of references to structs.
+func (pass *DisjunctionInferMapping) inferDiscriminatorField(schema *ast.Schema, def *ast.DisjunctionType) string {
+	fieldName := ""
+	// map[typeName][fieldName]value
+	candidates := make(map[string]map[string]any)
+
+	// Identify candidates from each branch
+	for _, branch := range def.Branches {
+		referredType, found := schema.Resolve(branch)
+		if !found {
+			continue
+		}
+
+		typeName := branch.AsRef().ReferredType
+		structType := referredType.AsStruct()
+		candidates[typeName] = make(map[string]any)
+
+		for _, field := range structType.Fields {
+			if field.Type.Kind != ast.KindScalar {
+				continue
+			}
+
+			scalarField := field.Type.AsScalar()
+			if !scalarField.IsConcrete() {
+				continue
+			}
+			if field.Type.AsScalar().ScalarKind != ast.KindString {
+				continue
+			}
+
+			candidates[typeName][field.Name] = scalarField.Value
+		}
+	}
+
+	// At this point, if a discriminator exists, it will be listed under the candidates
+	// of any type in our map.
+	// We need to check if all other types have a similar field.
+	someType := def.Branches[0].AsRef().ReferredType
+	allTypes := make([]string, 0, len(candidates))
+
+	for typeName := range candidates {
+		allTypes = append(allTypes, typeName)
+	}
+
+	for candidateFieldName := range candidates[someType] {
+		existsInAllBranches := true
+		for _, branchTypeName := range allTypes {
+			if _, ok := candidates[branchTypeName][candidateFieldName]; !ok {
+				existsInAllBranches = false
+				break
+			}
+		}
+
+		if existsInAllBranches {
+			fieldName = candidateFieldName
+			break
+		}
+	}
+
+	return fieldName
+}
+
+func (pass *DisjunctionInferMapping) buildDiscriminatorMapping(schema *ast.Schema, def *ast.DisjunctionType) (map[string]string, error) {
+	mapping := make(map[string]string, len(def.Branches))
+	if def.Discriminator == "" {
+		return nil, fmt.Errorf("discriminator field is empty: %w", ErrCanNotInferDiscriminator)
+	}
+
+	for _, branch := range def.Branches {
+		typeName := branch.AsRef().ReferredType
+		referredType, found := schema.Resolve(branch)
+		if !found {
+			return nil, fmt.Errorf("could not resolve reference '%s'", branch.AsRef().String())
+		}
+
+		structType := referredType.AsStruct()
+
+		field, found := structType.FieldByName(def.Discriminator)
+		if !found {
+			return nil, fmt.Errorf("discriminator field '%s' not found in Object '%s': %w", def.Discriminator, typeName, ErrCanNotInferDiscriminator)
+		}
+
+		// trust, but verify: we need the field to be an actual scalar with a concrete value?
+		if field.Type.Kind != ast.KindScalar {
+			return nil, fmt.Errorf("discriminator field is not a scalar: %w", ErrCanNotInferDiscriminator)
+		}
+
+		switch {
+		case field.Type.AsScalar().IsConcrete():
+			mapping[field.Type.AsScalar().Value.(string)] = typeName
+		case field.Type.Default != nil:
+			mapping[field.Type.Default.(string)] = typeName
+		default:
+			return nil, fmt.Errorf("discriminator field is not concrete: %w", ErrCanNotInferDiscriminator)
+		}
+	}
+
+	return mapping, nil
+}

--- a/internal/ast/compiler/disjunctions_infer_mapping.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping.go
@@ -173,6 +173,10 @@ func (pass *DisjunctionInferMapping) inferDiscriminatorField(schema *ast.Schema,
 			continue
 		}
 
+		if !referredType.IsStruct() {
+			continue
+		}
+
 		typeName := branch.AsRef().ReferredType
 		structType := referredType.AsStruct()
 		candidates[typeName] = make(map[string]any)

--- a/internal/ast/compiler/disjunctions_infer_mapping_test.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping_test.go
@@ -1,0 +1,292 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisjunctionInferMapping_WithNonDisjunctionObjects_HasNoImpact(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "AMap", ast.NewMap(ast.String(), ast.String())),
+		ast.NewObject("test", "ARef", ast.NewRef("test", "AMap")),
+		ast.NewObject("test", "AnEnum", ast.NewEnum([]ast.EnumValue{
+			{
+				Name:  "Foo",
+				Type:  ast.String(),
+				Value: "foo",
+			},
+			{
+				Name:  "Bar",
+				Type:  ast.String(),
+				Value: "bar",
+			},
+		})),
+		ast.NewObject("test", "AnArray", ast.NewArray(ast.String())),
+		ast.NewObject("test", "AScalar", ast.NewScalar(ast.KindInt8)),
+		ast.NewObject("test", "AStruct", ast.NewStruct(
+			ast.NewStructField("SomeNonDisjunctionField", ast.NewScalar(ast.KindInt8)),
+		)),
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionInferMapping{}, objects, objects)
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfScalars_AsAnObject_hasNoImpact(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfScalars", ast.NewDisjunction([]ast.Type{
+			ast.String(),
+			ast.Bool(),
+		})),
+	}
+
+	// Prepare expected output
+	disjunctionStructType := ast.NewStruct(
+		ast.NewStructField("String", ast.String(ast.Nullable())),
+		ast.NewStructField("Bool", ast.Bool(ast.Nullable())),
+	)
+	// The original disjunction definition is preserved as a hint
+	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = objects[0].Type.AsDisjunction()
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionInferMapping{}, objects, objects)
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetadata_NoDiscriminatorFieldCandidate(t *testing.T) {
+	req := require.New(t)
+
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
+			ast.NewRef("test", "SomeStruct"),
+			ast.NewRef("test", "OtherStruct"),
+		})),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Kind", ast.String(ast.Value("some-struct"))), // No equivalent in OtherStruct
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	compilerPass := &DisjunctionInferMapping{}
+	_, err := compilerPass.Process([]*ast.Schema{
+		{Package: "test", Objects: objects},
+	})
+	req.Error(err)
+	req.ErrorIs(err, ErrCanNotInferDiscriminator)
+	req.ErrorContains(err, "discriminator field is empty")
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetadata_NonScalarDiscriminator(t *testing.T) {
+	req := require.New(t)
+
+	// Prepare test input
+	disjunctionType := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	disjunctionType.Disjunction.Discriminator = "MapOfString"
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("FieldFoo", ast.String()),
+			ast.NewStructField("MapOfString", ast.NewMap(ast.String(), ast.String())),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("FieldBar", ast.Bool()),
+			ast.NewStructField("MapOfString", ast.NewMap(ast.String(), ast.String())),
+		)),
+	}
+
+	compilerPass := &DisjunctionInferMapping{}
+	_, err := compilerPass.Process([]*ast.Schema{
+		{Package: "test", Objects: objects},
+	})
+	req.Error(err)
+	req.ErrorIs(err, ErrCanNotInferDiscriminator)
+	req.ErrorContains(err, "field is not a scalar")
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetadata_NonConcreteDiscriminator(t *testing.T) {
+	req := require.New(t)
+
+	// Prepare test input
+	disjunctionType := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	disjunctionType.Disjunction.Discriminator = "Type"
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String()), // Not a concrete scalar
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	compilerPass := &DisjunctionInferMapping{}
+	_, err := compilerPass.Process([]*ast.Schema{
+		{Package: "test", Objects: objects},
+	})
+	req.Error(err)
+	req.ErrorIs(err, ErrCanNotInferDiscriminator)
+	req.ErrorContains(err, "field is not concrete")
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetadata_UnknownDiscriminatorField(t *testing.T) {
+	req := require.New(t)
+
+	// Prepare test input
+	disjunctionType := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	disjunctionType.Disjunction.Discriminator = "DoesNotExist"
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("some-struct"))),
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	compilerPass := &DisjunctionInferMapping{}
+	_, err := compilerPass.Process([]*ast.Schema{
+		{Package: "test", Objects: objects},
+	})
+	req.Error(err)
+	req.ErrorIs(err, ErrCanNotInferDiscriminator)
+	req.ErrorContains(err, "discriminator field 'DoesNotExist' not found")
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetadata(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
+			ast.NewRef("test", "SomeStruct"),
+			ast.NewRef("test", "OtherStruct"),
+		})),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("some-struct"))),
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("FieldBar", ast.NewMap(ast.String(), ast.String())),
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+		)),
+	}
+
+	// Prepare expected output
+	newDisjunction := objects[0].DeepCopy()
+	newDisjunction.Type.Disjunction.Discriminator = "Type"
+	newDisjunction.Type.Disjunction.DiscriminatorMapping = map[string]string{
+		"other-struct": "OtherStruct",
+		"some-struct":  "SomeStruct",
+	}
+
+	expectedObjects := []ast.Object{
+		newDisjunction,
+		objects[1],
+		objects[2],
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionInferMapping{}, objects, expectedObjects)
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFieldSet(t *testing.T) {
+	// Prepare test input
+	disjunctionType := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	// Add discriminator-related metadata to the disjunction
+	// Mapping omitted: it will be inferred
+	disjunctionType.Disjunction.Discriminator = "Kind"
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("some-struct"))),
+			ast.NewStructField("Kind", ast.String(ast.Value("some-kind"))),
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("Kind", ast.String(ast.Value("other-kind"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	// Prepare expected output
+	newDisjunction := objects[0].DeepCopy()
+	newDisjunction.Type.Disjunction.DiscriminatorMapping = map[string]string{
+		"other-kind": "OtherStruct",
+		"some-kind":  "SomeStruct",
+	}
+
+	expectedObjects := []ast.Object{
+		newDisjunction,
+		objects[1],
+		objects[2],
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionInferMapping{}, objects, expectedObjects)
+}
+
+func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFieldAndMappingSet(t *testing.T) {
+	// Prepare test input
+	disjunctionType := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	// Add discriminator-related metadata to the disjunction
+	disjunctionType.Disjunction.Discriminator = "Kind"
+	disjunctionType.Disjunction.DiscriminatorMapping = map[string]string{
+		"other-kind": "OtherStruct",
+		"some-kind":  "SomeStruct",
+	}
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("some-struct"))),
+			ast.NewStructField("Kind", ast.String(ast.Value("some-kind"))),
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("Kind", ast.String(ast.Value("other-kind"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &DisjunctionInferMapping{}, objects, objects)
+}

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -80,6 +80,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.FlattenDisjunctions{},
 		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.DisjunctionInferMapping{},
 		&compiler.DisjunctionToType{},
 	}
 }

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -55,6 +55,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.AnonymousEnumToExplicitType{},
 		&compiler.AnonymousStructsToNamed{},
 		&compiler.FlattenDisjunctions{},
+		&compiler.DisjunctionInferMapping{},
 		&compiler.DisjunctionToType{},
 	}
 }

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -37,7 +37,9 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 
 func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
+		&compiler.FlattenDisjunctions{},
 		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.DisjunctionInferMapping{},
 		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.AnonymousStructsToNamed{},
 	}


### PR DESCRIPTION
This PR splits the `DisjunctionToType` compiler pass even further, isolating the code responsible for inferring the discriminator field and mapping to use in its own pass.

I am doing this for two reasons:
* to make these passes less hard to read and understand
* to enable unmarshalling from JSON easier in languages like Python that support disjunctions but still need to know the discriminator & mapping to unmarshal correctly

Note: this PR doesn't change the code generated by cog