### PR TITLE
Fix go disjunctions marshalling

### DIFF
--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -96,7 +96,9 @@ func (jenny RawTypes) formatObject(def ast.Object) ([]byte, error) {
 		} else {
 			buffer.WriteString(fmt.Sprintf("type %s %s", defName, jenny.typeFormatter.formatType(def.Type)))
 		}
-	case ast.KindMap, ast.KindRef, ast.KindArray, ast.KindStruct, ast.KindIntersection:
+	case ast.KindRef:
+		buffer.WriteString(fmt.Sprintf("type %s = %s", defName, jenny.typeFormatter.formatType(def.Type)))
+	case ast.KindMap, ast.KindArray, ast.KindStruct, ast.KindIntersection:
 		buffer.WriteString(fmt.Sprintf("type %s %s", defName, jenny.typeFormatter.formatType(def.Type)))
 	default:
 		return nil, fmt.Errorf("unhandled type def kind: %s", def.Type.Kind)

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -1,4 +1,4 @@
-func (resource *{{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
+func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|upperCamelCase }} != nil {
 		return json.Marshal(resource.{{ .Name|upperCamelCase }})

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
@@ -1,4 +1,4 @@
-func (resource *{{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
+func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|upperCamelCase }} != nil {
 		return json.Marshal(resource.{{ .Name|upperCamelCase }})

--- a/testdata/jennies/rawtypes/disjunctions/GoJSONMarshalling/disjunctions/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoJSONMarshalling/disjunctions/types_json_marshalling_gen.go
@@ -1,5 +1,5 @@
 package disjunctions
-func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]byte, error) {
+func (resource SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]byte, error) {
 	if resource.SomeStruct != nil {
 		return json.Marshal(resource.SomeStruct)
 	}
@@ -59,7 +59,7 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 	return fmt.Errorf("could not unmarshal resource with `Type = %v`", discriminator)
 }
 
-func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
+func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {
 		return json.Marshal(resource.String)
 	}

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -1,7 +1,7 @@
 package disjunctions
 
 // Refresh rate or disabled.
-type RefreshRate StringOrBool
+type RefreshRate = StringOrBool
 
 type StringOrNull *string
 
@@ -10,7 +10,7 @@ type SomeStruct struct {
 	FieldAny any `json:"FieldAny"`
 }
 
-type BoolOrRef BoolOrSomeStruct
+type BoolOrRef = BoolOrSomeStruct
 
 type SomeOtherStruct struct {
 	Type string `json:"Type"`
@@ -22,7 +22,7 @@ type YetAnotherStruct struct {
 	Bar uint8 `json:"Bar"`
 }
 
-type SeveralRefs SomeStructOrSomeOtherStructOrYetAnotherStruct
+type SeveralRefs = SomeStructOrSomeOtherStructOrYetAnotherStruct
 
 type BoolOrSomeStruct struct {
 	Bool *bool `json:"Bool,omitempty"`

--- a/testdata/jennies/rawtypes/package-with-dashes/GoJSONMarshalling/withdashes/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoJSONMarshalling/withdashes/types_json_marshalling_gen.go
@@ -1,5 +1,5 @@
 package withdashes
-func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
+func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {
 		return json.Marshal(resource.String)
 	}

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -5,7 +5,7 @@ type SomeStruct struct {
 }
 
 // Refresh rate or disabled.
-type RefreshRate StringOrBool
+type RefreshRate = StringOrBool
 
 type StringOrBool struct {
 	String *string `json:"String,omitempty"`

--- a/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
@@ -8,7 +8,7 @@ type SomeStruct struct {
 	FieldAny any `json:"FieldAny"`
 }
 
-type RefToSomeStruct SomeStruct
+type RefToSomeStruct = SomeStruct
 
-type RefToSomeStructFromOtherPackage otherpkg.SomeDistantStruct
+type RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoJSONMarshalling/struct_complex_fields/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoJSONMarshalling/struct_complex_fields/types_json_marshalling_gen.go
@@ -1,5 +1,5 @@
 package struct_complex_fields
-func (resource *StringOrBool) MarshalJSON() ([]byte, error) {
+func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {
 		return json.Marshal(resource.String)
 	}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-foundation-sdk/issues/38

This PR fixes two bugs related to how disjunctions are handled and marshaled to JSON in go.

The first commit ensures that a struct resulting from a disjunction is marshaled correctly, irrelevantly of whether you use a pointer receiver or not.

The second commit ensures that type aliases are actually defined as aliases (as opposed to a new type). This is to ensure that the correct `MarshalJSON()` function will be called when marshaling.