### PR TITLE
Jsonschema/recursive definition

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -34,6 +34,7 @@ type Config struct {
 
 type generator struct {
 	schema *ast.Schema
+	seen   map[string]struct{}
 }
 
 func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
@@ -42,6 +43,7 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 			Package:  c.Package,
 			Metadata: c.SchemaMetadata,
 		},
+		seen: make(map[string]struct{}),
 	}
 
 	compiler := schemaparser.NewCompiler()
@@ -78,9 +80,11 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 }
 
 func (g *generator) declareDefinition(definitionName string, schema *schemaparser.Schema) error {
-	if _, found := g.schema.LocateObject(definitionName); found {
+	if _, found := g.seen[definitionName]; found {
 		return nil
 	}
+
+	g.seen[definitionName] = struct{}{}
 
 	def, err := g.walkDefinition(schema)
 	if err != nil {

--- a/testdata/jsonschema/recursive/GenerateAST/ir.json
+++ b/testdata/jsonschema/recursive/GenerateAST/ir.json
@@ -10,17 +10,6 @@
         "Struct": {
           "Fields": [
             {
-              "Name": "value",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": false
-            },
-            {
               "Name": "edges",
               "Type": {
                 "Kind": "array",
@@ -34,6 +23,17 @@
                       "ReferredType": "Node"
                     }
                   }
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "value",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
                 }
               },
               "Required": false

--- a/testdata/jsonschema/recursive/GenerateAST/ir.json
+++ b/testdata/jsonschema/recursive/GenerateAST/ir.json
@@ -1,0 +1,50 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": [
+    {
+      "Name": "Node",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "value",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "edges",
+              "Type": {
+                "Kind": "array",
+                "Nullable": false,
+                "Array": {
+                  "ValueType": {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "grafanatest",
+                      "ReferredType": "Node"
+                    }
+                  }
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "Node"
+      }
+    }
+  ]
+}

--- a/testdata/jsonschema/recursive/schema.json
+++ b/testdata/jsonschema/recursive/schema.json
@@ -1,0 +1,20 @@
+{
+  "$ref": "#/definitions/Node",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Node": {
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "edges": {
+          "items": {
+            "$ref": "#/definitions/Node"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
The JSONSchema parser crashes if the schema contains recursive definitions (like the [`cloudwatch` query](https://github.com/grafana/kind-registry/blob/8978db169909894c4354edf9b388ad90243bbf0c/grafana/next/composable/cloudwatch/dataquery.cue#L133-L135) does).

This PR fixes that.