### PR TITLE
Add missing "interval" field in prometheus dataquery

### DIFF
--- a/internal/ast/compiler/compiler.go
+++ b/internal/ast/compiler/compiler.go
@@ -43,6 +43,7 @@ func CommonPasses() Passes {
 		&DashboardTimePicker{},
 		&Cloudwatch{},
 		&GoogleCloudMonitoring{},
+		&PrometheusDataquery{},
 		&LibraryPanels{},
 		&TestData{},
 	}

--- a/internal/ast/compiler/constants.go
+++ b/internal/ast/compiler/constants.go
@@ -5,6 +5,9 @@ const (
 	libraryPanelObject     = "LibraryPanel"
 	libraryPanelModelField = "model"
 
+	prometheusPackage         = "prometheus"
+	prometheusDataqueryObject = "dataquery"
+
 	dashboardPackage                = "dashboard"
 	dashboardObject                 = "Dashboard"
 	dashboardPanelObject            = "Panel"

--- a/internal/ast/compiler/prometheusdataquery.go
+++ b/internal/ast/compiler/prometheusdataquery.go
@@ -1,0 +1,45 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*PrometheusDataquery)(nil)
+
+// PrometheusDataquery rewrites the definition of the prometheus.Dataquery type and adds a few missing fields.
+// Note: this pass is meant to be removed once the schema is up-to-date.
+type PrometheusDataquery struct {
+}
+
+func (pass *PrometheusDataquery) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for i, schema := range schemas {
+		schemas[i] = pass.processSchema(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *PrometheusDataquery) processSchema(schema *ast.Schema) *ast.Schema {
+	for i, object := range schema.Objects {
+		if schema.Package == prometheusPackage && object.Name == prometheusDataqueryObject {
+			schema.Objects[i] = pass.processDataquery(object)
+			continue
+		}
+	}
+
+	return schema
+}
+
+func (pass *PrometheusDataquery) processDataquery(object ast.Object) ast.Object {
+	if !object.Type.IsStruct() {
+		return object
+	}
+
+	if _, exists := object.Type.AsStruct().FieldByName("interval"); !exists {
+		object.Type.Struct.Fields = append(object.Type.Struct.Fields,
+			ast.NewStructField("interval", ast.String(), ast.Comments([]string{"An additional lower limit for the step parameter of the Prometheus query and for the", "`$__interval` and `$__rate_interval` variables."})),
+		)
+	}
+
+	return object
+}

--- a/internal/ast/compiler/prometheusdataquery.go
+++ b/internal/ast/compiler/prometheusdataquery.go
@@ -8,8 +8,7 @@ var _ Pass = (*PrometheusDataquery)(nil)
 
 // PrometheusDataquery rewrites the definition of the prometheus.Dataquery type and adds a few missing fields.
 // Note: this pass is meant to be removed once the schema is up-to-date.
-type PrometheusDataquery struct {
-}
+type PrometheusDataquery struct{}
 
 func (pass *PrometheusDataquery) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
 	for i, schema := range schemas {
@@ -23,7 +22,6 @@ func (pass *PrometheusDataquery) processSchema(schema *ast.Schema) *ast.Schema {
 	for i, object := range schema.Objects {
 		if schema.Package == prometheusPackage && object.Name == prometheusDataqueryObject {
 			schema.Objects[i] = pass.processDataquery(object)
-			continue
 		}
 	}
 

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -690,6 +690,12 @@ func Required() StructFieldOption {
 	}
 }
 
+func Comments(comments []string) StructFieldOption {
+	return func(field *StructField) {
+		field.Comments = comments
+	}
+}
+
 func NewStructField(name string, fieldType Type, opts ...StructFieldOption) StructField {
 	field := StructField{
 		Name: name,


### PR DESCRIPTION
Relates to https://github.com/grafana/grafana-foundation-sdk/issues/36

The CUE schema doesn't contain this field, so until it's updated we can *artificially* define it with a compiler pass.

Cf grafana/grafana for its definition: https://github.com/grafana/grafana/blob/9c0501a1674ba66169e082984f36534427a0eaf8/public/app/plugins/datasource/prometheus/types.ts#L16