### PR TITLE
Fix incorrect typed vs untyped constant parsing in jsonschema

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -129,7 +129,7 @@ func (g *generator) walkDefinition(schema *schemaparser.Schema) (ast.Type, error
 		}
 
 		if len(schema.Constant) != 0 {
-			return g.walkConstant(schema)
+			return g.walkUntypedConstant(schema)
 		}
 
 		return ast.Any(), nil
@@ -145,7 +145,7 @@ func (g *generator) walkDefinition(schema *schemaparser.Schema) (ast.Type, error
 		case typeNull:
 			def = ast.Null()
 		case typeBoolean:
-			def = ast.Bool(ast.Default(schema.Default))
+			def, err = g.walkBool(schema)
 		case typeString:
 			def, err = g.walkString(schema)
 		case typeObject:
@@ -199,7 +199,7 @@ func (g *generator) walkDisjunctionBranches(branches []*schemaparser.Schema) ([]
 	return definitions, nil
 }
 
-func (g *generator) walkConstant(schema *schemaparser.Schema) (ast.Type, error) {
+func (g *generator) walkUntypedConstant(schema *schemaparser.Schema) (ast.Type, error) {
 	value := schema.Constant[0]
 
 	switch constant := value.(type) {
@@ -283,6 +283,10 @@ func (g *generator) walkRef(schema *schemaparser.Schema) (ast.Type, error) {
 func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 	def := ast.String(ast.Default(schema.Default))
 
+	if schema.Constant != nil {
+		def.Scalar.Value = schema.Constant[0]
+	}
+
 	if schema.MinLength != -1 {
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.MinLengthOp,
@@ -299,6 +303,16 @@ func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 	return def, nil
 }
 
+func (g *generator) walkBool(schema *schemaparser.Schema) (ast.Type, error) {
+	def := ast.Bool(ast.Default(schema.Default))
+
+	if schema.Constant != nil {
+		def.Scalar.Value = schema.Constant[0]
+	}
+
+	return def, nil
+}
+
 func (g *generator) walkNumber(schema *schemaparser.Schema) (ast.Type, error) {
 	scalarKind := ast.KindInt64
 	if schema.Types[0] == typeNumber {
@@ -306,6 +320,10 @@ func (g *generator) walkNumber(schema *schemaparser.Schema) (ast.Type, error) {
 	}
 
 	def := ast.NewScalar(scalarKind, ast.Default(schema.Default))
+
+	if schema.Constant != nil {
+		def.Scalar.Value = unwrapJSONNumber(schema.Constant[0])
+	}
 
 	if schema.Minimum != nil {
 		value, _ := schema.Minimum.Int64()

--- a/testdata/jsonschema/consts/GenerateAST/ir.json
+++ b/testdata/jsonschema/consts/GenerateAST/ir.json
@@ -22,6 +22,18 @@
               "Required": false
             },
             {
+              "Name": "boolean_with_type",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "bool",
+                  "Value": true
+                }
+              },
+              "Required": false
+            },
+            {
               "Name": "integer",
               "Type": {
                 "Kind": "scalar",
@@ -34,7 +46,43 @@
               "Required": false
             },
             {
+              "Name": "number",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "int64",
+                  "Value": 3
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "number_with_type",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "float64",
+                  "Value": 3.2
+                }
+              },
+              "Required": false
+            },
+            {
               "Name": "string",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Value": "constant"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "string_with_type",
               "Type": {
                 "Kind": "scalar",
                 "Nullable": false,

--- a/testdata/jsonschema/consts/schema.json
+++ b/testdata/jsonschema/consts/schema.json
@@ -10,7 +10,22 @@
         "string": {
           "const": "constant"
         },
+        "string_with_type": {
+          "type": "string",
+          "const": "constant"
+        },
+        "number": {
+          "const": 3
+        },
+        "number_with_type": {
+          "type": "number",
+          "const": 3.2
+        },
         "boolean": {
+          "const": true
+        },
+        "boolean_with_type": {
+          "type": "boolean",
           "const": true
         }
       }


### PR DESCRIPTION
While playing with JSONSchemas generated from typescript models in grafana/grafana, I encountered a bug caused by constants that were incorrectly parsed.

Our parser was correct for untyped `const` definitions, but not typed ones. This PR addresses this issue.