### PR TITLE
Correctly parse enum values in jsonschema

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -375,7 +375,7 @@ func (g *generator) walkEnum(schema *schemaparser.Schema) (ast.Type, error) {
 		values = append(values, ast.EnumValue{
 			Type:  enumType,
 			Name:  fmt.Sprintf("%v", enumValue),
-			Value: enumValue,
+			Value: unwrapJSONNumber(enumValue),
 		})
 	}
 

--- a/internal/jsonschema/utils.go
+++ b/internal/jsonschema/utils.go
@@ -1,6 +1,7 @@
 package jsonschema
 
 import (
+	"encoding/json"
 	"strings"
 
 	schemaparser "github.com/santhosh-tekuri/jsonschema"
@@ -21,4 +22,22 @@ func schemaComments(schema *schemaparser.Schema) []string {
 	}
 
 	return filtered
+}
+
+func unwrapJSONNumber(input any) any {
+	if val, ok := input.(json.Number); ok {
+		asInt, err := val.Int64()
+		if err == nil {
+			return asInt
+		}
+
+		asFloat, err := val.Float64()
+		if err == nil {
+			return asFloat
+		}
+
+		return val.String()
+	}
+
+	return input
 }


### PR DESCRIPTION
The parser we use for jsonschema returns `json.Number` instances for numeric enum values. This can be a problem since jennies expect scalar Go values when doing the codegen.

This PR unwraps these values before injecting them into the IR.