### PR TITLE
Support packages with dashes in Go

### DIFF
--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -34,7 +34,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 		}
 
 		filename := filepath.Join(
-			strings.ToLower(builder.Package),
+			formatPackageName(builder.Package),
 			fmt.Sprintf("%s_builder_gen.go", strings.ToLower(builder.Name)),
 		)
 

--- a/internal/jennies/golang/imports.go
+++ b/internal/jennies/golang/imports.go
@@ -10,7 +10,7 @@ import (
 func NewImportMap() *common.DirectImportMap {
 	return common.NewDirectImportMap(
 		common.WithAliasSanitizer[common.DirectImportMap](func(alias string) string {
-			return strings.ReplaceAll(alias, "/", "")
+			return formatPackageName(strings.ReplaceAll(alias, "/", ""))
 		}),
 		common.WithFormatter(func(importMap common.DirectImportMap) string {
 			if importMap.Imports.Len() == 0 {

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -36,7 +36,7 @@ func (jenny JSONMarshalling) Generate(context common.Context) (codejen.Files, er
 		}
 
 		filename := filepath.Join(
-			strings.ToLower(schema.Package),
+			formatPackageName(schema.Package),
 			"types_json_marshalling_gen.go",
 		)
 
@@ -103,7 +103,7 @@ func (jenny JSONMarshalling) generateSchema(context common.Context, schema *ast.
 	}
 
 	return []byte(fmt.Sprintf(`package %[1]s
-%[2]s%[3]s`, strings.ToLower(schema.Package), importStatements, buffer.String())), nil
+%[2]s%[3]s`, formatPackageName(schema.Package), importStatements, buffer.String())), nil
 }
 
 func (jenny JSONMarshalling) objectNeedsCustomMarshal(obj ast.Object) bool {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -31,7 +31,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 		}
 
 		filename := filepath.Join(
-			strings.ToLower(schema.Package),
+			formatPackageName(schema.Package),
 			"types_gen.go",
 		)
 
@@ -70,7 +70,7 @@ func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
 
 	return []byte(fmt.Sprintf(`package %[1]s
 
-%[2]s%[3]s`, strings.ToLower(schema.Package), importStatements, buffer.String())), nil
+%[2]s%[3]s`, formatPackageName(schema.Package), importStatements, buffer.String())), nil
 }
 
 func (jenny RawTypes) formatObject(def ast.Object) ([]byte, error) {

--- a/internal/jennies/golang/templates/builders/builder.tmpl
+++ b/internal/jennies/golang/templates/builders/builder.tmpl
@@ -1,4 +1,4 @@
-package {{ .Package }}
+package {{ .Package | formatPackageName }}
 {{ $options := include "options" . }}
 {{ .Imports }}
 

--- a/internal/jennies/golang/templates/runtime/variant_plugins.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_plugins.tmpl
@@ -7,11 +7,11 @@ func RegisterDefaultPlugins() {
 
     // Panelcfg variants
 {{- range $schema := index .init_map "panelcfg" }}
-	runtime.RegisterPanelcfgVariant({{ $schema.Package }}.VariantConfig())
+	runtime.RegisterPanelcfgVariant({{ $schema.Package | formatPackageName }}.VariantConfig())
 {{- end }}
 
     // Dataquery variants
 {{- range $schema := index .init_map "dataquery" }}
-	runtime.RegisterDataqueryVariant({{ $schema.Package }}.VariantConfig())
+	runtime.RegisterDataqueryVariant({{ $schema.Package | formatPackageName }}.VariantConfig())
 {{- end }}
 }

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -39,7 +39,8 @@ func init() {
 			},
 		}).
 		Funcs(map[string]any{
-			"formatScalar": formatScalar,
+			"formatPackageName": formatPackageName,
+			"formatScalar":      formatScalar,
 			"formatArgName": func(name string) string {
 				return escapeVarName(tools.LowerCamelCase(name))
 			},

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
@@ -312,4 +313,10 @@ func (formatter *typeFormatter) formatIntersection(def ast.IntersectionType) str
 	buffer.WriteString("}")
 
 	return buffer.String()
+}
+
+func formatPackageName(pkg string) string {
+	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
+
+	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
 }

--- a/internal/jennies/golang/variantsplugins.go
+++ b/internal/jennies/golang/variantsplugins.go
@@ -49,7 +49,7 @@ func (jenny VariantsPlugins) variantPlugins(context common.Context) (string, err
 		}
 
 		variant := string(schema.Metadata.Variant)
-		imports.Add(schema.Package, jenny.Config.importPath(schema.Package))
+		imports.Add(schema.Package, jenny.Config.importPath(formatPackageName(schema.Package)))
 		initMap[variant] = append(initMap[variant], schema)
 	}
 

--- a/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
@@ -1,0 +1,48 @@
+package builderpkg
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+	withdashes "github.com/grafana/cog/generated/with-dashes"
+)
+
+var _ cog.Builder[withdashes.SomeStruct] = (*SomeNiceBuilderBuilder)(nil)
+
+type SomeNiceBuilderBuilder struct {
+    internal *withdashes.SomeStruct
+    errors map[string]cog.BuildErrors
+}
+
+func NewSomeNiceBuilderBuilder() *SomeNiceBuilderBuilder {
+	resource := &withdashes.SomeStruct{}
+	builder := &SomeNiceBuilderBuilder{
+		internal: resource,
+		errors: make(map[string]cog.BuildErrors),
+	}
+
+	builder.applyDefaults()
+
+	return builder
+}
+
+func (builder *SomeNiceBuilderBuilder) Build() (withdashes.SomeStruct, error) {
+	var errs cog.BuildErrors
+
+	for _, err := range builder.errors {
+		errs = append(errs, cog.MakeBuildErrors("SomeNiceBuilder", err)...)
+	}
+
+	if len(errs) != 0 {
+		return withdashes.SomeStruct{}, errs
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuilder {
+    builder.internal.Title = title
+
+    return builder
+}
+
+func (builder *SomeNiceBuilderBuilder) applyDefaults() {
+}

--- a/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
+++ b/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
@@ -1,0 +1,19 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import with-dashes
+
+
+class SomeNiceBuilder(cogbuilder.Builder[with-dashes.SomeStruct]):    
+    __internal: with-dashes.SomeStruct
+
+    def __init__(self):
+        self.__internal = with-dashes.SomeStruct()
+
+    def build(self) -> with-dashes.SomeStruct:
+        return self.__internal    
+    
+    def title(self, title: str) -> typing.Self:        
+        self.__internal.title = title
+    
+        return self
+    

--- a/testdata/jennies/builders/package-with-dashes/TypescriptBuilder/src/builder-pkg/somenicebuilder_builder_gen.ts
+++ b/testdata/jennies/builders/package-with-dashes/TypescriptBuilder/src/builder-pkg/somenicebuilder_builder_gen.ts
@@ -1,0 +1,19 @@
+import * as cog from '../cog';
+import * as with-dashes from '../with-dashes';
+
+export class SomeNiceBuilderBuilder implements cog.Builder<with-dashes.SomeStruct> {
+    private readonly internal: with-dashes.SomeStruct;
+
+    constructor() {
+        this.internal = with-dashes.defaultSomeStruct();
+    }
+
+    build(): with-dashes.SomeStruct {
+        return this.internal;
+    }
+
+    title(title: string): this {
+        this.internal.title = title;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/package-with-dashes/builders_context.json
+++ b/testdata/jennies/builders/package-with-dashes/builders_context.json
@@ -1,0 +1,147 @@
+{
+  "Schemas": [
+    {
+      "Package": "with-dashes",
+      "Metadata": {},
+      "Objects": [
+        {
+          "Name": "SomeStruct",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "with-dashes",
+            "ReferredType": "SomeStruct"
+          }
+        }
+      ]
+    }
+  ],
+  "Builders": [
+    {
+      "Schema": {
+        "Package": "with-dashes",
+        "Metadata": {},
+        "Objects": [
+          {
+            "Name": "SomeStruct",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "title",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "with-dashes",
+              "ReferredType": "SomeStruct"
+            }
+          }
+        ]
+      },
+      "For": {
+        "Name": "SomeStruct",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "with-dashes",
+          "ReferredType": "SomeStruct"
+        }
+      },
+      "Package": "builder-pkg",
+      "Name": "SomeNiceBuilder",
+      "Options": [
+        {
+          "Name": "title",
+          "Args": [
+            {
+              "Name": "title",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
+++ b/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
@@ -1,12 +1,12 @@
 package intersections
 
 import (
-	externalPkg "github.com/grafana/cog/generated/externalPkg"
+	externalpkg "github.com/grafana/cog/generated/externalPkg"
 )
 
 type Intersections struct {
 	SomeStruct
-	externalPkg.AnotherStruct
+	externalpkg.AnotherStruct
 
 	FieldString string `json:"fieldString"`
 	FieldInteger int32 `json:"fieldInteger"`

--- a/testdata/jennies/rawtypes/package-with-dashes/GoJSONMarshalling/withdashes/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoJSONMarshalling/withdashes/types_json_marshalling_gen.go
@@ -1,0 +1,43 @@
+package withdashes
+func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
+	if resource.String != nil {
+		return json.Marshal(resource.String)
+	}
+
+	if resource.Bool != nil {
+		return json.Marshal(resource.Bool)
+	}
+
+	return nil, nil
+}
+
+func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	var errList []error
+
+	// String
+	var String string
+	if err := json.Unmarshal(raw, &String); err != nil {
+		errList = append(errList, err)
+		resource.String = nil
+	} else {
+		resource.String = &String
+		return nil
+	}
+
+	// Bool
+	var Bool bool
+	if err := json.Unmarshal(raw, &Bool); err != nil {
+		errList = append(errList, err)
+		resource.Bool = nil
+	} else {
+		resource.Bool = &Bool
+		return nil
+	}
+
+	return errors.Join(errList...)
+}
+

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -1,0 +1,14 @@
+package withdashes
+
+type SomeStruct struct {
+	FieldAny any `json:"FieldAny"`
+}
+
+// Refresh rate or disabled.
+type RefreshRate StringOrBool
+
+type StringOrBool struct {
+	String *string `json:"String,omitempty"`
+	Bool *bool `json:"Bool,omitempty"`
+}
+

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/RefreshRate.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/RefreshRate.java
@@ -1,0 +1,7 @@
+package with-dashes;
+
+
+// Refresh rate or disabled.
+public class RefreshRate extends StringOrBool {
+    
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/SomeStruct.java
@@ -1,0 +1,7 @@
+package with-dashes;
+
+
+public class SomeStruct {
+    public Object FieldAny;
+    
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/StringOrBool.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/StringOrBool.java
@@ -1,0 +1,8 @@
+package with-dashes;
+
+
+public class StringOrBool {
+    public String String;
+    public Boolean Bool;
+    
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
+++ b/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
@@ -1,0 +1,25 @@
+import typing
+
+
+class SomeStruct:
+    field_any: object
+
+    def __init__(self, field_any: object = None):
+        self.field_any = field_any
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "FieldAny": self.field_any,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args = {
+            "field_any": data["FieldAny"],
+        }
+        return cls(**args)
+
+
+# Refresh rate or disabled.
+RefreshRate = typing.Union[typing.Union[str, bool]]

--- a/testdata/jennies/rawtypes/package-with-dashes/TypescriptRawTypes/src/with-dashes/types_gen.ts
+++ b/testdata/jennies/rawtypes/package-with-dashes/TypescriptRawTypes/src/with-dashes/types_gen.ts
@@ -1,0 +1,13 @@
+export interface someStruct {
+	FieldAny: any;
+}
+
+export const defaultSomeStruct = (): someStruct => ({
+	FieldAny: {},
+});
+
+// Refresh rate or disabled.
+export type RefreshRate = string | boolean;
+
+export const defaultRefreshRate = (): RefreshRate => ("");
+

--- a/testdata/jennies/rawtypes/package-with-dashes/ir.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/ir.json
@@ -1,0 +1,50 @@
+{
+  "Package": "with-dashes",
+  "Objects": [
+    {
+      "Name": "someStruct",
+      "Type": {
+        "Kind": "struct",
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "FieldAny",
+              "Required": true,
+              "Type": {
+                "Kind": "scalar",
+                "Scalar": {
+                  "ScalarKind": "any"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "Name": "RefreshRate",
+      "Comments": [
+        "Refresh rate or disabled."
+      ],
+      "Type": {
+        "Kind": "disjunction",
+        "Disjunction": {
+          "Branches": [
+            {
+              "Kind": "scalar",
+              "Scalar": {
+                "ScalarKind": "string"
+              }
+            },
+            {
+              "Kind": "scalar",
+              "Scalar": {
+                "ScalarKind": "bool"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Our jennies do not sanitize package names enough, so if a package contains dashes it will be rendered as-is in the generated code, which is a problem for most languages.

Starting with Go, let's fix that!