### PR TITLE
Jsonschema registry

### DIFF
--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -168,7 +168,6 @@ func doGenerate(allTargets jennies.LanguageJennies, opts Options) error {
 	}
 
 	rootCodeJenFS := codejen.NewFS()
-
 	for language, target := range targetsByLanguage {
 		fmt.Printf("Running '%s' jennies...\n", language)
 

--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -125,6 +125,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
 	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
 	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
+	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")
@@ -138,6 +139,7 @@ func Command() *cobra.Command {
 	_ = cmd.MarkFlagDirname("kindsys-core")
 	_ = cmd.MarkFlagDirname("kindsys-custom")
 	_ = cmd.MarkFlagDirname("kind-registry")
+	_ = cmd.MarkFlagDirname("jsonschema-registry")
 	_ = cmd.MarkFlagFilename("jsonschema")
 	_ = cmd.MarkFlagDirname("openapi")
 	_ = cmd.MarkFlagDirname("output")

--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -118,14 +118,14 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.VeneerConfigFiles, "veneer", "c", nil, "Veneer configuration file.")
 	cmd.Flags().StringArrayVar(&opts.VeneerConfigDirectories, "veneers", nil, "Veneer configuration directories.")
 
-	cmd.Flags().StringArrayVar(&opts.CueEntrypoints, "cue", nil, "CUE input schema.")                                                  // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysCoreEntrypoints, "kindsys-core", nil, "Kindys core kinds input schema.")                   // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysComposableEntrypoints, "kindsys-composable", nil, "Kindys composable kinds input schema.") // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.KindsysCustomEntrypoints, "kindsys-custom", nil, "Kindys custom kinds input schema.")             // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
-	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
-	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
-	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.CueEntrypoints, "cue", nil, "CUE input schema.")                                                                                                           // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysCoreEntrypoints, "kindsys-core", nil, "Kindys core kinds input schema.")                                                                            // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysComposableEntrypoints, "kindsys-composable", nil, "Kindys composable kinds input schema.")                                                          // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.KindsysCustomEntrypoints, "kindsys-custom", nil, "Kindys custom kinds input schema.")                                                                      // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                                                                                      // TODO: better usage text
+	cmd.Flags().StringArrayVar(&opts.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                                                                               // TODO: better usage text
+	cmd.Flags().StringVar(&opts.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                                                                                  // TODO: better usage text
+	cmd.Flags().StringVar(&opts.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input. This flag is totally experimental and it could be deleted in forward versions.") // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")

--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -40,6 +40,7 @@ func Command() *cobra.Command {
 	cmd.Flags().StringArrayVar(&opts.LoaderOptions.JSONSchemaEntrypoints, "jsonschema", nil, "Jsonschema input schema.")                             // TODO: better usage text
 	cmd.Flags().StringArrayVar(&opts.LoaderOptions.OpenAPIEntrypoints, "openapi", nil, "Openapi input schema.")                                      // TODO: better usage text
 	cmd.Flags().StringVar(&opts.LoaderOptions.KindRegistryPath, "kind-registry", "", "Kind registry input.")                                         // TODO: better usage text
+	cmd.Flags().StringVar(&opts.LoaderOptions.JSONSchemaRegistryPath, "jsonschema-registry", "", "JSONschema registry input.")                       // TODO: better usage text
 
 	cmd.Flags().StringArrayVarP(&opts.LoaderOptions.CueImports, "include-cue-import", "I", nil, "Specify an additional library import directory. Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common")
 	cmd.Flags().StringVar(&opts.LoaderOptions.KindRegistryVersion, "kind-registry-version", "next", "Schemas version")
@@ -48,6 +49,7 @@ func Command() *cobra.Command {
 	_ = cmd.MarkFlagDirname("kindsys-core")
 	_ = cmd.MarkFlagDirname("kindsys-custom")
 	_ = cmd.MarkFlagDirname("kind-registry")
+	_ = cmd.MarkFlagDirname("jsonschema-registry")
 	_ = cmd.MarkFlagFilename("jsonschema")
 	_ = cmd.MarkFlagDirname("openapi")
 

--- a/cmd/cli/loaders/cue.go
+++ b/cmd/cli/loaders/cue.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yalue/merged_fs"
 )
 
-func cueLoader(opts Options) ([]*ast.Schema, error) {
+func cueLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/jsonregistry.go
+++ b/cmd/cli/loaders/jsonregistry.go
@@ -1,0 +1,118 @@
+package loaders
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jsonschema"
+)
+
+func jsonschemaRegistryLoader(opts Options) ([]*ast.Schema, error) {
+	var allSchemas []*ast.Schema
+
+	if opts.JSONSchemaRegistryPath == "" {
+		return nil, nil
+	}
+
+	coreEntrypoints, err := locateJSONEntrypoints(opts, "core")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate core entrypoints: %w", err)
+	}
+
+	panelsEntrypoints, err := locateJSONEntrypoints(opts, "panels")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate panel entrypoints: %w", err)
+	}
+
+	dataqueriesEntrypoints, err := locateJSONEntrypoints(opts, "dataqueries")
+	if err != nil {
+		return nil, fmt.Errorf("could not locate dataqueries entrypoints: %w", err)
+	}
+
+	coreSchemas, err := loadJSONEntryPoints(coreEntrypoints, ast.SchemaMeta{
+		Kind: ast.SchemaKindCore,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	panelSchemas, err := loadJSONEntryPoints(panelsEntrypoints, ast.SchemaMeta{
+		Kind:    ast.SchemaKindComposable,
+		Variant: ast.SchemaVariantPanel,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dataqueriesSchemas, err := loadJSONEntryPoints(dataqueriesEntrypoints, ast.SchemaMeta{
+		Kind:    ast.SchemaKindComposable,
+		Variant: ast.SchemaVariantDataQuery,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	allSchemas = append(allSchemas, coreSchemas...)
+	allSchemas = append(allSchemas, panelSchemas...)
+	allSchemas = append(allSchemas, dataqueriesSchemas...)
+
+	return allSchemas, nil
+}
+
+func loadJSONEntryPoints(entrypoints []string, schemaMeta ast.SchemaMeta) ([]*ast.Schema, error) {
+	allSchemas := make([]*ast.Schema, 0, len(entrypoints))
+	for _, entrypoint := range entrypoints {
+		reader, err := os.Open(entrypoint)
+		if err != nil {
+			return nil, err
+		}
+
+		pkg := guessPackageFromFilename(entrypoint)
+
+		meta := schemaMeta
+		meta.Identifier = pkg
+
+		schemaAst, err := jsonschema.GenerateAST(reader, jsonschema.Config{
+			Package:        pkg,
+			SchemaMetadata: meta,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		allSchemas = append(allSchemas, schemaAst)
+	}
+
+	return allSchemas, nil
+}
+
+func locateJSONEntrypoints(opts Options, kind string) ([]string, error) {
+	directory := filepath.Join(opts.JSONSchemaRegistryPath, kind)
+
+	var results []string
+	err := filepath.WalkDir(directory, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		results = append(results, path)
+
+		return nil
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/cmd/cli/loaders/jsonregistry.go
+++ b/cmd/cli/loaders/jsonregistry.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/cog/internal/jsonschema"
 )
 
-func jsonschemaRegistryLoader(opts Options) ([]*ast.Schema, error) {
+func jsonschemaRegistryLoader(opts Options) (ast.Schemas, error) {
 	var allSchemas []*ast.Schema
 
 	if opts.JSONSchemaRegistryPath == "" {

--- a/cmd/cli/loaders/jsonschema.go
+++ b/cmd/cli/loaders/jsonschema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/cog/internal/jsonschema"
 )
 
-func jsonschemaLoader(opts Options) ([]*ast.Schema, error) {
+func jsonschemaLoader(opts Options) (ast.Schemas, error) {
 	allSchemas := make([]*ast.Schema, 0, len(opts.JSONSchemaEntrypoints))
 	for _, entrypoint := range opts.JSONSchemaEntrypoints {
 		reader, err := os.Open(entrypoint)

--- a/cmd/cli/loaders/kindregistry.go
+++ b/cmd/cli/loaders/kindregistry.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 )
 
-func kindRegistryLoader(opts Options) ([]*ast.Schema, error) {
+func kindRegistryLoader(opts Options) (ast.Schemas, error) {
 	var allSchemas []*ast.Schema
 
 	if opts.KindRegistryPath == "" {

--- a/cmd/cli/loaders/kindsyscomposable.go
+++ b/cmd/cli/loaders/kindsyscomposable.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysComposableLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysComposableLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/kindsyscore.go
+++ b/cmd/cli/loaders/kindsyscore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysCoreLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysCoreLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/kindsyscustom.go
+++ b/cmd/cli/loaders/kindsyscustom.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-func kindsysCustomLoader(opts Options) ([]*ast.Schema, error) {
+func kindsysCustomLoader(opts Options) (ast.Schemas, error) {
 	libraries, err := opts.cueIncludeImports()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/loaders/openapi.go
+++ b/cmd/cli/loaders/openapi.go
@@ -5,7 +5,7 @@ import (
 	"github.com/grafana/cog/internal/openapi"
 )
 
-func openapiLoader(opts Options) ([]*ast.Schema, error) {
+func openapiLoader(opts Options) (ast.Schemas, error) {
 	allSchemas := make([]*ast.Schema, 0, len(opts.OpenAPIEntrypoints))
 	for _, entrypoint := range opts.OpenAPIEntrypoints {
 		schemaAst, err := openapi.GenerateAST(entrypoint, openapi.Config{

--- a/cmd/cli/loaders/options.go
+++ b/cmd/cli/loaders/options.go
@@ -12,24 +12,26 @@ import (
 type LoaderRef string
 
 const (
-	CUE               LoaderRef = "cue"
-	KindsysCore       LoaderRef = "kindsys-core"
-	KindsysComposable LoaderRef = "kindsys-composable"
-	KindsysCustom     LoaderRef = "kindsys-custom"
-	JSONSchema        LoaderRef = "jsonschema"
-	OpenAPI           LoaderRef = "openapi"
-	KindRegistry      LoaderRef = "kind-registry"
+	CUE                LoaderRef = "cue"
+	KindsysCore        LoaderRef = "kindsys-core"
+	KindsysComposable  LoaderRef = "kindsys-composable"
+	KindsysCustom      LoaderRef = "kindsys-custom"
+	JSONSchema         LoaderRef = "jsonschema"
+	OpenAPI            LoaderRef = "openapi"
+	KindRegistry       LoaderRef = "kind-registry"
+	JSONSchemaRegistry LoaderRef = "jsonschema-registry"
 )
 
 func loadersMap() map[LoaderRef]Loader {
 	return map[LoaderRef]Loader{
-		CUE:               cueLoader,
-		KindsysCore:       kindsysCoreLoader,
-		KindsysComposable: kindsysComposableLoader,
-		KindsysCustom:     kindsysCustomLoader,
-		JSONSchema:        jsonschemaLoader,
-		OpenAPI:           openapiLoader,
-		KindRegistry:      kindRegistryLoader,
+		CUE:                cueLoader,
+		KindsysCore:        kindsysCoreLoader,
+		KindsysComposable:  kindsysComposableLoader,
+		KindsysCustom:      kindsysCustomLoader,
+		JSONSchema:         jsonschemaLoader,
+		OpenAPI:            openapiLoader,
+		KindRegistry:       kindRegistryLoader,
+		JSONSchemaRegistry: jsonschemaRegistryLoader,
 	}
 }
 
@@ -43,6 +45,7 @@ type Options struct {
 	JSONSchemaEntrypoints        []string
 	OpenAPIEntrypoints           []string
 	KindRegistryPath             string
+	JSONSchemaRegistryPath       string
 
 	// Cue-specific options
 	CueImports []string

--- a/cmd/cli/loaders/options.go
+++ b/cmd/cli/loaders/options.go
@@ -35,7 +35,7 @@ func loadersMap() map[LoaderRef]Loader {
 	}
 }
 
-type Loader func(opts Options) ([]*ast.Schema, error)
+type Loader func(opts Options) (ast.Schemas, error)
 
 type Options struct {
 	CueEntrypoints               []string
@@ -86,8 +86,8 @@ func ForSchemaType(schemaType LoaderRef) (Loader, error) {
 	return loader, nil
 }
 
-func LoadAll(opts Options) ([]*ast.Schema, error) {
-	var allSchemas []*ast.Schema
+func LoadAll(opts Options) (ast.Schemas, error) {
+	var allSchemas ast.Schemas
 
 	for loaderRef := range loadersMap() {
 		loader, err := ForSchemaType(loaderRef)
@@ -103,7 +103,7 @@ func LoadAll(opts Options) ([]*ast.Schema, error) {
 		allSchemas = append(allSchemas, schemas...)
 	}
 
-	return allSchemas, nil
+	return allSchemas.Consolidate()
 }
 
 func guessPackageFromFilename(filename string) string {

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type Kind string
@@ -475,6 +477,13 @@ func NewObject(pkg string, name string, objectType Type) Object {
 			ReferredType: name,
 		},
 	}
+}
+
+func (object Object) Equal(other Object) bool {
+	return object.Name == other.Name &&
+		cmp.Equal(object.Comments, other.Comments) &&
+		cmp.Equal(object.Type, other.Type) &&
+		cmp.Equal(object.SelfRef, other.SelfRef)
 }
 
 func (object Object) DeepCopy() Object {


### PR DESCRIPTION
In the context of https://github.com/grafana/cog/issues/71, I'm generating JSON schemas for a lot of types defined in grafana/grafana.

To be able to use these schemas with cog, I am relying on a "jsonschema registry" loader that this PR introduces.

It's not meant to stay in the codebase forever since we don't have a clear path forward on how schemas will be defined and where they'll be published, but this loader can at least be useful in the context of #71