### PR TITLE
Objects orderedmap

### DIFF
--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -168,7 +168,6 @@ func doGenerate(allTargets jennies.LanguageJennies, opts Options) error {
 	}
 
 	rootCodeJenFS := codejen.NewFS()
-
 	for language, target := range targetsByLanguage {
 		fmt.Printf("Running '%s' jennies...\n", language)
 

--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -125,6 +125,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
 	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
 	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
+	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")
@@ -138,6 +139,7 @@ func Command() *cobra.Command {
 	_ = cmd.MarkFlagDirname("kindsys-core")
 	_ = cmd.MarkFlagDirname("kindsys-custom")
 	_ = cmd.MarkFlagDirname("kind-registry")
+	_ = cmd.MarkFlagDirname("jsonschema-registry")
 	_ = cmd.MarkFlagFilename("jsonschema")
 	_ = cmd.MarkFlagDirname("openapi")
 	_ = cmd.MarkFlagDirname("output")

--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -118,14 +118,14 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.VeneerConfigFiles, "veneer", "c", nil, "Veneer configuration file.")
 	cmd.Flags().StringArrayVar(&opts.VeneerConfigDirectories, "veneers", nil, "Veneer configuration directories.")
 
-	cmd.Flags().StringArrayVar(&opts.CueEntrypoints, "cue", nil, "CUE input schema.")                                                  // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysCoreEntrypoints, "kindsys-core", nil, "Kindys core kinds input schema.")                   // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysComposableEntrypoints, "kindsys-composable", nil, "Kindys composable kinds input schema.") // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysCustomEntrypoints, "kindsys-custom", nil, "Kindys custom kinds input schema.")             // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
-	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
-	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.CueEntrypoints, "cue", nil, "CUE input schema.")                                                                                                           // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysCoreEntrypoints, "kindsys-core", nil, "Kindys core kinds input schema.")                                                                            // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysComposableEntrypoints, "kindsys-composable", nil, "Kindys composable kinds input schema.")                                                          // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysCustomEntrypoints, "kindsys-custom", nil, "Kindys custom kinds input schema.")                                                                      // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                                                                                      // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                                                                               // TODO: better usage text
+	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                                                                                  // TODO: better usage text
+	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input. This flag is totally experimental and it could be deleted in forward versions.") // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")

--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -40,6 +40,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.LoaderOptions.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
 	cmd.Flags().StringArrayVar(&opts.LoaderOptions.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
 	cmd.Flags().StringVar(&opts.LoaderOptions.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
+	cmd.Flags().StringVar(&opts.LoaderOptions.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.LoaderOptions.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.LoaderOptions.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")
@@ -48,6 +49,7 @@ func Command() *cobra.Command {
 	_ = cmd.MarkFlagDirname("kindsys-core")
 	_ = cmd.MarkFlagDirname("kindsys-custom")
 	_ = cmd.MarkFlagDirname("kind-registry")
+	_ = cmd.MarkFlagDirname("jsonschema-registry")
 	_ = cmd.MarkFlagFilename("jsonschema")
 	_ = cmd.MarkFlagDirname("openapi")
 

--- a/cmd/cli/loaders/cue.go
+++ b/cmd/cli/loaders/cue.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yalue/merged_fs"
 )
 
-func cueLoader(opts Options) ([]*ast.Schema, error) {
+func cueLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/jsonregistry.go
+++ b/cmd/cli/loaders/jsonregistry.go
@@ -1,0 +1,118 @@
+package loaders
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jsonschema"
+)
+
+func jsonschemaRegistryLoader(opts Options) ([]*ast.Schema, error) {
+	var allSchemas []*ast.Schema
+
+	if opts.JSONSchemaRegistryPath == "" {
+		return nil, nil
+	}
+
+	coreEntrypoints, err := locateJSONEntrypoints(opts, "core")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate core entrypoints: %w", err)
+	}
+
+	panelsEntrypoints, err := locateJSONEntrypoints(opts, "panels")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate panel entrypoints: %w", err)
+	}
+
+	dataqueriesEntrypoints, err := locateJSONEntrypoints(opts, "dataqueries")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate dataqueries entrypoints: %w", err)
+	}
+
+	coreSchemas, err := loadJSONEntryPoints(coreEntrypoints, ast.SchemaMeta{
+		Kind: ast.SchemaKindCore,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	panelSchemas, err := loadJSONEntryPoints(panelsEntrypoints, ast.SchemaMeta{
+		Kind:    ast.SchemaKindComposable,
+		Variant: ast.SchemaVariantPanel,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dataqueriesSchemas, err := loadJSONEntryPoints(dataqueriesEntrypoints, ast.SchemaMeta{
+		Kind:    ast.SchemaKindComposable,
+		Variant: ast.SchemaVariantDataQuery,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	allSchemas = append(allSchemas, coreSchemas...)
+	allSchemas = append(allSchemas, panelSchemas...)
+	allSchemas = append(allSchemas, dataqueriesSchemas...)
+
+	return allSchemas, nil
+}
+
+func loadJSONEntryPoints(entrypoints []string, schemaMeta ast.SchemaMeta) ([]*ast.Schema, error) {
+	allSchemas := make([]*ast.Schema, 0, len(entrypoints))
+	for _, entrypoint := range entrypoints {
+		reader, err := os.Open(entrypoint)
+		if err != nil {
+			return nil, err
+		}
+
+		pkg := guessPackageFromFilename(entrypoint)
+
+		meta := schemaMeta
+		meta.Identifier = pkg
+
+		schemaAst, err := jsonschema.GenerateAST(reader, jsonschema.Config{
+			Package:        pkg,
+			SchemaMetadata: meta,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		allSchemas = append(allSchemas, schemaAst)
+	}
+
+	return allSchemas, nil
+}
+
+func locateJSONEntrypoints(opts Options, kind string) ([]string, error) {
+	directory := filepath.Join(opts.JSONSchemaRegistryPath, kind)
+
+	var results []string
+	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		results = append(results, path)
+
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/cmd/cli/loaders/jsonregistry.go
+++ b/cmd/cli/loaders/jsonregistry.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/cog/internal/jsonschema"
 )
 
-func jsonschemaRegistryLoader(opts Options) ([]*ast.Schema, error) {
+func jsonschemaRegistryLoader(opts Options) (ast.Schemas, error) {
 	var allSchemas []*ast.Schema
 
 	if opts.JSONSchemaRegistryPath == "" {

--- a/cmd/cli/loaders/jsonschema.go
+++ b/cmd/cli/loaders/jsonschema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/cog/internal/jsonschema"
 )
 
-func jsonschemaLoader(opts Options) ([]*ast.Schema, error) {
+func jsonschemaLoader(opts Options) (ast.Schemas, error) {
 	allSchemas := make([]*ast.Schema, 0, len(opts.JSONSchemaEntrypoints))
 	for _, entrypoint := range opts.JSONSchemaEntrypoints {
 		reader, err := os.Open(entrypoint)

--- a/cmd/cli/loaders/kindregistry.go
+++ b/cmd/cli/loaders/kindregistry.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 )
 
-func kindRegistryLoader(opts Options) ([]*ast.Schema, error) {
+func kindRegistryLoader(opts Options) (ast.Schemas, error) {
 	var allSchemas []*ast.Schema
 
 	if opts.KindRegistryPath == "" {

--- a/cmd/cli/loaders/kindsyscomposable.go
+++ b/cmd/cli/loaders/kindsyscomposable.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysComposableLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysComposableLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/kindsyscore.go
+++ b/cmd/cli/loaders/kindsyscore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysCoreLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysCoreLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/kindsyscustom.go
+++ b/cmd/cli/loaders/kindsyscustom.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysCustomLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysCustomLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/openapi.go
+++ b/cmd/cli/loaders/openapi.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/cog/internal/openapi"
 )
 
-func openapiLoader(opts Options) ([]*ast.Schema, error) {
+func openapiLoader(opts Options) (ast.Schemas, error) {
 	allSchemas := make([]*ast.Schema, 0, len(opts.OpenAPIEntrypoints))
 	for _, entrypoint := range opts.OpenAPIEntrypoints {
 		schemaAst, err := openapi.GenerateAST(entrypoint, openapi.Config{

--- a/cmd/cli/loaders/options.go
+++ b/cmd/cli/loaders/options.go
@@ -12,24 +12,26 @@ import (
 type LoaderRef string
 
 const (
-	CUE               LoaderRef = "cue"
-	KindsysCore       LoaderRef = "kindsys-core"
-	KindsysComposable LoaderRef = "kindsys-composable"
-	KindsysCustom     LoaderRef = "kindsys-custom"
-	JSONSchema        LoaderRef = "jsonschema"
-	OpenAPI           LoaderRef = "openapi"
-	KindRegistry      LoaderRef = "kind-registry"
+	CUE                LoaderRef = "cue"
+	KindsysCore        LoaderRef = "kindsys-core"
+	KindsysComposable  LoaderRef = "kindsys-composable"
+	KindsysCustom      LoaderRef = "kindsys-custom"
+	JSONSchema         LoaderRef = "jsonschema"
+	OpenAPI            LoaderRef = "openapi"
+	KindRegistry       LoaderRef = "kind-registry"
+	JSONSchemaRegistry LoaderRef = "jsonschema-registry"
 )
 
 func loadersMap() map[LoaderRef]Loader {
 	return map[LoaderRef]Loader{
-		CUE:               cueLoader,
-		KindsysCore:       kindsysCoreLoader,
-		KindsysComposable: kindsysComposableLoader,
-		KindsysCustom:     kindsysCustomLoader,
-		JSONSchema:        jsonschemaLoader,
-		OpenAPI:           openapiLoader,
-		KindRegistry:      kindRegistryLoader,
+		CUE:                cueLoader,
+		KindsysCore:        kindsysCoreLoader,
+		KindsysComposable:  kindsysComposableLoader,
+		KindsysCustom:      kindsysCustomLoader,
+		JSONSchema:         jsonschemaLoader,
+		OpenAPI:            openapiLoader,
+		KindRegistry:       kindRegistryLoader,
+		JSONSchemaRegistry: jsonschemaRegistryLoader,
 	}
 }
 
@@ -43,6 +45,7 @@ type Options struct {
 	JSONSchemaEntrypoints        []string
 	OpenAPIEntrypoints           []string
 	KindRegistryPath             string
+	JSONSchemaRegistryPath       string
 
 	// Cue-specific options
 	CueImports []string

--- a/cmd/cli/loaders/options.go
+++ b/cmd/cli/loaders/options.go
@@ -35,7 +35,7 @@ func loadersMap() map[LoaderRef]Loader {
 	}
 }
 
-type Loader func(opts Options) ([]*ast.Schema, error)
+type Loader func(opts Options) (ast.Schemas, error)
 
 type Options struct {
 	CueEntrypoints               []string
@@ -86,8 +86,8 @@ func ForSchemaType(schemaType LoaderRef) (Loader, error) {
 	return loader, nil
 }
 
-func LoadAll(opts Options) ([]*ast.Schema, error) {
-	var allSchemas []*ast.Schema
+func LoadAll(opts Options) (ast.Schemas, error) {
+	var allSchemas ast.Schemas
 
 	for loaderRef := range loadersMap() {
 		loader, err := ForSchemaType(loaderRef)
@@ -103,7 +103,7 @@ func LoadAll(opts Options) ([]*ast.Schema, error) {
 		allSchemas = append(allSchemas, schemas...)
 	}
 
-	return allSchemas, nil
+	return allSchemas.Consolidate()
 }
 
 func guessPackageFromFilename(filename string) string {

--- a/internal/ast/compiler/anonymous_enum_test.go
+++ b/internal/ast/compiler/anonymous_enum_test.go
@@ -4,19 +4,19 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestAnonymousEnumToExplicitType_withNoAnonymousEnum(t *testing.T) {
 	// Prepare test input
 	schema := &ast.Schema{
 		Package: "without_enums",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("without_enums", "AString", ast.String()),
-
 			ast.NewObject("without_enums", "AStruct", ast.NewStruct(
 				ast.NewStructField("AString", ast.String()),
 			)),
-		},
+		),
 	}
 
 	// Run the compiler pass
@@ -27,7 +27,7 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInStruct(t *testing.T) {
 	// Prepare test input
 	schema := &ast.Schema{
 		Package: "with_enums",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("with_enums", "Panel", ast.NewStruct(
 				ast.NewStructField("title", ast.String()),
 				ast.NewStructField("type", ast.NewEnum([]ast.EnumValue{
@@ -39,27 +39,27 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInStruct(t *testing.T) {
 				{Name: "Auto", Value: "auto", Type: ast.String()},
 				{Name: "Manual", Value: "manual", Type: ast.String()},
 			})),
-		},
+		),
 	}
 
 	// Prepare expected output
 	expected := &ast.Schema{
 		Package: "with_enums",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("with_enums", "Panel", ast.NewStruct(
 				ast.NewStructField("title", ast.String()),
 				ast.NewStructField("type", ast.NewRef("with_enums", "PanelType")),
 			)),
 
 			// this object is unchanged
-			schema.Objects[1],
+			schema.Objects.Get("Mode"),
 
 			// the anonymous enum, turned into an object
 			ast.NewObject("with_enums", "PanelType", ast.NewEnum([]ast.EnumValue{
 				{Name: "Foo", Value: "foo", Type: ast.String()},
 				{Name: "Bar", Value: "bar", Type: ast.String()},
 			})),
-		},
+		),
 	}
 
 	// Run the compiler pass
@@ -70,20 +70,20 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInArray(t *testing.T) {
 	// Prepare test input
 	schema := &ast.Schema{
 		Package: "in_array",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("in_array", "TypesList", ast.NewArray(
 				ast.NewEnum([]ast.EnumValue{
 					{Name: "Foo", Value: "foo", Type: ast.String()},
 					{Name: "Bar", Value: "bar", Type: ast.String()},
 				}),
 			)),
-		},
+		),
 	}
 
 	// Prepare expected output
 	expected := &ast.Schema{
 		Package: "in_array",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("in_array", "TypesList", ast.NewArray(
 				ast.NewRef("in_array", "TypesListEnum")),
 			),
@@ -93,7 +93,7 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInArray(t *testing.T) {
 				{Name: "Foo", Value: "foo", Type: ast.String()},
 				{Name: "Bar", Value: "bar", Type: ast.String()},
 			})),
-		},
+		),
 	}
 
 	// Run the compiler pass

--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -44,13 +44,12 @@ func (pass *AnonymousStructsToNamed) Process(schemas []*ast.Schema) ([]*ast.Sche
 }
 
 func (pass *AnonymousStructsToNamed) processSchema(schema *ast.Schema) *ast.Schema {
-	pass.newObjects = make([]ast.Object, 0, len(schema.Objects))
-	for _, object := range schema.Objects {
-		newObj := pass.processObject(object)
-		pass.newObjects = append(pass.newObjects, newObj)
-	}
+	pass.newObjects = nil
 
-	schema.Objects = pass.newObjects
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object)
+	})
+	schema.AddObjects(pass.newObjects...)
 
 	return schema
 }

--- a/internal/ast/compiler/dashboard.go
+++ b/internal/ast/compiler/dashboard.go
@@ -22,12 +22,13 @@ func (pass *Dashboard) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
 }
 
 func (pass *Dashboard) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if schema.Package == dashboardPackage && object.Name == dashboardObject {
-			schema.Objects[i] = pass.processDashboard(object)
-			continue
+			return pass.processDashboard(object)
 		}
-	}
+
+		return object
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/dashboardpanels_test.go
+++ b/internal/ast/compiler/dashboardpanels_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestDashboardPanelsRewrite(t *testing.T) {
@@ -11,16 +12,16 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: "team",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("team", "Team", ast.NewStruct(
 					ast.NewStructField("Name", ast.String()),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
 			Package: "dashboard",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("dashboard", "Panel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
 					ast.NewStructField("Type", ast.String()),
@@ -45,7 +46,7 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 						ast.NewRef("dashboard", "GraphPanel"),
 					}))),
 				)),
-			},
+			),
 		},
 	}
 
@@ -57,7 +58,7 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 		// The panels field are rewritten for RowPanel and Dashboard
 		&ast.Schema{
 			Package: "dashboard",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("dashboard", "Panel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
 					ast.NewStructField("Type", ast.String()),
@@ -81,7 +82,7 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 						ast.DiscriminatorCatchAll: "Panel",
 					})))),
 				)),
-			},
+			),
 		},
 	}
 

--- a/internal/ast/compiler/dashboardtargets.go
+++ b/internal/ast/compiler/dashboardtargets.go
@@ -45,18 +45,14 @@ func (pass *DashboardTargetsRewrite) Process(schemas []*ast.Schema) ([]*ast.Sche
 }
 
 func (pass *DashboardTargetsRewrite) processSchema(schema *ast.Schema) *ast.Schema {
-	newSchema := schema.DeepCopy()
-	newSchema.Objects = nil
+	schema.Objects = schema.Objects.Filter(func(_ string, object ast.Object) bool {
+		return object.Name != dashboardTargetObject
+	})
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object)
+	})
 
-	for _, object := range schema.Objects {
-		if object.Name == dashboardTargetObject {
-			continue
-		}
-
-		newSchema.Objects = append(newSchema.Objects, pass.processObject(object))
-	}
-
-	return &newSchema
+	return schema
 }
 
 func (pass *DashboardTargetsRewrite) processObject(object ast.Object) ast.Object {

--- a/internal/ast/compiler/dashboardtargets_test.go
+++ b/internal/ast/compiler/dashboardtargets_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestDashboardTargetsRewrite_withNoRefToTarget(t *testing.T) {
@@ -11,24 +12,24 @@ func TestDashboardTargetsRewrite_withNoRefToTarget(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: dashboardPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(dashboardPackage, "RefToStruct", ast.NewRef(dashboardPackage, "AStruct")),
 
 				ast.NewObject(dashboardPackage, "AStruct", ast.NewStruct(
 					ast.NewStructField("AString", ast.String()),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
 			Package: "not_dashboard_package",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("not_dashboard_package", "RefToTarget", ast.NewRef("not_dashboard_package", dashboardTargetObject)),
 
 				ast.NewObject("not_dashboard_package", "AStruct", ast.NewStruct(
 					ast.NewStructField("AString", ast.String()),
 				)),
-			},
+			),
 		},
 	}
 
@@ -40,7 +41,7 @@ func TestDashboardTargetsRewrite_withRefToTarget(t *testing.T) {
 	// Prepare test input
 	schema := &ast.Schema{
 		Package: dashboardPackage,
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject(dashboardPackage, "RefToTarget", ast.NewRef(dashboardPackage, dashboardTargetObject)),
 
 			ast.NewObject(dashboardPackage, "AStruct", ast.NewStruct(
@@ -52,7 +53,7 @@ func TestDashboardTargetsRewrite_withRefToTarget(t *testing.T) {
 					ast.NewRef(dashboardPackage, dashboardTargetObject),
 				})),
 			)),
-		},
+		),
 	}
 
 	dataqueryComposableSlotType := ast.NewComposableSlot(ast.SchemaVariantDataQuery)
@@ -60,7 +61,7 @@ func TestDashboardTargetsRewrite_withRefToTarget(t *testing.T) {
 	// Prepare expected output
 	expected := &ast.Schema{
 		Package: dashboardPackage,
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject(dashboardPackage, "RefToTarget", dataqueryComposableSlotType),
 
 			ast.NewObject(dashboardPackage, "AStruct", ast.NewStruct(
@@ -72,7 +73,7 @@ func TestDashboardTargetsRewrite_withRefToTarget(t *testing.T) {
 					dataqueryComposableSlotType,
 				})),
 			)),
-		},
+		),
 	}
 
 	// Run the compiler pass

--- a/internal/ast/compiler/dashboardtimepicker.go
+++ b/internal/ast/compiler/dashboardtimepicker.go
@@ -55,19 +55,19 @@ func (pass *DashboardTimePicker) processSchema(schema *ast.Schema) (*ast.Schema,
 	var timepickerObject ast.Object
 	var dashboardObj ast.Object
 
-	for i, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if object.Name != dashboardObject {
-			continue
+			return object
 		}
 
 		dashboardObj, timepickerObject = pass.processDashboard(object)
 
-		schema.Objects[i] = dashboardObj
-	}
+		return dashboardObj
+	})
 
 	// did we actually define a new object?
 	if timepickerObject.Name != "" {
-		schema.Objects = append(schema.Objects, timepickerObject)
+		schema.AddObject(timepickerObject)
 	}
 
 	return schema, nil

--- a/internal/ast/compiler/dashboardtimepicker_test.go
+++ b/internal/ast/compiler/dashboardtimepicker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestDashboardTimePicker(t *testing.T) {
@@ -11,16 +12,16 @@ func TestDashboardTimePicker(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: "team",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("team", "Team", ast.NewStruct(
 					ast.NewStructField("Name", ast.String()),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
 			Package: "dashboard",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("dashboard", "Panel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
 				)),
@@ -30,7 +31,7 @@ func TestDashboardTimePicker(t *testing.T) {
 						ast.NewStructField("refresh_intervals", ast.NewArray(ast.String())),
 					)),
 				)),
-			},
+			),
 		},
 	}
 
@@ -42,7 +43,7 @@ func TestDashboardTimePicker(t *testing.T) {
 		// The timepicker is no longer an anonymous struct
 		&ast.Schema{
 			Package: "dashboard",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("dashboard", "Panel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
 				)),
@@ -53,7 +54,7 @@ func TestDashboardTimePicker(t *testing.T) {
 				ast.NewObject("dashboard", "TimePicker", ast.NewStruct(
 					ast.NewStructField("refresh_intervals", ast.NewArray(ast.String())),
 				)),
-			},
+			),
 		},
 	}
 

--- a/internal/ast/compiler/dataquery_identification.go
+++ b/internal/ast/compiler/dataquery_identification.go
@@ -25,12 +25,11 @@ func (pass *DataqueryIdentification) Process(schemas []*ast.Schema) ([]*ast.Sche
 }
 
 func (pass *DataqueryIdentification) processSchema(schema *ast.Schema, commonDataquery ast.Object) *ast.Schema {
-	newSchema := schema.DeepCopy()
-	for i, object := range schema.Objects {
-		newSchema.Objects[i] = pass.processObject(object, commonDataquery)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object, commonDataquery)
+	})
 
-	return &newSchema
+	return schema
 }
 
 func (pass *DataqueryIdentification) processObject(object ast.Object, commonDataquery ast.Object) ast.Object {

--- a/internal/ast/compiler/disjunctions_infer_mapping.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping.go
@@ -34,12 +34,17 @@ func (pass *DisjunctionInferMapping) Process(schemas []*ast.Schema) ([]*ast.Sche
 
 func (pass *DisjunctionInferMapping) processSchema(schema *ast.Schema) (*ast.Schema, error) {
 	var err error
-
-	for i, object := range schema.Objects {
-		schema.Objects[i], err = pass.processObject(schema, object)
-		if err != nil {
-			return nil, err
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		processedObject, innerErr := pass.processObject(schema, object)
+		if innerErr != nil {
+			err = innerErr
+			return object
 		}
+
+		return processedObject
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return schema, nil

--- a/internal/ast/compiler/disjunctions_infer_mapping_test.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +61,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 	req := require.New(t)
 
 	// Prepare test input
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
 			ast.NewRef("test", "SomeStruct"),
 			ast.NewRef("test", "OtherStruct"),
@@ -74,7 +75,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
 			ast.NewStructField("FieldBar", ast.Bool()),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionInferMapping{}
 	_, err := compilerPass.Process([]*ast.Schema{
@@ -95,7 +96,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 	})
 	disjunctionType.Disjunction.Discriminator = "MapOfString"
 
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
 
 		ast.NewObject("test", "SomeStruct", ast.NewStruct(
@@ -106,7 +107,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 			ast.NewStructField("FieldBar", ast.Bool()),
 			ast.NewStructField("MapOfString", ast.NewMap(ast.String(), ast.String())),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionInferMapping{}
 	_, err := compilerPass.Process([]*ast.Schema{
@@ -127,7 +128,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 	})
 	disjunctionType.Disjunction.Discriminator = "Type"
 
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
 
 		ast.NewObject("test", "SomeStruct", ast.NewStruct(
@@ -138,7 +139,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
 			ast.NewStructField("FieldBar", ast.Bool()),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionInferMapping{}
 	_, err := compilerPass.Process([]*ast.Schema{
@@ -159,7 +160,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 	})
 	disjunctionType.Disjunction.Discriminator = "DoesNotExist"
 
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
 
 		ast.NewObject("test", "SomeStruct", ast.NewStruct(
@@ -170,7 +171,7 @@ func TestDisjunctionInferMapping_WithDisjunctionOfRefs_AsAnObject_NoDiscriminato
 			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
 			ast.NewStructField("FieldBar", ast.Bool()),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionInferMapping{}
 	_, err := compilerPass.Process([]*ast.Schema{

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -186,7 +187,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 	req := require.New(t)
 
 	// Prepare test input
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewDisjunction([]ast.Type{
 			ast.NewRef("test", "SomeStruct"),
 			ast.NewRef("test", "OtherStruct"),
@@ -200,7 +201,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_NoDiscriminatorMetad
 			ast.NewStructField("FieldBar", ast.NewMap(ast.String(), ast.String())),
 			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionToType{}
 	_, err := compilerPass.Process([]*ast.Schema{
@@ -222,7 +223,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 	// Mapping omitted: it will be inferred
 	disjunctionType.Disjunction.Discriminator = "Kind"
 
-	objects := []ast.Object{
+	objects := testutils.ObjectsMap(
 		ast.NewObject("test", "ADisjunctionOfRefs", disjunctionType),
 
 		ast.NewObject("test", "SomeStruct", ast.NewStruct(
@@ -235,7 +236,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 			ast.NewStructField("Kind", ast.String(ast.Value("other-kind"))),
 			ast.NewStructField("FieldBar", ast.Bool()),
 		)),
-	}
+	)
 
 	compilerPass := &DisjunctionToType{}
 	_, err := compilerPass.Process([]*ast.Schema{

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -41,9 +41,9 @@ func (pass *DisjunctionWithNullToOptional) Process(schemas []*ast.Schema) ([]*as
 }
 
 func (pass *DisjunctionWithNullToOptional) processSchema(schema *ast.Schema) (*ast.Schema, error) {
-	for i, object := range schema.Objects {
-		schema.Objects[i] = pass.processObject(object)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object)
+	})
 
 	return schema, nil
 }

--- a/internal/ast/compiler/flatten_disjunctions.go
+++ b/internal/ast/compiler/flatten_disjunctions.go
@@ -52,9 +52,9 @@ func (pass *FlattenDisjunctions) Process(schemas []*ast.Schema) ([]*ast.Schema, 
 }
 
 func (pass *FlattenDisjunctions) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
-		schema.Objects[i] = pass.processObject(schema, object)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(schema, object)
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/googlecloudmonitoring.go
+++ b/internal/ast/compiler/googlecloudmonitoring.go
@@ -40,23 +40,18 @@ func (pass *GoogleCloudMonitoring) Process(schemas []*ast.Schema) ([]*ast.Schema
 }
 
 func (pass *GoogleCloudMonitoring) processSchema(schema *ast.Schema) (*ast.Schema, error) {
-	newSchema := schema.DeepCopy()
-	newSchema.Objects = nil
-
-	for _, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if object.Name == "CloudMonitoringQuery" {
-			newSchema.Objects = append(newSchema.Objects, pass.processCloudMonitoringQuery(object))
-			continue
+			return pass.processCloudMonitoringQuery(object)
 		}
 		if object.Name == "TimeSeriesList" {
-			newSchema.Objects = append(newSchema.Objects, pass.processTimeSeriesList(object))
-			continue
+			return pass.processTimeSeriesList(object)
 		}
 
-		newSchema.Objects = append(newSchema.Objects, object)
-	}
+		return object
+	})
 
-	return &newSchema, nil
+	return schema, nil
 }
 
 func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object) ast.Object {

--- a/internal/ast/compiler/librarypanels.go
+++ b/internal/ast/compiler/librarypanels.go
@@ -45,19 +45,15 @@ func (pass *LibraryPanels) Process(schemas []*ast.Schema) ([]*ast.Schema, error)
 }
 
 func (pass *LibraryPanels) parseSchema(schema *ast.Schema, dashboardPanel ast.Object) *ast.Schema {
-	newSchema := schema.DeepCopy()
-	newSchema.Objects = nil
-
-	for _, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if object.Name != libraryPanelObject {
-			newSchema.Objects = append(newSchema.Objects, object)
-			continue
+			return object
 		}
 
-		newSchema.Objects = append(newSchema.Objects, pass.processLibraryPanel(object, dashboardPanel))
-	}
+		return pass.processLibraryPanel(object, dashboardPanel)
+	})
 
-	return &newSchema
+	return schema
 }
 
 func (pass *LibraryPanels) processLibraryPanel(object ast.Object, dashboardPanel ast.Object) ast.Object {

--- a/internal/ast/compiler/librarypanels_test.go
+++ b/internal/ast/compiler/librarypanels_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestLibraryPanels_withNoLibraryPanel(t *testing.T) {
@@ -11,11 +12,11 @@ func TestLibraryPanels_withNoLibraryPanel(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: dashboardPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(dashboardPackage, dashboardPanelObject, ast.NewStruct(
 					ast.NewStructField("AString", ast.String()),
 				)),
-			},
+			),
 		},
 	}
 
@@ -28,11 +29,11 @@ func TestLibraryPanels_withNoPanel(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: libraryPanelPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(libraryPanelObject, libraryPanelObject, ast.NewStruct(
 					ast.NewStructField(libraryPanelModelField, ast.Any()),
 				)),
-			},
+			),
 		},
 	}
 
@@ -45,7 +46,7 @@ func TestLibraryPanels_rewrite(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: dashboardPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(dashboardPackage, dashboardPanelObject, ast.NewStruct(
 					ast.NewStructField(dashboardPanelIDField, ast.String()),
 					ast.NewStructField(dashboardPanelGridPosField, ast.Any()),
@@ -53,17 +54,17 @@ func TestLibraryPanels_rewrite(t *testing.T) {
 					ast.NewStructField(dashboardPanelTypeField, ast.String()),
 					ast.NewStructField(dashboardPanelsField, ast.NewArray(ast.Any())),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
 			Package: libraryPanelPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(libraryPanelObject, libraryPanelObject, ast.NewStruct(
 					ast.NewStructField("uid", ast.String()),
 					ast.NewStructField(libraryPanelModelField, ast.Any()),
 				)),
-			},
+			),
 		},
 	}
 
@@ -74,7 +75,7 @@ func TestLibraryPanels_rewrite(t *testing.T) {
 
 		&ast.Schema{
 			Package: libraryPanelPackage,
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject(libraryPanelObject, libraryPanelObject, ast.NewStruct(
 					ast.NewStructField("uid", ast.String()),
 					ast.NewStructField(libraryPanelModelField, ast.NewStruct(
@@ -82,7 +83,7 @@ func TestLibraryPanels_rewrite(t *testing.T) {
 						ast.NewStructField(dashboardPanelsField, ast.NewArray(ast.Any())),
 					)),
 				)),
-			},
+			),
 		},
 	}
 

--- a/internal/ast/compiler/not_required_as_nullable.go
+++ b/internal/ast/compiler/not_required_as_nullable.go
@@ -20,9 +20,9 @@ func (pass *NotRequiredFieldAsNullableType) Process(schemas []*ast.Schema) ([]*a
 }
 
 func (pass *NotRequiredFieldAsNullableType) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
-		schema.Objects[i] = pass.processObject(object)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object)
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/prefix_enum_values.go
+++ b/internal/ast/compiler/prefix_enum_values.go
@@ -33,9 +33,11 @@ func (pass *PrefixEnumValues) Process(schemas []*ast.Schema) ([]*ast.Schema, err
 }
 
 func (pass *PrefixEnumValues) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
-		schema.Objects[i].Type = pass.processType(object.Name, object.Type)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		object.Type = pass.processType(object.Name, object.Type)
+
+		return object
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/prometheusdataquery.go
+++ b/internal/ast/compiler/prometheusdataquery.go
@@ -19,11 +19,13 @@ func (pass *PrometheusDataquery) Process(schemas []*ast.Schema) ([]*ast.Schema, 
 }
 
 func (pass *PrometheusDataquery) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if schema.Package == prometheusPackage && object.Name == prometheusDataqueryObject {
-			schema.Objects[i] = pass.processDataquery(object)
+			return pass.processDataquery(object)
 		}
-	}
+
+		return object
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/rename_numeric_enum_values.go
+++ b/internal/ast/compiler/rename_numeric_enum_values.go
@@ -34,9 +34,11 @@ func (pass *RenameNumericEnumValues) Process(schemas []*ast.Schema) ([]*ast.Sche
 }
 
 func (pass *RenameNumericEnumValues) processSchema(schema *ast.Schema) *ast.Schema {
-	for i, object := range schema.Objects {
-		schema.Objects[i].Type = pass.processType(object.Type)
-	}
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		object.Type = pass.processType(object.Type)
+
+		return object
+	})
 
 	return schema
 }

--- a/internal/ast/compiler/testdata.go
+++ b/internal/ast/compiler/testdata.go
@@ -57,20 +57,20 @@ func (t TestData) processSchema(schema *ast.Schema) *ast.Schema {
 		return schema
 	}
 
-	var obj ast.Object
+	var processed ast.Object
 	var keyObject ast.Object
 
-	for i, object := range schema.Objects {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if object.Name != testDataSimulatorQueryObject {
-			continue
+			return object
 		}
 
-		obj, keyObject = t.processObject(object)
-		schema.Objects[i] = obj
-	}
+		processed, keyObject = t.processObject(object)
+		return processed
+	})
 
 	if keyObject.Name != "" {
-		schema.Objects = append(schema.Objects, keyObject)
+		schema.AddObject(keyObject)
 	}
 
 	return schema

--- a/internal/ast/compiler/unspec_test.go
+++ b/internal/ast/compiler/unspec_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 )
 
 func TestUnspec(t *testing.T) {
@@ -11,25 +12,25 @@ func TestUnspec(t *testing.T) {
 	schemas := ast.Schemas{
 		&ast.Schema{
 			Package: "without_spec",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("without_spec", "NotAStruct", ast.String()),
 
 				ast.NewObject("without_spec", "AStruct", ast.NewStruct(
 					ast.NewStructField("AString", ast.String()),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
 			Package: "with_spec_no_meta_id",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_no_meta_id", "Metadata", ast.NewStruct(
 					ast.NewStructField("SomeMeta", ast.String()),
 				)),
 				ast.NewObject("with_spec_no_meta_id", "Spec", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
 				)),
-			},
+			),
 		},
 
 		&ast.Schema{
@@ -37,14 +38,14 @@ func TestUnspec(t *testing.T) {
 			Metadata: ast.SchemaMeta{
 				Identifier: "Dashboard",
 			},
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_and_meta_id", "Metadata", ast.NewStruct(
 					ast.NewStructField("SomeMeta", ast.String()),
 				)),
 				ast.NewObject("with_spec_and_meta_id", "Spec", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
 				)),
-			},
+			),
 		},
 	}
 
@@ -56,11 +57,11 @@ func TestUnspec(t *testing.T) {
 		// No identifier defined in schema metadata: the package is used as name instead of "Spec"
 		&ast.Schema{
 			Package: "with_spec_no_meta_id",
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_no_meta_id", "with_spec_no_meta_id", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
 				)),
-			},
+			),
 		},
 
 		// Identifier defined in the schema metadata: it's used as object name instead of "Spec"
@@ -69,11 +70,11 @@ func TestUnspec(t *testing.T) {
 			Metadata: ast.SchemaMeta{
 				Identifier: "Dashboard",
 			},
-			Objects: []ast.Object{
+			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_and_meta_id", "Dashboard", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
 				)),
-			},
+			),
 		},
 	}
 

--- a/internal/ast/compiler/utils_test.go
+++ b/internal/ast/compiler/utils_test.go
@@ -11,8 +11,11 @@ import (
 func runPassOnObjects(t *testing.T, pass Pass, input []ast.Object, expectedOutput []ast.Object) {
 	t.Helper()
 
-	inputSchema := &ast.Schema{Package: "test", Objects: input}
-	expectedOutputSchema := &ast.Schema{Package: "test", Objects: expectedOutput}
+	inputSchema := ast.NewSchema("test", ast.SchemaMeta{})
+	inputSchema.AddObjects(input...)
+
+	expectedOutputSchema := ast.NewSchema("test", ast.SchemaMeta{})
+	expectedOutputSchema.AddObjects(expectedOutput...)
 
 	runPassOnSchema(t, pass, inputSchema, expectedOutputSchema)
 }

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Kind string
@@ -475,6 +477,13 @@ func NewObject(pkg string, name string, objectType Type) Object {
 			ReferredType: name,
 		},
 	}
+}
+
+func (object Object) Equal(other Object) bool {
+	return object.Name == other.Name &&
+		cmp.Equal(object.Comments, other.Comments) &&
+		cmp.Equal(object.Type, other.Type) &&
+		cmp.Equal(object.SelfRef, other.SelfRef)
 }
 
 func (object Object) DeepCopy() Object {

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -40,6 +40,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 }
 
 func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, error) {
+	var err error
 	files := make(codejen.Files, 0)
 	scalars := make(map[string]ast.ScalarType)
 
@@ -53,21 +54,22 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 
 	jenny.typeFormatter = jenny.typeFormatter.withPackageMapper(packageMapper)
 
-	for _, object := range schema.Objects {
+	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		jenny.imports = NewImportMap()
 		if object.Type.IsMap() || object.Type.IsArray() {
-			continue
+			return
 		}
 		if object.Type.IsScalar() {
 			if object.Type.AsScalar().IsConcrete() {
 				scalars[object.Name] = object.Type.AsScalar()
 			}
-			continue
+			return
 		}
 
-		output, err := jenny.generateSchema(schema.Package, object)
-		if err != nil {
-			return nil, err
+		output, innerErr := jenny.generateSchema(schema.Package, object)
+		if innerErr != nil {
+			err = innerErr
+			return
 		}
 
 		filename := filepath.Join(
@@ -76,6 +78,9 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	if len(scalars) > 0 {

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -72,10 +72,7 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 	}
 
 	if c.SchemaMetadata.Variant == ast.SchemaVariantDataQuery || c.SchemaMetadata.Variant == ast.SchemaVariantPanel {
-		root, found := g.schema.LocateObject(rootObjectName)
-		if found {
-			root.Type.Hints[ast.HintImplementsVariant] = string(c.SchemaMetadata.Variant)
-		}
+		g.schema.Objects.Get(rootObjectName).Type.Hints[ast.HintImplementsVariant] = string(c.SchemaMetadata.Variant)
 	}
 
 	// To ensure a consistent output, since github.com/santhosh-tekuri/jsonschema

--- a/internal/jsonschema/generator_test.go
+++ b/internal/jsonschema/generator_test.go
@@ -55,7 +55,7 @@ func TestGenerateAST_parsesEnumValues(t *testing.T) {
 	req.NoError(err)
 	req.NotNil(t, schemaAst)
 
-	enumType := schemaAst.Objects[0].Type.Enum
+	enumType := schemaAst.Objects.At(0).Type.Enum
 
 	req.Equal(int64(1), enumType.Values[0].Value)
 }

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -45,10 +45,7 @@ func GenerateAST(filePath string, cfg Config) (*ast.Schema, error) {
 	}
 
 	g := &generator{
-		schema: &ast.Schema{
-			Package:  cfg.Package,
-			Metadata: cfg.SchemaMetadata,
-		},
+		schema: ast.NewSchema(cfg.Package, cfg.SchemaMetadata),
 	}
 
 	if oapi.Components == nil {
@@ -69,7 +66,7 @@ func (g *generator) declareDefinition(schemas openapi3.Schemas) error {
 			return err
 		}
 
-		g.schema.Objects = append(g.schema.Objects, ast.Object{
+		g.schema.AddObject(ast.Object{
 			Name:     name,
 			Comments: schemaComments(schemaRef.Value),
 			Type:     def,
@@ -79,10 +76,6 @@ func (g *generator) declareDefinition(schemas openapi3.Schemas) error {
 			},
 		})
 	}
-
-	sort.Slice(g.schema.Objects, func(i, j int) bool {
-		return g.schema.Objects[i].Name < g.schema.Objects[j].Name
-	})
 
 	return nil
 }

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -55,6 +56,10 @@ func GenerateAST(filePath string, cfg Config) (*ast.Schema, error) {
 	if err := g.declareDefinition(oapi.Components.Schemas); err != nil {
 		return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
 	}
+
+	// To ensure a consistent output, since github.com/getkin/kin-openapi/openapi3
+	// doesn't guarantee the order of the definitions it parses.
+	g.schema.Objects.Sort(orderedmap.SortStrings)
 
 	return g.schema, nil
 }

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -40,10 +40,7 @@ type generator struct {
 
 func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
 	g := &generator{
-		schema: &ast.Schema{
-			Package:  c.Package,
-			Metadata: c.SchemaMetadata,
-		},
+		schema: ast.NewSchema(c.Package, c.SchemaMetadata),
 		refResolver: newReferenceResolver(val, referenceResolverConfig{
 			Libraries: c.Libraries,
 		}),
@@ -79,7 +76,7 @@ func (g *generator) walkCueSchemaWithVariantEnvelope(v cue.Value) error {
 				return err
 			}
 
-			g.schema.Objects = append(g.schema.Objects, n)
+			g.schema.AddObject(n)
 			continue
 		}
 
@@ -98,7 +95,7 @@ func (g *generator) walkCueSchemaWithVariantEnvelope(v cue.Value) error {
 	structType := ast.NewStruct(rootObjectFields...)
 	structType.Hints[ast.HintImplementsVariant] = string(g.schema.Metadata.Variant)
 
-	g.schema.Objects = append(g.schema.Objects, ast.Object{
+	g.schema.AddObject(ast.Object{
 		Name:     string(g.schema.Metadata.Variant),
 		Comments: commentsFromCueValue(v),
 		Type:     structType,
@@ -125,7 +122,7 @@ func (g *generator) walkCueSchema(v cue.Value) error {
 			return err
 		}
 
-		g.schema.Objects = append(g.schema.Objects, n)
+		g.schema.AddObject(n)
 	}
 
 	return nil

--- a/internal/testutils/orderedmap.go
+++ b/internal/testutils/orderedmap.go
@@ -1,0 +1,14 @@
+package testutils
+
+import (
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
+)
+
+func ObjectsMap(objects ...ast.Object) *orderedmap.Map[string, ast.Object] {
+	ordered := orderedmap.New[string, ast.Object]()
+	for _, object := range objects {
+		ordered.Set(object.Name, object)
+	}
+	return ordered
+}

--- a/internal/veneers/builder/rules_test.go
+++ b/internal/veneers/builder/rules_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +19,7 @@ func TestDuplicate(t *testing.T) {
 		{
 			Schema: &ast.Schema{
 				Package: "pkg",
-				Objects: []ast.Object{originalObject},
+				Objects: testutils.ObjectsMap(originalObject),
 			},
 			For:     originalObject,
 			Package: "pkg",
@@ -57,7 +58,7 @@ func TestInitialize(t *testing.T) {
 		{
 			Schema: &ast.Schema{
 				Package: "pkg",
-				Objects: []ast.Object{originalObject},
+				Objects: testutils.ObjectsMap(originalObject),
 			},
 			For:     originalObject,
 			Package: "pkg",
@@ -77,10 +78,7 @@ func TestInitialize(t *testing.T) {
 	rule := Initialize(
 		ByName("pkg", "Dashboard"),
 		[]Initialization{
-			{
-				PropertyPath: "name",
-				Value:        "great name, isn't it?",
-			},
+			{PropertyPath: "name", Value: "great name, isn't it?"},
 		},
 	)
 	updatedBuilders, err := rule(originalBuilders)

--- a/internal/veneers/option/actions_test.go
+++ b/internal/veneers/option/actions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,11 +120,11 @@ func TestDisjunctionAsOptionsAction_withDisjunctionStruct(t *testing.T) {
 	ref := ast.NewRef("dashboard", "PanelOrRow")
 	schema := &ast.Schema{
 		Package: "dashboard",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("dashboard", "PanelOrRow", panelOrRow),
 			ast.NewObject("dashboard", "Row", rowType),
 			ast.NewObject("dashboard", "Panel", panelType),
-		},
+		),
 	}
 	builder := ast.Builder{Schema: schema}
 
@@ -164,9 +165,9 @@ func TestStructFieldsAsOptionsAction_withRefArg(t *testing.T) {
 	ref := ast.NewRef("dashboard", "Time")
 	schema := &ast.Schema{
 		Package: "dashboard",
-		Objects: []ast.Object{
+		Objects: testutils.ObjectsMap(
 			ast.NewObject("dashboard", "Time", timeType),
-		},
+		),
 	}
 	builder := ast.Builder{Schema: schema}
 

--- a/testdata/jennies/builders/anonymous_struct/builders_context.json
+++ b/testdata/jennies/builders/anonymous_struct/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "anonymous_struct",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -55,7 +55,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -63,8 +63,8 @@
       "Schema": {
         "Package": "anonymous_struct",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -115,7 +115,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/array_append/builders_context.json
+++ b/testdata/jennies/builders/array_append/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "sandbox",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -36,7 +36,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -44,8 +44,8 @@
       "Schema": {
         "Package": "sandbox",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -77,7 +77,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/basic_struct/builders_context.json
+++ b/testdata/jennies/builders/basic_struct/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "basic_struct",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Comments": [
             "SomeStruct, to hold data."
@@ -79,7 +79,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -87,8 +87,8 @@
       "Schema": {
         "Package": "basic_struct",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Comments": [
               "SomeStruct, to hold data."
@@ -163,7 +163,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/basic_struct_defaults/builders_context.json
+++ b/testdata/jennies/builders/basic_struct_defaults/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "basic_struct_defaults",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -76,7 +76,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -84,8 +84,8 @@
       "Schema": {
         "Package": "basic_struct_defaults",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -157,7 +157,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
@@ -49,6 +49,7 @@ func (builder *DashboardBuilder) Title(title string) *DashboardBuilder {
     return builder
 }
 
+// will be expanded to []cog.Builder<DashboardLink>
 func (builder *DashboardBuilder) Links(links []cog.Builder[DashboardLink]) *DashboardBuilder {
         linksResources := make([]DashboardLink, 0, len(links))
         for _, r := range links {
@@ -64,6 +65,7 @@ func (builder *DashboardBuilder) Links(links []cog.Builder[DashboardLink]) *Dash
     return builder
 }
 
+// will be expanded to cog.Builder<DashboardLink>
 func (builder *DashboardBuilder) SingleLink(singleLink cog.Builder[DashboardLink]) *DashboardBuilder {
         singleLinkResource, err := singleLink.Build()
         if err != nil {

--- a/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
+++ b/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
@@ -42,13 +42,21 @@ class Dashboard(cogbuilder.Builder[builder_delegation.Dashboard]):
     
         return self
     
-    def links(self, links: list[cogbuilder.Builder[builder_delegation.DashboardLink]]) -> typing.Self:        
+    def links(self, links: list[cogbuilder.Builder[builder_delegation.DashboardLink]]) -> typing.Self:    
+        """
+        will be expanded to []cog.Builder<DashboardLink>
+        """
+            
         links_resources = [r.build() for r in links]
         self.__internal.links = links_resources
     
         return self
     
-    def single_link(self, single_link: cogbuilder.Builder[builder_delegation.DashboardLink]) -> typing.Self:        
+    def single_link(self, single_link: cogbuilder.Builder[builder_delegation.DashboardLink]) -> typing.Self:    
+        """
+        will be expanded to cog.Builder<DashboardLink>
+        """
+            
         single_link_resource = single_link.build()
         self.__internal.single_link = single_link_resource
     

--- a/testdata/jennies/builders/builder_delegation/TypescriptBuilder/src/builder_delegation/dashboard_builder_gen.ts
+++ b/testdata/jennies/builders/builder_delegation/TypescriptBuilder/src/builder_delegation/dashboard_builder_gen.ts
@@ -22,12 +22,14 @@ export class DashboardBuilder implements cog.Builder<builder_delegation.Dashboar
         return this;
     }
 
+    // will be expanded to []cog.Builder<DashboardLink>
     links(links: cog.Builder<builder_delegation.DashboardLink>[]): this {
         const linksResources = links.map(builder => builder.build());
         this.internal.links = linksResources;
         return this;
     }
 
+    // will be expanded to cog.Builder<DashboardLink>
     singleLink(singleLink: cog.Builder<builder_delegation.DashboardLink>): this {
         const singleLinkResource = singleLink.build();
         this.internal.singleLink = singleLinkResource;

--- a/testdata/jennies/builders/builder_delegation/builders_context.json
+++ b/testdata/jennies/builders/builder_delegation/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "builder_delegation",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "DashboardLink": {
           "Name": "DashboardLink",
           "Type": {
             "Kind": "struct",
@@ -41,7 +41,7 @@
             "ReferredType": "DashboardLink"
           }
         },
-        {
+        "Dashboard": {
           "Name": "Dashboard",
           "Type": {
             "Kind": "struct",
@@ -72,6 +72,9 @@
                 },
                 {
                   "Name": "links",
+                  "Comments": [
+                    "will be expanded to []cog.Builder\u003cDashboardLink\u003e"
+                  ],
                   "Type": {
                     "Kind": "array",
                     "Nullable": false,
@@ -90,6 +93,9 @@
                 },
                 {
                   "Name": "singleLink",
+                  "Comments": [
+                    "will be expanded to cog.Builder\u003cDashboardLink\u003e"
+                  ],
                   "Type": {
                     "Kind": "ref",
                     "Nullable": false,
@@ -108,7 +114,7 @@
             "ReferredType": "Dashboard"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -116,8 +122,8 @@
       "Schema": {
         "Package": "builder_delegation",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "DashboardLink": {
             "Name": "DashboardLink",
             "Type": {
               "Kind": "struct",
@@ -154,7 +160,7 @@
               "ReferredType": "DashboardLink"
             }
           },
-          {
+          "Dashboard": {
             "Name": "Dashboard",
             "Type": {
               "Kind": "struct",
@@ -185,6 +191,9 @@
                   },
                   {
                     "Name": "links",
+                    "Comments": [
+                      "will be expanded to []cog.Builder\u003cDashboardLink\u003e"
+                    ],
                     "Type": {
                       "Kind": "array",
                       "Nullable": false,
@@ -203,6 +212,9 @@
                   },
                   {
                     "Name": "singleLink",
+                    "Comments": [
+                      "will be expanded to cog.Builder\u003cDashboardLink\u003e"
+                    ],
                     "Type": {
                       "Kind": "ref",
                       "Nullable": false,
@@ -221,7 +233,7 @@
               "ReferredType": "Dashboard"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "DashboardLink",
@@ -359,8 +371,8 @@
       "Schema": {
         "Package": "builder_delegation",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "DashboardLink": {
             "Name": "DashboardLink",
             "Type": {
               "Kind": "struct",
@@ -397,7 +409,7 @@
               "ReferredType": "DashboardLink"
             }
           },
-          {
+          "Dashboard": {
             "Name": "Dashboard",
             "Type": {
               "Kind": "struct",
@@ -428,6 +440,9 @@
                   },
                   {
                     "Name": "links",
+                    "Comments": [
+                      "will be expanded to []cog.Builder\u003cDashboardLink\u003e"
+                    ],
                     "Type": {
                       "Kind": "array",
                       "Nullable": false,
@@ -446,6 +461,9 @@
                   },
                   {
                     "Name": "singleLink",
+                    "Comments": [
+                      "will be expanded to cog.Builder\u003cDashboardLink\u003e"
+                    ],
                     "Type": {
                       "Kind": "ref",
                       "Nullable": false,
@@ -464,7 +482,7 @@
               "ReferredType": "Dashboard"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Dashboard",
@@ -497,6 +515,9 @@
               },
               {
                 "Name": "links",
+                "Comments": [
+                  "will be expanded to []cog.Builder\u003cDashboardLink\u003e"
+                ],
                 "Type": {
                   "Kind": "array",
                   "Nullable": false,
@@ -515,6 +536,9 @@
               },
               {
                 "Name": "singleLink",
+                "Comments": [
+                  "will be expanded to cog.Builder\u003cDashboardLink\u003e"
+                ],
                 "Type": {
                   "Kind": "ref",
                   "Nullable": false,
@@ -628,6 +652,9 @@
         },
         {
           "Name": "links",
+          "Comments": [
+            "will be expanded to []cog.Builder\u003cDashboardLink\u003e"
+          ],
           "Args": [
             {
               "Name": "links",
@@ -694,6 +721,9 @@
         },
         {
           "Name": "singleLink",
+          "Comments": [
+            "will be expanded to cog.Builder\u003cDashboardLink\u003e"
+          ],
           "Args": [
             {
               "Name": "singleLink",

--- a/testdata/jennies/builders/composable_slot/builders_context.json
+++ b/testdata/jennies/builders/composable_slot/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "composable_slot",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "Dashboard": {
           "Name": "Dashboard",
           "Type": {
             "Kind": "struct",
@@ -47,7 +47,7 @@
             "ReferredType": "Dashboard"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -55,8 +55,8 @@
       "Schema": {
         "Package": "composable_slot",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "Dashboard": {
             "Name": "Dashboard",
             "Type": {
               "Kind": "struct",
@@ -99,7 +99,7 @@
               "ReferredType": "Dashboard"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Dashboard",

--- a/testdata/jennies/builders/constant_assignment/builders_context.json
+++ b/testdata/jennies/builders/constant_assignment/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "sandbox",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -41,7 +41,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -49,8 +49,8 @@
       "Schema": {
         "Package": "sandbox",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -87,7 +87,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/constraints/builders_context.json
+++ b/testdata/jennies/builders/constraints/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "constraints",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -63,7 +63,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -71,8 +71,8 @@
       "Schema": {
         "Package": "constraints",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -131,7 +131,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/constructor_argument/builders_context.json
+++ b/testdata/jennies/builders/constructor_argument/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "sandbox",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -38,8 +38,8 @@
       "Schema": {
         "Package": "sandbox",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -65,7 +65,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/constructor_initializations/builders_context.json
+++ b/testdata/jennies/builders/constructor_initializations/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "constructor_initializations",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomePanel": {
           "Name": "SomePanel",
           "Type": {
             "Kind": "struct",
@@ -54,7 +54,7 @@
             "ReferredType": "SomePanel"
           }
         },
-        {
+        "CursorMode": {
           "Name": "CursorMode",
           "Type": {
             "Kind": "enum",
@@ -98,7 +98,7 @@
             "ReferredType": "CursorMode"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -106,8 +106,8 @@
       "Schema": {
         "Package": "constructor_initializations",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomePanel": {
             "Name": "SomePanel",
             "Type": {
               "Kind": "struct",
@@ -157,7 +157,7 @@
               "ReferredType": "SomePanel"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomePanel",

--- a/testdata/jennies/builders/dataquery_variant_builder/builders_context.json
+++ b/testdata/jennies/builders/dataquery_variant_builder/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "dataquery_variant_builder",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "Loki": {
           "Name": "Loki",
           "Type": {
             "Kind": "struct",
@@ -33,7 +33,7 @@
             "ReferredType": "Loki"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -41,8 +41,8 @@
       "Schema": {
         "Package": "dataquery_variant_builder",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "Loki": {
             "Name": "Loki",
             "Type": {
               "Kind": "struct",
@@ -71,7 +71,7 @@
               "ReferredType": "Loki"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Loki",

--- a/testdata/jennies/builders/envelope_assignment/builders_context.json
+++ b/testdata/jennies/builders/envelope_assignment/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "sandbox",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "Dashboard": {
           "Name": "Dashboard",
           "Type": {
             "Kind": "struct",
@@ -37,7 +37,7 @@
             "ReferredType": "Dashboard"
           }
         },
-        {
+        "Variable": {
           "Name": "Variable",
           "Type": {
             "Kind": "struct",
@@ -74,7 +74,7 @@
             "ReferredType": "Variable"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -82,8 +82,8 @@
       "Schema": {
         "Package": "sandbox",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "Dashboard": {
             "Name": "Dashboard",
             "Type": {
               "Kind": "struct",
@@ -116,7 +116,7 @@
               "ReferredType": "Dashboard"
             }
           },
-          {
+          "Variable": {
             "Name": "Variable",
             "Type": {
               "Kind": "struct",
@@ -153,7 +153,7 @@
               "ReferredType": "Variable"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Dashboard",

--- a/testdata/jennies/builders/foreign_builder/builders_context.json
+++ b/testdata/jennies/builders/foreign_builder/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "some_pkg",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -38,8 +38,8 @@
       "Schema": {
         "Package": "some_pkg",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -65,7 +65,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/initialization_safeguards/builders_context.json
+++ b/testdata/jennies/builders/initialization_safeguards/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "initialization_safeguards",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "LegendOptions": {
           "Name": "LegendOptions",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "LegendOptions"
           }
         },
-        {
+        "Options": {
           "Name": "Options",
           "Type": {
             "Kind": "struct",
@@ -60,7 +60,7 @@
             "ReferredType": "Options"
           }
         },
-        {
+        "SomePanel": {
           "Name": "SomePanel",
           "Type": {
             "Kind": "struct",
@@ -98,7 +98,7 @@
             "ReferredType": "SomePanel"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -106,8 +106,8 @@
       "Schema": {
         "Package": "initialization_safeguards",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "LegendOptions": {
             "Name": "LegendOptions",
             "Type": {
               "Kind": "struct",
@@ -133,7 +133,7 @@
               "ReferredType": "LegendOptions"
             }
           },
-          {
+          "Options": {
             "Name": "Options",
             "Type": {
               "Kind": "struct",
@@ -163,7 +163,7 @@
               "ReferredType": "Options"
             }
           },
-          {
+          "SomePanel": {
             "Name": "SomePanel",
             "Type": {
               "Kind": "struct",
@@ -201,7 +201,7 @@
               "ReferredType": "SomePanel"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomePanel",
@@ -243,7 +243,6 @@
       },
       "Package": "initialization_safeguards",
       "Name": "SomePanel",
-      "Properties": null,
       "Options": [
         {
           "Name": "title",

--- a/testdata/jennies/builders/known_any/builders_context.json
+++ b/testdata/jennies/builders/known_any/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "known_any",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "SomeStruct"
           }
         },
-        {
+        "Config": {
           "Name": "Config",
           "Type": {
             "Kind": "struct",
@@ -56,7 +56,7 @@
             "ReferredType": "Config"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -64,8 +64,8 @@
       "Schema": {
         "Package": "known_any",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -91,7 +91,7 @@
               "ReferredType": "SomeStruct"
             }
           },
-          {
+          "Config": {
             "Name": "Config",
             "Type": {
               "Kind": "struct",
@@ -117,7 +117,7 @@
               "ReferredType": "Config"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/package-with-dashes/builders_context.json
+++ b/testdata/jennies/builders/package-with-dashes/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "with-dashes",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -38,8 +38,8 @@
       "Schema": {
         "Package": "with-dashes",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -65,7 +65,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/properties/builders_context.json
+++ b/testdata/jennies/builders/properties/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "properties",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -30,7 +30,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -38,8 +38,8 @@
       "Schema": {
         "Package": "properties",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -65,7 +65,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/references/builders_context.json
+++ b/testdata/jennies/builders/references/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "some_pkg",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "Person": {
           "Name": "Person",
           "Type": {
             "Kind": "struct",
@@ -31,13 +31,13 @@
             "ReferredType": "Person"
           }
         }
-      ]
+      }
     },
     {
       "Package": "other_pkg",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "Name": {
           "Name": "Name",
           "Type": {
             "Kind": "struct",
@@ -74,7 +74,7 @@
             "ReferredType": "Name"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -82,8 +82,8 @@
       "Schema": {
         "Package": "some_pkg",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "Person": {
             "Name": "Person",
             "Type": {
               "Kind": "struct",
@@ -110,7 +110,7 @@
               "ReferredType": "Person"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Person",

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/builders_context.json
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "sandbox",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "SomeStruct": {
           "Name": "SomeStruct",
           "Type": {
             "Kind": "struct",
@@ -55,7 +55,7 @@
             "ReferredType": "SomeStruct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -63,8 +63,8 @@
       "Schema": {
         "Package": "sandbox",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "SomeStruct": {
             "Name": "SomeStruct",
             "Type": {
               "Kind": "struct",
@@ -115,7 +115,7 @@
               "ReferredType": "SomeStruct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "SomeStruct",

--- a/testdata/jennies/builders/struct_with_defaults/builders_context.json
+++ b/testdata/jennies/builders/struct_with_defaults/builders_context.json
@@ -3,8 +3,8 @@
     {
       "Package": "struct_with_defaults",
       "Metadata": {},
-      "Objects": [
-        {
+      "Objects": {
+        "NestedStruct": {
           "Name": "NestedStruct",
           "Type": {
             "Kind": "struct",
@@ -41,7 +41,7 @@
             "ReferredType": "NestedStruct"
           }
         },
-        {
+        "Struct": {
           "Name": "Struct",
           "Type": {
             "Kind": "struct",
@@ -208,7 +208,7 @@
             "ReferredType": "Struct"
           }
         }
-      ]
+      }
     }
   ],
   "Builders": [
@@ -216,8 +216,8 @@
       "Schema": {
         "Package": "struct_with_defaults",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "NestedStruct": {
             "Name": "NestedStruct",
             "Type": {
               "Kind": "struct",
@@ -254,7 +254,7 @@
               "ReferredType": "NestedStruct"
             }
           },
-          {
+          "Struct": {
             "Name": "Struct",
             "Type": {
               "Kind": "struct",
@@ -421,7 +421,7 @@
               "ReferredType": "Struct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "NestedStruct",
@@ -462,7 +462,6 @@
       },
       "Package": "struct_with_defaults",
       "Name": "NestedStruct",
-      "Properties": null,
       "Options": [
         {
           "Name": "stringVal",
@@ -560,8 +559,8 @@
       "Schema": {
         "Package": "struct_with_defaults",
         "Metadata": {},
-        "Objects": [
-          {
+        "Objects": {
+          "NestedStruct": {
             "Name": "NestedStruct",
             "Type": {
               "Kind": "struct",
@@ -598,7 +597,7 @@
               "ReferredType": "NestedStruct"
             }
           },
-          {
+          "Struct": {
             "Name": "Struct",
             "Type": {
               "Kind": "struct",
@@ -765,7 +764,7 @@
               "ReferredType": "Struct"
             }
           }
-        ]
+        }
       },
       "For": {
         "Name": "Struct",
@@ -936,7 +935,6 @@
       },
       "Package": "struct_with_defaults",
       "Name": "Struct",
-      "Properties": null,
       "Options": [
         {
           "Name": "allFields",

--- a/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
+++ b/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
@@ -29,3 +29,6 @@ ArrayOfRefs = list['SomeStruct']
 
 
 ArrayOfArrayOfNumbers = list[list[int]]
+
+
+

--- a/testdata/jennies/rawtypes/arrays/ir.json
+++ b/testdata/jennies/rawtypes/arrays/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "arrays",
-  "Objects": [
-    {
+  "Objects": {
+    "ArrayOfStrings": {
       "Name": "ArrayOfStrings",
       "Comments": [
         "List of tags, maybe?"
@@ -18,7 +18,7 @@
         }
       }
     },
-    {
+    "someStruct": {
       "Name": "someStruct",
       "Type": {
         "Kind": "struct",
@@ -38,7 +38,7 @@
         }
       }
     },
-    {
+    "ArrayOfRefs": {
       "Name": "ArrayOfRefs",
       "Type": {
         "Kind": "array",
@@ -53,7 +53,7 @@
         }
       }
     },
-    {
+    "ArrayOfArrayOfNumbers": {
       "Name": "ArrayOfArrayOfNumbers",
       "Type": {
         "Kind": "array",
@@ -72,5 +72,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/disjunctions/GoJSONMarshalling/disjunctions/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoJSONMarshalling/disjunctions/types_json_marshalling_gen.go
@@ -1,4 +1,46 @@
 package disjunctions
+func (resource StringOrBool) MarshalJSON() ([]byte, error) {
+	if resource.String != nil {
+		return json.Marshal(resource.String)
+	}
+
+	if resource.Bool != nil {
+		return json.Marshal(resource.Bool)
+	}
+
+	return nil, nil
+}
+
+func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	var errList []error
+
+	// String
+	var String string
+	if err := json.Unmarshal(raw, &String); err != nil {
+		errList = append(errList, err)
+		resource.String = nil
+	} else {
+		resource.String = &String
+		return nil
+	}
+
+	// Bool
+	var Bool bool
+	if err := json.Unmarshal(raw, &Bool); err != nil {
+		errList = append(errList, err)
+		resource.Bool = nil
+	} else {
+		resource.Bool = &Bool
+		return nil
+	}
+
+	return errors.Join(errList...)
+}
+
 func (resource SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]byte, error) {
 	if resource.SomeStruct != nil {
 		return json.Marshal(resource.SomeStruct)
@@ -57,47 +99,5 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 	}
 
 	return fmt.Errorf("could not unmarshal resource with `Type = %v`", discriminator)
-}
-
-func (resource StringOrBool) MarshalJSON() ([]byte, error) {
-	if resource.String != nil {
-		return json.Marshal(resource.String)
-	}
-
-	if resource.Bool != nil {
-		return json.Marshal(resource.Bool)
-	}
-
-	return nil, nil
-}
-
-func (resource *StringOrBool) UnmarshalJSON(raw []byte) error {
-	if raw == nil {
-		return nil
-	}
-
-	var errList []error
-
-	// String
-	var String string
-	if err := json.Unmarshal(raw, &String); err != nil {
-		errList = append(errList, err)
-		resource.String = nil
-	} else {
-		resource.String = &String
-		return nil
-	}
-
-	// Bool
-	var Bool bool
-	if err := json.Unmarshal(raw, &Bool); err != nil {
-		errList = append(errList, err)
-		resource.Bool = nil
-	} else {
-		resource.Bool = &Bool
-		return nil
-	}
-
-	return errors.Join(errList...)
 }
 

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -24,6 +24,11 @@ type YetAnotherStruct struct {
 
 type SeveralRefs = SomeStructOrSomeOtherStructOrYetAnotherStruct
 
+type StringOrBool struct {
+	String *string `json:"String,omitempty"`
+	Bool *bool `json:"Bool,omitempty"`
+}
+
 type BoolOrSomeStruct struct {
 	Bool *bool `json:"Bool,omitempty"`
 	SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
@@ -33,10 +38,5 @@ type SomeStructOrSomeOtherStructOrYetAnotherStruct struct {
 	SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
 	SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
 	YetAnotherStruct *YetAnotherStruct `json:"YetAnotherStruct,omitempty"`
-}
-
-type StringOrBool struct {
-	String *string `json:"String,omitempty"`
-	Bool *bool `json:"Bool,omitempty"`
 }
 

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
@@ -1,7 +1,6 @@
 package disjunctions;
 
 
-public class StringOrNull {
-    public String String;
+public class StringOrNull extends StringOrNull {
     
 }

--- a/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
+++ b/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
@@ -81,3 +81,6 @@ class YetAnotherStruct:
 
 
 SeveralRefs = typing.Union[typing.Union['SomeStruct', 'SomeOtherStruct', 'YetAnotherStruct']]
+
+
+

--- a/testdata/jennies/rawtypes/disjunctions/ir.json
+++ b/testdata/jennies/rawtypes/disjunctions/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "disjunctions",
-  "Objects": [
-    {
+  "Objects": {
+    "RefreshRate": {
       "Name": "RefreshRate",
       "Comments": [
         "Refresh rate or disabled."
@@ -26,7 +26,7 @@
         }
       }
     },
-    {
+    "StringOrNull": {
       "Name": "StringOrNull",
       "Type": {
         "Kind": "disjunction",
@@ -48,7 +48,7 @@
         }
       }
     },
-    {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Type": {
         "Kind": "struct",
@@ -79,7 +79,7 @@
         }
       }
     },
-    {
+    "BoolOrRef": {
       "Name": "BoolOrRef",
       "Type": {
         "Kind": "disjunction",
@@ -102,7 +102,7 @@
         }
       }
     },
-    {
+    "SomeOtherStruct": {
       "Name": "SomeOtherStruct",
       "Type": {
         "Kind": "struct",
@@ -133,7 +133,7 @@
         }
       }
     },
-    {
+    "YetAnotherStruct": {
       "Name": "YetAnotherStruct",
       "Type": {
         "Kind": "struct",
@@ -164,7 +164,7 @@
         }
       }
     },
-    {
+    "SeveralRefs": {
       "Name": "SeveralRefs",
       "Type": {
         "Kind": "disjunction",
@@ -195,5 +195,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/enums/PythonRawTypes/models/enums.py
+++ b/testdata/jennies/rawtypes/enums/PythonRawTypes/models/enums.py
@@ -30,3 +30,6 @@ class DashboardCursorSync(enum.IntEnum):
     OFF = 0
     CROSSHAIR = 1
     TOOLTIP = 2
+
+
+

--- a/testdata/jennies/rawtypes/enums/ir.json
+++ b/testdata/jennies/rawtypes/enums/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "enums",
-  "Objects": [
-    {
+  "Objects": {
+    "Operator": {
       "Name": "Operator",
       "Comments": [
         "This is a very interesting string enum."
@@ -38,7 +38,7 @@
         "ReferredType": "Operator"
       }
     },
-    {
+    "TableSortOrder": {
       "Name": "TableSortOrder",
       "Type": {
         "Kind": "enum",
@@ -72,7 +72,7 @@
         "ReferredType": "TableSortOrder"
       }
     },
-    {
+    "LogsSortOrder": {
       "Name": "LogsSortOrder",
       "Type": {
         "Kind": "enum",
@@ -106,7 +106,7 @@
         "ReferredType": "LogsSortOrder"
       }
     },
-    {
+    "DashboardCursorSync": {
       "Name": "DashboardCursorSync",
       "Comments": [
         "0 for no shared crosshair or tooltip (default).",
@@ -155,5 +155,5 @@
         "ReferredType": "DashboardCursorSync"
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -25,6 +25,42 @@ class NestedStruct:
         return cls(**args)
 
 
+class Struct:
+    all_fields: 'NestedStruct'
+    partial_fields: 'NestedStruct'
+    empty_fields: 'NestedStruct'
+    complex_field: 'DefaultsStructComplexField'
+    partial_complex_field: 'DefaultsStructPartialComplexField'
+
+    def __init__(self, all_fields: typing.Optional['NestedStruct'] = None, partial_fields: typing.Optional['NestedStruct'] = None, empty_fields: typing.Optional['NestedStruct'] = None, complex_field: typing.Optional['DefaultsStructComplexField'] = None, partial_complex_field: typing.Optional['DefaultsStructPartialComplexField'] = None):
+        self.all_fields = all_fields if all_fields is not None else NestedStruct(int_val=3, string_val="hello")
+        self.partial_fields = partial_fields if partial_fields is not None else NestedStruct(int_val=3)
+        self.empty_fields = empty_fields if empty_fields is not None else NestedStruct()
+        self.complex_field = complex_field if complex_field is not None else DefaultsStructComplexField(array=["hello"], nested=DefaultsStructComplexFieldNested(nested_val="nested"), uid="myUID")
+        self.partial_complex_field = partial_complex_field if partial_complex_field is not None else DefaultsStructPartialComplexField()
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "allFields": None if self.all_fields is None else self.all_fields.to_json(),
+            "partialFields": None if self.partial_fields is None else self.partial_fields.to_json(),
+            "emptyFields": None if self.empty_fields is None else self.empty_fields.to_json(),
+            "complexField": None if self.complex_field is None else self.complex_field.to_json(),
+            "partialComplexField": None if self.partial_complex_field is None else self.partial_complex_field.to_json(),
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args = {
+            "all_fields": NestedStruct.from_json(data["allFields"]),
+            "partial_fields": NestedStruct.from_json(data["partialFields"]),
+            "empty_fields": NestedStruct.from_json(data["emptyFields"]),
+            "complex_field": DefaultsStructComplexField.from_json(data["complexField"]),
+            "partial_complex_field": DefaultsStructPartialComplexField.from_json(data["partialComplexField"]),
+        }
+        return cls(**args)
+
+
 class DefaultsStructComplexFieldNested:
     nested_val: str
 
@@ -97,37 +133,4 @@ class DefaultsStructPartialComplexField:
         return cls(**args)
 
 
-class Struct:
-    all_fields: 'NestedStruct'
-    partial_fields: 'NestedStruct'
-    empty_fields: 'NestedStruct'
-    complex_field: 'DefaultsStructComplexField'
-    partial_complex_field: 'DefaultsStructPartialComplexField'
 
-    def __init__(self, all_fields: typing.Optional['NestedStruct'] = None, partial_fields: typing.Optional['NestedStruct'] = None, empty_fields: typing.Optional['NestedStruct'] = None, complex_field: typing.Optional['DefaultsStructComplexField'] = None, partial_complex_field: typing.Optional['DefaultsStructPartialComplexField'] = None):
-        self.all_fields = all_fields if all_fields is not None else NestedStruct(int_val=3, string_val="hello")
-        self.partial_fields = partial_fields if partial_fields is not None else NestedStruct(int_val=3)
-        self.empty_fields = empty_fields if empty_fields is not None else NestedStruct()
-        self.complex_field = complex_field if complex_field is not None else DefaultsStructComplexField(array=["hello"], nested=DefaultsStructComplexFieldNested(nested_val="nested"), uid="myUID")
-        self.partial_complex_field = partial_complex_field if partial_complex_field is not None else DefaultsStructPartialComplexField()
-
-    def to_json(self) -> dict[str, object]:
-        payload: dict[str, object] = {
-            "allFields": None if self.all_fields is None else self.all_fields.to_json(),
-            "partialFields": None if self.partial_fields is None else self.partial_fields.to_json(),
-            "emptyFields": None if self.empty_fields is None else self.empty_fields.to_json(),
-            "complexField": None if self.complex_field is None else self.complex_field.to_json(),
-            "partialComplexField": None if self.partial_complex_field is None else self.partial_complex_field.to_json(),
-        }
-        return payload
-
-    @classmethod
-    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
-            "all_fields": NestedStruct.from_json(data["allFields"]),
-            "partial_fields": NestedStruct.from_json(data["partialFields"]),
-            "empty_fields": NestedStruct.from_json(data["emptyFields"]),
-            "complex_field": DefaultsStructComplexField.from_json(data["complexField"]),
-            "partial_complex_field": DefaultsStructPartialComplexField.from_json(data["partialComplexField"]),
-        }
-        return cls(**args)

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/ir.json
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "defaults",
-  "Objects": [
-    {
+  "Objects": {
+    "NestedStruct": {
       "Name": "NestedStruct",
       "SelfRef": {
         "ReferredPkg": "defaults",
@@ -38,7 +38,7 @@
         }
       }
     },
-    {
+    "Struct": {
       "Name": "Struct",
       "SelfRef": {
         "ReferredPkg": "defaults",
@@ -202,5 +202,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/intersections/ir.json
+++ b/testdata/jennies/rawtypes/intersections/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "intersections",
-  "Objects": [
-    {
+  "Objects": {
+    "Intersections": {
       "Name": "Intersections",
       "Type": {
         "Kind": "intersection",
@@ -61,7 +61,7 @@
         }
       }
     },
-    {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Type": {
         "Kind": "struct",
@@ -82,5 +82,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
+++ b/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
@@ -32,3 +32,6 @@ MapOfStringToRef = dict[str, 'SomeStruct']
 
 
 MapOfStringToMapOfStringToBool = dict[str, dict[str, bool]]
+
+
+

--- a/testdata/jennies/rawtypes/maps/ir.json
+++ b/testdata/jennies/rawtypes/maps/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "maps",
-  "Objects": [
-    {
+  "Objects": {
+    "MapOfStringToAny": {
       "Name": "MapOfStringToAny",
       "Comments": [
         "String to... something."
@@ -24,7 +24,7 @@
         }
       }
     },
-    {
+    "MapOfStringToString": {
       "Name": "MapOfStringToString",
       "Type": {
         "Kind": "map",
@@ -44,7 +44,7 @@
         }
       }
     },
-    {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Type": {
         "Kind": "struct",
@@ -64,7 +64,7 @@
         }
       }
     },
-    {
+    "MapOfStringToRef": {
       "Name": "MapOfStringToRef",
       "Type": {
         "Kind": "map",
@@ -85,7 +85,7 @@
         }
       }
     },
-    {
+    "MapOfStringToMapOfStringToBool": {
       "Name": "MapOfStringToMapOfStringToBool",
       "Type": {
         "Kind": "map",
@@ -116,5 +116,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
+++ b/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
@@ -23,3 +23,6 @@ class SomeStruct:
 
 # Refresh rate or disabled.
 RefreshRate = typing.Union[typing.Union[str, bool]]
+
+
+

--- a/testdata/jennies/rawtypes/package-with-dashes/ir.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "with-dashes",
-  "Objects": [
-    {
+  "Objects": {
+    "someStruct": {
       "Name": "someStruct",
       "Type": {
         "Kind": "struct",
@@ -21,7 +21,7 @@
         }
       }
     },
-    {
+    "RefreshRate": {
       "Name": "RefreshRate",
       "Comments": [
         "Refresh rate or disabled."
@@ -46,5 +46,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
+++ b/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
@@ -26,3 +26,6 @@ RefToSomeStruct = 'SomeStruct'
 
 
 RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct
+
+
+

--- a/testdata/jennies/rawtypes/refs/ir.json
+++ b/testdata/jennies/rawtypes/refs/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "refs",
-  "Objects": [
-    {
+  "Objects": {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Type": {
         "Kind": "struct",
@@ -21,7 +21,7 @@
         }
       }
     },
-    {
+    "RefToSomeStruct": {
       "Name": "RefToSomeStruct",
       "Type": {
         "Kind": "ref",
@@ -31,7 +31,7 @@
         }
       }
     },
-    {
+    "RefToSomeStructFromOtherPackage": {
       "Name": "RefToSomeStructFromOtherPackage",
       "Type": {
         "Kind": "ref",
@@ -41,5 +41,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/scalars/PythonRawTypes/models/scalars.py
+++ b/testdata/jennies/rawtypes/scalars/PythonRawTypes/models/scalars.py
@@ -44,3 +44,6 @@ ScalarTypeInt32 = int
 
 
 ScalarTypeInt64 = int
+
+
+

--- a/testdata/jennies/rawtypes/scalars/ir.json
+++ b/testdata/jennies/rawtypes/scalars/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "scalars",
-  "Objects": [
-    {
+  "Objects": {
+    "constTypeString": {
       "Name": "constTypeString",
       "Type": {
         "Kind": "scalar",
@@ -11,7 +11,7 @@
         }
       }
     },
-    {
+    "scalarTypeAny": {
       "Name": "scalarTypeAny",
       "Type": {
         "Kind": "scalar",
@@ -20,7 +20,7 @@
         }
       }
     },
-    {
+    "ScalarTypeBool": {
       "Name": "ScalarTypeBool",
       "Type": {
         "Kind": "scalar",
@@ -29,7 +29,7 @@
         }
       }
     },
-    {
+    "ScalarTypeBytes": {
       "Name": "ScalarTypeBytes",
       "Type": {
         "Kind": "scalar",
@@ -38,7 +38,7 @@
         }
       }
     },
-    {
+    "ScalarTypeString": {
       "Name": "ScalarTypeString",
       "Type": {
         "Kind": "scalar",
@@ -47,7 +47,7 @@
         }
       }
     },
-    {
+    "ScalarTypeFloat32": {
       "Name": "ScalarTypeFloat32",
       "Type": {
         "Kind": "scalar",
@@ -56,7 +56,7 @@
         }
       }
     },
-    {
+    "ScalarTypeFloat64": {
       "Name": "ScalarTypeFloat64",
       "Type": {
         "Kind": "scalar",
@@ -65,7 +65,7 @@
         }
       }
     },
-    {
+    "ScalarTypeUint8": {
       "Name": "ScalarTypeUint8",
       "Type": {
         "Kind": "scalar",
@@ -74,7 +74,7 @@
         }
       }
     },
-    {
+    "ScalarTypeUint16": {
       "Name": "ScalarTypeUint16",
       "Type": {
         "Kind": "scalar",
@@ -83,7 +83,7 @@
         }
       }
     },
-    {
+    "ScalarTypeUint32": {
       "Name": "ScalarTypeUint32",
       "Type": {
         "Kind": "scalar",
@@ -92,7 +92,7 @@
         }
       }
     },
-    {
+    "ScalarTypeUint64": {
       "Name": "ScalarTypeUint64",
       "Type": {
         "Kind": "scalar",
@@ -101,7 +101,7 @@
         }
       }
     },
-    {
+    "ScalarTypeInt8": {
       "Name": "ScalarTypeInt8",
       "Type": {
         "Kind": "scalar",
@@ -110,7 +110,7 @@
         }
       }
     },
-    {
+    "ScalarTypeInt16": {
       "Name": "ScalarTypeInt16",
       "Type": {
         "Kind": "scalar",
@@ -119,7 +119,7 @@
         }
       }
     },
-    {
+    "ScalarTypeInt32": {
       "Name": "ScalarTypeInt32",
       "Type": {
         "Kind": "scalar",
@@ -128,7 +128,7 @@
         }
       }
     },
-    {
+    "ScalarTypeInt64": {
       "Name": "ScalarTypeInt64",
       "Type": {
         "Kind": "scalar",
@@ -137,5 +137,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -1,26 +1,6 @@
 import typing
 
 
-class StructComplexFieldsSomeStructFieldAnonymousStruct:
-    field_any: object
-
-    def __init__(self, field_any: object = None):
-        self.field_any = field_any
-
-    def to_json(self) -> dict[str, object]:
-        payload: dict[str, object] = {
-            "FieldAny": self.field_any,
-        }
-        return payload
-
-    @classmethod
-    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
-            "field_any": data["FieldAny"],
-        }
-        return cls(**args)
-
-
 class SomeStruct:
     """
     This struct does things.
@@ -91,3 +71,26 @@ class SomeOtherStruct:
             "field_any": data["FieldAny"],
         }
         return cls(**args)
+
+
+class StructComplexFieldsSomeStructFieldAnonymousStruct:
+    field_any: object
+
+    def __init__(self, field_any: object = None):
+        self.field_any = field_any
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "FieldAny": self.field_any,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args = {
+            "field_any": data["FieldAny"],
+        }
+        return cls(**args)
+
+
+

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/ir.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "struct_complex_fields",
-  "Objects": [
-    {
+  "Objects": {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "SelfRef": {
         "ReferredPkg": "struct_complex_fields",
@@ -187,7 +187,7 @@
         }
       }
     },
-    {
+    "SomeOtherStruct": {
       "Name": "SomeOtherStruct",
       "SelfRef": {
         "ReferredPkg": "struct_complex_fields",
@@ -211,5 +211,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/struct_with_defaults/ir.json
+++ b/testdata/jennies/rawtypes/struct_with_defaults/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "defaults",
-  "Objects": [
-    {
+  "Objects": {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Type": {
         "Kind": "struct",
@@ -66,5 +66,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
@@ -1,26 +1,6 @@
 import typing
 
 
-class StructOptionalFieldsSomeStructFieldAnonymousStruct:
-    field_any: object
-
-    def __init__(self, field_any: object = None):
-        self.field_any = field_any
-
-    def to_json(self) -> dict[str, object]:
-        payload: dict[str, object] = {
-            "FieldAny": self.field_any,
-        }
-        return payload
-
-    @classmethod
-    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
-            "field_any": data["FieldAny"],
-        }
-        return cls(**args)
-
-
 class SomeStruct:
     field_ref: typing.Optional['SomeOtherStruct']
     field_string: typing.Optional[str]
@@ -87,3 +67,26 @@ class SomeOtherStruct:
             "field_any": data["FieldAny"],
         }
         return cls(**args)
+
+
+class StructOptionalFieldsSomeStructFieldAnonymousStruct:
+    field_any: object
+
+    def __init__(self, field_any: object = None):
+        self.field_any = field_any
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "FieldAny": self.field_any,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args = {
+            "field_any": data["FieldAny"],
+        }
+        return cls(**args)
+
+
+

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/ir.json
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "struct_optional_fields",
-  "Objects": [
-    {
+  "Objects": {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "SelfRef": {
         "ReferredPkg": "struct_optional_fields",
@@ -103,7 +103,7 @@
         }
       }
     },
-    {
+    "SomeOtherStruct": {
       "Name": "SomeOtherStruct",
       "SelfRef": {
         "ReferredPkg": "struct_optional_fields",
@@ -127,5 +127,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/ir.json
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "basic",
-  "Objects": [
-    {
+  "Objects": {
+    "SomeStruct": {
       "Name": "SomeStruct",
       "Comments": [
         "This",
@@ -172,5 +172,5 @@
         }
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/allof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/allof_object/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "AllOf": {
       "Name": "AllOf",
       "Type": {
         "Kind": "intersection",
@@ -55,5 +55,5 @@
         "ReferredType": "AllOf"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/anyof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_object/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "AnyOf": {
       "Name": "AnyOf",
       "Type": {
         "Kind": "disjunction",
@@ -31,5 +31,5 @@
         "ReferredType": "AnyOf"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "AnyOfField": {
       "Name": "AnyOfField",
       "Type": {
         "Kind": "struct",
@@ -43,5 +43,5 @@
         "ReferredType": "AnyOfField"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/array_any/GenerateAST/ir.json
+++ b/testdata/jsonschema/array_any/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -34,5 +34,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/basic_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/basic_object/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -155,5 +155,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/consts/GenerateAST/ir.json
+++ b/testdata/jsonschema/consts/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -101,5 +101,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/defaults/GenerateAST/ir.json
+++ b/testdata/jsonschema/defaults/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -111,5 +111,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/enum/GenerateAST/ir.json
+++ b/testdata/jsonschema/enum/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -96,5 +96,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
+++ b/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "AdHocVariableFilter": {
       "Name": "AdHocVariableFilter",
       "Type": {
         "Kind": "struct",
@@ -61,7 +61,7 @@
         "ReferredType": "AdHocVariableFilter"
       }
     },
-    {
+    "DataSourceRef": {
       "Name": "DataSourceRef",
       "Type": {
         "Kind": "struct",
@@ -104,7 +104,7 @@
         "ReferredType": "DataSourceRef"
       }
     },
-    {
+    "InfluxQuery": {
       "Name": "InfluxQuery",
       "Type": {
         "Kind": "struct",
@@ -575,7 +575,7 @@
         "ReferredType": "InfluxQuery"
       }
     },
-    {
+    "InfluxQueryPart": {
       "Name": "InfluxQueryPart",
       "Type": {
         "Kind": "struct",
@@ -644,7 +644,7 @@
         "ReferredType": "InfluxQueryPart"
       }
     },
-    {
+    "InfluxQueryTag": {
       "Name": "InfluxQueryTag",
       "Type": {
         "Kind": "struct",
@@ -703,5 +703,5 @@
         "ReferredType": "InfluxQueryTag"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/number_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/number_constraints/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -67,5 +67,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
+++ b/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Entrypoint": {
       "Name": "Entrypoint",
       "Type": {
         "Kind": "struct",
@@ -53,7 +53,7 @@
         "ReferredType": "Entrypoint"
       }
     },
-    {
+    "ObjectAdditionalPropertiesWithSchema": {
       "Name": "ObjectAdditionalPropertiesWithSchema",
       "Type": {
         "Kind": "map",
@@ -80,7 +80,7 @@
         "ReferredType": "ObjectAdditionalPropertiesWithSchema"
       }
     },
-    {
+    "ObjectNoAdditionalProperties": {
       "Name": "ObjectNoAdditionalProperties",
       "Type": {
         "Kind": "scalar",
@@ -94,7 +94,7 @@
         "ReferredType": "ObjectNoAdditionalProperties"
       }
     },
-    {
+    "ObjectNoProperties": {
       "Name": "ObjectNoProperties",
       "Type": {
         "Kind": "scalar",
@@ -108,5 +108,5 @@
         "ReferredType": "ObjectNoProperties"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/oneof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_object/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "OneOf": {
       "Name": "OneOf",
       "Type": {
         "Kind": "disjunction",
@@ -31,5 +31,5 @@
         "ReferredType": "OneOf"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "OneOfField": {
       "Name": "OneOfField",
       "Type": {
         "Kind": "struct",
@@ -43,5 +43,5 @@
         "ReferredType": "OneOfField"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/recursive/GenerateAST/ir.json
+++ b/testdata/jsonschema/recursive/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Node": {
       "Name": "Node",
       "Type": {
         "Kind": "struct",
@@ -46,5 +46,5 @@
         "ReferredType": "Node"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "grafanatest": {
       "Name": "grafanatest",
       "Type": {
         "Kind": "struct",
@@ -29,7 +29,7 @@
         "ReferredType": "grafanatest"
       }
     },
-    {
+    "is-string": {
       "Name": "is-string",
       "Type": {
         "Kind": "scalar",
@@ -43,5 +43,5 @@
         "ReferredType": "is-string"
       }
     }
-  ]
+  }
 }

--- a/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "SomeObject": {
       "Name": "SomeObject",
       "Type": {
         "Kind": "struct",
@@ -42,5 +42,5 @@
         "ReferredType": "SomeObject"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/arrays/GenerateAST/ir.json
+++ b/testdata/openapi/arrays/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Arrays": {
       "Name": "Arrays",
       "Type": {
         "Kind": "struct",
@@ -69,7 +69,7 @@
         "ReferredType": "Arrays"
       }
     },
-    {
+    "Test": {
       "Name": "Test",
       "Type": {
         "Kind": "struct",
@@ -95,5 +95,5 @@
         "ReferredType": "Test"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/datatypes/GenerateAST/ir.json
+++ b/testdata/openapi/datatypes/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "DataTypes": {
       "Name": "DataTypes",
       "Type": {
         "Kind": "struct",
@@ -96,5 +96,5 @@
         "ReferredType": "DataTypes"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/defaults/GenerateAST/ir.json
+++ b/testdata/openapi/defaults/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Array": {
       "Name": "Array",
       "Type": {
         "Kind": "array",
@@ -25,7 +25,7 @@
         "ReferredType": "Array"
       }
     },
-    {
+    "Boolean": {
       "Name": "Boolean",
       "Type": {
         "Kind": "scalar",
@@ -40,7 +40,7 @@
         "ReferredType": "Boolean"
       }
     },
-    {
+    "Enum": {
       "Name": "Enum",
       "Type": {
         "Kind": "enum",
@@ -78,7 +78,7 @@
         "ReferredType": "Enum"
       }
     },
-    {
+    "Float": {
       "Name": "Float",
       "Type": {
         "Kind": "scalar",
@@ -93,7 +93,7 @@
         "ReferredType": "Float"
       }
     },
-    {
+    "Integer": {
       "Name": "Integer",
       "Type": {
         "Kind": "scalar",
@@ -108,7 +108,7 @@
         "ReferredType": "Integer"
       }
     },
-    {
+    "String": {
       "Name": "String",
       "Type": {
         "Kind": "scalar",
@@ -123,5 +123,5 @@
         "ReferredType": "String"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/discriminator/GenerateAST/ir.json
+++ b/testdata/openapi/discriminator/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Discriminator": {
       "Name": "Discriminator",
       "Type": {
         "Kind": "struct",
@@ -132,7 +132,7 @@
         "ReferredType": "Discriminator"
       }
     },
-    {
+    "Value1": {
       "Name": "Value1",
       "Type": {
         "Kind": "struct",
@@ -159,7 +159,7 @@
         "ReferredType": "Value1"
       }
     },
-    {
+    "Value2": {
       "Name": "Value2",
       "Type": {
         "Kind": "struct",
@@ -186,7 +186,7 @@
         "ReferredType": "Value2"
       }
     },
-    {
+    "Value3": {
       "Name": "Value3",
       "Type": {
         "Kind": "struct",
@@ -213,5 +213,5 @@
         "ReferredType": "Value3"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/enums/GenerateAST/ir.json
+++ b/testdata/openapi/enums/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Enums": {
       "Name": "Enums",
       "Type": {
         "Kind": "struct",
@@ -120,5 +120,5 @@
         "ReferredType": "Enums"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/external_refs/GenerateAST/ir.json
+++ b/testdata/openapi/external_refs/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "WithOneRef": {
       "Name": "WithOneRef",
       "Type": {
         "Kind": "intersection",
@@ -44,7 +44,7 @@
         "ReferredType": "WithOneRef"
       }
     },
-    {
+    "WithTwoRef": {
       "Name": "WithTwoRef",
       "Type": {
         "Kind": "intersection",
@@ -94,5 +94,5 @@
         "ReferredType": "WithTwoRef"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/intersections/GenerateAST/ir.json
+++ b/testdata/openapi/intersections/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Enum": {
       "Name": "Enum",
       "Type": {
         "Kind": "enum",
@@ -39,7 +39,7 @@
         "ReferredType": "Enum"
       }
     },
-    {
+    "Mixed": {
       "Name": "Mixed",
       "Type": {
         "Kind": "intersection",
@@ -81,7 +81,7 @@
         "ReferredType": "Mixed"
       }
     },
-    {
+    "Structs": {
       "Name": "Structs",
       "Type": {
         "Kind": "intersection",
@@ -120,7 +120,7 @@
         "ReferredType": "Structs"
       }
     },
-    {
+    "Value1": {
       "Name": "Value1",
       "Type": {
         "Kind": "struct",
@@ -147,7 +147,7 @@
         "ReferredType": "Value1"
       }
     },
-    {
+    "Value2": {
       "Name": "Value2",
       "Type": {
         "Kind": "struct",
@@ -174,7 +174,7 @@
         "ReferredType": "Value2"
       }
     },
-    {
+    "Value3": {
       "Name": "Value3",
       "Type": {
         "Kind": "struct",
@@ -201,5 +201,5 @@
         "ReferredType": "Value3"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/nested_structs/GenerateAST/ir.json
+++ b/testdata/openapi/nested_structs/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Nested": {
       "Name": "Nested",
       "Type": {
         "Kind": "struct",
@@ -52,5 +52,5 @@
         "ReferredType": "Nested"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/refs/GenerateAST/ir.json
+++ b/testdata/openapi/refs/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Refs": {
       "Name": "Refs",
       "Type": {
         "Kind": "struct",
@@ -29,7 +29,7 @@
         "ReferredType": "Refs"
       }
     },
-    {
+    "Test": {
       "Name": "Test",
       "Type": {
         "Kind": "struct",
@@ -55,5 +55,5 @@
         "ReferredType": "Test"
       }
     }
-  ]
+  }
 }

--- a/testdata/openapi/split_schema/GenerateAST/ir.json
+++ b/testdata/openapi/split_schema/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Array": {
       "Name": "Array",
       "Type": {
         "Kind": "array",
@@ -23,7 +23,7 @@
         "ReferredType": "Array"
       }
     },
-    {
+    "Partial": {
       "Name": "Partial",
       "Type": {
         "Kind": "struct",
@@ -49,5 +49,5 @@
         "ReferredType": "Partial"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/arrays/GenerateAST/ir.json
+++ b/testdata/simplecue/arrays/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "refStruct": {
       "Name": "refStruct",
       "Type": {
         "Kind": "struct",
@@ -28,7 +28,7 @@
         "ReferredType": "refStruct"
       }
     },
-    {
+    "struct": {
       "Name": "struct",
       "Type": {
         "Kind": "struct",
@@ -54,7 +54,7 @@
         "ReferredType": "struct"
       }
     },
-    {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -139,5 +139,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/common_timezone_disjunction/GenerateAST/ir.json
+++ b/testdata/simplecue/common_timezone_disjunction/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "TimeZoneUtc": {
       "Name": "TimeZoneUtc",
       "Comments": [
         "Use UTC/GMT timezone"
@@ -23,7 +23,7 @@
         "ReferredType": "TimeZoneUtc"
       }
     },
-    {
+    "TimeZoneBrowser": {
       "Name": "TimeZoneBrowser",
       "Comments": [
         "Use the timezone defined by end user web browser"
@@ -44,7 +44,7 @@
         "ReferredType": "TimeZoneBrowser"
       }
     },
-    {
+    "TimeZone": {
       "Name": "TimeZone",
       "Comments": [
         "A specific timezone from https://en.wikipedia.org/wiki/Tz_database"
@@ -89,7 +89,7 @@
         "ReferredType": "TimeZone"
       }
     },
-    {
+    "DisjunctionWithOnlyConcreteValues": {
       "Name": "DisjunctionWithOnlyConcreteValues",
       "Comments": [
         "This should become an enum"
@@ -140,5 +140,5 @@
         "ReferredType": "DisjunctionWithOnlyConcreteValues"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/defaults/GenerateAST/ir.json
+++ b/testdata/simplecue/defaults/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "StringEnum": {
       "Name": "StringEnum",
       "Type": {
         "Kind": "enum",
@@ -50,7 +50,7 @@
         "ReferredType": "StringEnum"
       }
     },
-    {
+    "IntEnum": {
       "Name": "IntEnum",
       "Type": {
         "Kind": "enum",
@@ -102,7 +102,7 @@
         "ReferredType": "IntEnum"
       }
     },
-    {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -285,5 +285,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/defaults_on_struct/GenerateAST/ir.json
+++ b/testdata/simplecue/defaults_on_struct/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "Enum": {
       "Name": "Enum",
       "Type": {
         "Kind": "enum",
@@ -50,7 +50,7 @@
         "ReferredType": "Enum"
       }
     },
-    {
+    "HeatmapColorOptions": {
       "Name": "HeatmapColorOptions",
       "Type": {
         "Kind": "struct",
@@ -132,7 +132,7 @@
         "ReferredType": "HeatmapColorOptions"
       }
     },
-    {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -164,5 +164,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/disjunctions/GenerateAST/ir.json
+++ b/testdata/simplecue/disjunctions/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -140,5 +140,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/enums/GenerateAST/ir.json
+++ b/testdata/simplecue/enums/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "IntEnum": {
       "Name": "IntEnum",
       "Type": {
         "Kind": "enum",
@@ -54,7 +54,7 @@
         "ReferredType": "IntEnum"
       }
     },
-    {
+    "StringEnum": {
       "Name": "StringEnum",
       "Type": {
         "Kind": "enum",
@@ -102,7 +102,7 @@
         "ReferredType": "StringEnum"
       }
     },
-    {
+    "Operator": {
       "Name": "Operator",
       "Type": {
         "Kind": "enum",
@@ -139,5 +139,5 @@
         "ReferredType": "Operator"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/maps/GenerateAST/ir.json
+++ b/testdata/simplecue/maps/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "intStringMap": {
       "Name": "intStringMap",
       "Type": {
         "Kind": "map",
@@ -29,7 +29,7 @@
         "ReferredType": "intStringMap"
       }
     },
-    {
+    "stringStringMap": {
       "Name": "stringStringMap",
       "Type": {
         "Kind": "map",
@@ -56,7 +56,7 @@
         "ReferredType": "stringStringMap"
       }
     },
-    {
+    "foo": {
       "Name": "foo",
       "Type": {
         "Kind": "struct",
@@ -82,7 +82,7 @@
         "ReferredType": "foo"
       }
     },
-    {
+    "stringRefMap": {
       "Name": "stringRefMap",
       "Type": {
         "Kind": "map",
@@ -110,7 +110,7 @@
         "ReferredType": "stringRefMap"
       }
     },
-    {
+    "stringToMapOfMap": {
       "Name": "stringToMapOfMap",
       "Type": {
         "Kind": "map",
@@ -150,5 +150,5 @@
         "ReferredType": "stringToMapOfMap"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
+++ b/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "HelloMsg": {
       "Name": "HelloMsg",
       "Type": {
         "Kind": "struct",
@@ -40,7 +40,7 @@
         "ReferredType": "HelloMsg"
       }
     },
-    {
+    "ByeMsg": {
       "Name": "ByeMsg",
       "Type": {
         "Kind": "struct",
@@ -78,7 +78,7 @@
         "ReferredType": "ByeMsg"
       }
     },
-    {
+    "QuestionMsg": {
       "Name": "QuestionMsg",
       "Type": {
         "Kind": "struct",
@@ -116,7 +116,7 @@
         "ReferredType": "QuestionMsg"
       }
     },
-    {
+    "AnswerMsg": {
       "Name": "AnswerMsg",
       "Type": {
         "Kind": "struct",
@@ -154,7 +154,7 @@
         "ReferredType": "AnswerMsg"
       }
     },
-    {
+    "ChitChat": {
       "Name": "ChitChat",
       "Type": {
         "Kind": "disjunction",
@@ -185,7 +185,7 @@
         "ReferredType": "ChitChat"
       }
     },
-    {
+    "Message": {
       "Name": "Message",
       "Type": {
         "Kind": "disjunction",
@@ -224,5 +224,5 @@
         "ReferredType": "Message"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/numbers_constraints/GenerateAST/ir.json
+++ b/testdata/simplecue/numbers_constraints/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -105,5 +105,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/refs/GenerateAST/ir.json
+++ b/testdata/simplecue/refs/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "IntEnum": {
       "Name": "IntEnum",
       "Type": {
         "Kind": "enum",
@@ -55,7 +55,7 @@
         "ReferredType": "IntEnum"
       }
     },
-    {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -128,7 +128,7 @@
         "ReferredType": "container"
       }
     },
-    {
+    "anything": {
       "Name": "anything",
       "Type": {
         "Kind": "scalar",
@@ -142,7 +142,7 @@
         "ReferredType": "anything"
       }
     },
-    {
+    "foo": {
       "Name": "foo",
       "Type": {
         "Kind": "struct",
@@ -174,5 +174,5 @@
         "ReferredType": "foo"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/scalars/GenerateAST/ir.json
+++ b/testdata/simplecue/scalars/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "container": {
       "Name": "container",
       "Type": {
         "Kind": "struct",
@@ -149,5 +149,5 @@
         "ReferredType": "container"
       }
     }
-  ]
+  }
 }

--- a/testdata/simplecue/unifications/GenerateAST/ir.json
+++ b/testdata/simplecue/unifications/GenerateAST/ir.json
@@ -1,8 +1,8 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "Objects": [
-    {
+  "Objects": {
+    "InlineScript": {
       "Name": "InlineScript",
       "Type": {
         "Kind": "disjunction",
@@ -43,7 +43,7 @@
         "ReferredType": "InlineScript"
       }
     },
-    {
+    "MetricAggregationWithInlineScript": {
       "Name": "MetricAggregationWithInlineScript",
       "Type": {
         "Kind": "struct",
@@ -82,7 +82,7 @@
         "ReferredType": "MetricAggregationWithInlineScript"
       }
     },
-    {
+    "Average": {
       "Name": "Average",
       "Type": {
         "Kind": "struct",
@@ -144,5 +144,5 @@
         "ReferredType": "Average"
       }
     }
-  ]
+  }
 }


### PR DESCRIPTION
This PR changes the way `Object`s are store in the schema IR.

The idea is that we mainly need to do two things with objects:
* iterate over them, in a consistent order (for our tests to be reliable, and the generated output to be stable)
* access them by name

With that in mind, it makes sense to store objects in an ordered map rather than in a list.