### PR TITLE
Do not exclude the `regex` option from QueryVariable builders

### DIFF
--- a/config/dashboard.variables.veneers.common.yaml
+++ b/config/dashboard.variables.veneers.common.yaml
@@ -83,7 +83,6 @@ options:
   # QueryVariable #
   #################
   - omit: { by_builder: QueryVariable.skipUrlSync }
-  - omit: { by_builder: QueryVariable.regex }
 
   #################
   # AdHocVariable #


### PR DESCRIPTION
This option was omitted by mistake: it should exist for that type of variable.

Fixes grafana/grafana-foundation-sdk#37