### PR TITLE
Fix generation of struct fields defined as a reference to a constant

### DIFF
--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -58,7 +58,7 @@ func (jenny JSONMarshalling) generateSchema(context common.Context, schema *ast.
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = defaultTypeFormatter(jenny.packageMapper)
+	jenny.typeFormatter = defaultTypeFormatter(context, jenny.packageMapper)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		if jenny.objectNeedsCustomMarshal(object) {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -25,7 +25,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
-		output, err := jenny.generateSchema(schema)
+		output, err := jenny.generateSchema(context, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -41,12 +41,12 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
+func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
 	var buffer strings.Builder
 	var err error
 
 	imports := NewImportMap()
-	jenny.typeFormatter = defaultTypeFormatter(func(pkg string) string {
+	jenny.typeFormatter = defaultTypeFormatter(context, func(pkg string) string {
 		if imports.IsIdentical(pkg, schema.Package) {
 			return ""
 		}

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -30,7 +30,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
-		output, err := jenny.generateSchema(schema)
+		output, err := jenny.generateSchema(context, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -47,7 +47,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
+func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
 	var buffer strings.Builder
 	var err error
 
@@ -60,7 +60,7 @@ func (jenny RawTypes) generateSchema(schema *ast.Schema) ([]byte, error) {
 		return imports.Add(pkg, fmt.Sprintf("../%s", pkg))
 	}
 
-	jenny.typeFormatter = defaultTypeFormatter(packageMapper)
+	jenny.typeFormatter = defaultTypeFormatter(context, packageMapper)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		typeDefGen, innerErr := jenny.formatObject(object, packageMapper)
@@ -301,7 +301,11 @@ func (jenny RawTypes) defaultValuesForReference(typeDef ast.Type, packageMapper 
 
 	// is the reference to a constant?
 	if referredType.Type.Kind == ast.KindScalar && referredType.Type.AsScalar().IsConcrete() {
-		return raw(fmt.Sprintf("%s.%s", ref.ReferredPkg, ref.ReferredType))
+		if pkg != "" {
+			return raw(fmt.Sprintf("%s.%s", pkg, ref.ReferredType))
+		}
+
+		return raw(ref.ReferredType)
 	}
 
 	if referredType.Type.Kind == ast.KindEnum {
@@ -314,7 +318,7 @@ func (jenny RawTypes) defaultValuesForReference(typeDef ast.Type, packageMapper 
 	}
 
 	if pkg != "" {
-		return raw(fmt.Sprintf("%s.default%s()", ref.ReferredPkg, ref.ReferredType))
+		return raw(fmt.Sprintf("%s.default%s()", pkg, ref.ReferredType))
 	}
 
 	return raw(fmt.Sprintf("default%s()", ref.ReferredType))

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -12,7 +12,10 @@ type SomeStruct struct {
 	FieldAnonymousStruct struct {
 	FieldAny any `json:"FieldAny"`
 } `json:"FieldAnonymousStruct"`
+	FieldRefToConstant string `json:"fieldRefToConstant"`
 }
+
+const ConnectionPath = "straight"
 
 type SomeOtherStruct struct {
 	FieldAny any `json:"FieldAny"`

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/Constants.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/Constants.java
@@ -1,0 +1,5 @@
+package struct_complex_fields;
+
+public class Constants {
+    public static final String ConnectionPath = "straight";
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -12,5 +12,6 @@ public class SomeStruct {
     public List<String> FieldArrayOfStrings;
     public Map<String, String> FieldMapOfStringToString;
     public StructComplexFieldsSomeStructFieldAnonymousStruct FieldAnonymousStruct;
+    public String fieldRefToConstant;
     
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -14,8 +14,9 @@ class SomeStruct:
     field_array_of_strings: list[str]
     field_map_of_string_to_string: dict[str, str]
     field_anonymous_struct: 'StructComplexFieldsSomeStructFieldAnonymousStruct'
+    field_ref_to_constant: 'ConnectionPath'
 
-    def __init__(self, field_ref: typing.Optional['SomeOtherStruct'] = None, field_disjunction_of_scalars: typing.Union[str, bool] = "", field_mixed_disjunction: typing.Union[str, 'SomeOtherStruct'] = "", field_disjunction_with_null: typing.Optional[str] = None, operator: typing.Optional[typing.Literal[">", "<"]] = None, field_array_of_strings: typing.Optional[list[str]] = None, field_map_of_string_to_string: typing.Optional[dict[str, str]] = None, field_anonymous_struct: typing.Optional['StructComplexFieldsSomeStructFieldAnonymousStruct'] = None):
+    def __init__(self, field_ref: typing.Optional['SomeOtherStruct'] = None, field_disjunction_of_scalars: typing.Union[str, bool] = "", field_mixed_disjunction: typing.Union[str, 'SomeOtherStruct'] = "", field_disjunction_with_null: typing.Optional[str] = None, operator: typing.Optional[typing.Literal[">", "<"]] = None, field_array_of_strings: typing.Optional[list[str]] = None, field_map_of_string_to_string: typing.Optional[dict[str, str]] = None, field_anonymous_struct: typing.Optional['StructComplexFieldsSomeStructFieldAnonymousStruct'] = None, field_ref_to_constant: typing.Optional['ConnectionPath'] = None):
         self.field_ref = field_ref if field_ref is not None else SomeOtherStruct()
         self.field_disjunction_of_scalars = field_disjunction_of_scalars
         self.field_mixed_disjunction = field_mixed_disjunction
@@ -24,6 +25,7 @@ class SomeStruct:
         self.field_array_of_strings = field_array_of_strings if field_array_of_strings is not None else []
         self.field_map_of_string_to_string = field_map_of_string_to_string if field_map_of_string_to_string is not None else {}
         self.field_anonymous_struct = field_anonymous_struct if field_anonymous_struct is not None else StructComplexFieldsSomeStructFieldAnonymousStruct()
+        self.field_ref_to_constant = field_ref_to_constant if field_ref_to_constant is not None else ConnectionPath()
 
     def to_json(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -35,6 +37,7 @@ class SomeStruct:
             "FieldArrayOfStrings": self.field_array_of_strings,
             "FieldMapOfStringToString": self.field_map_of_string_to_string,
             "FieldAnonymousStruct": None if self.field_anonymous_struct is None else self.field_anonymous_struct.to_json(),
+            "fieldRefToConstant": self.field_ref_to_constant,
         }
         return payload
 
@@ -49,8 +52,12 @@ class SomeStruct:
             "field_array_of_strings": data["FieldArrayOfStrings"],
             "field_map_of_string_to_string": data["FieldMapOfStringToString"],
             "field_anonymous_struct": StructComplexFieldsSomeStructFieldAnonymousStruct.from_json(data["FieldAnonymousStruct"]),
+            "field_ref_to_constant": data["fieldRefToConstant"],
         }
         return cls(**args)
+
+
+ConnectionPath = typing.Literal["straight"]
 
 
 class SomeOtherStruct:

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/TypescriptRawTypes/src/struct_complex_fields/types_gen.ts
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/TypescriptRawTypes/src/struct_complex_fields/types_gen.ts
@@ -10,6 +10,7 @@ export interface SomeStruct {
 	FieldAnonymousStruct: {
 		FieldAny: any;
 	};
+	fieldRefToConstant: "straight";
 }
 
 export const defaultSomeStruct = (): SomeStruct => ({
@@ -23,7 +24,10 @@ export const defaultSomeStruct = (): SomeStruct => ({
 	FieldAnonymousStruct: {
 	FieldAny: {},
 },
+	fieldRefToConstant: ConnectionPath,
 });
+
+export const ConnectionPath = "straight";
 
 export interface SomeOtherStruct {
 	FieldAny: any;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/ir.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/ir.json
@@ -182,9 +182,36 @@
                   ]
                 }
               }
+            },
+            {
+              "Name": "fieldRefToConstant",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "struct_complex_fields",
+                  "ReferredType": "ConnectionPath"
+                }
+              },
+              "Required": true
             }
           ]
         }
+      }
+    },
+    "ConnectionPath": {
+      "Name": "ConnectionPath",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "string",
+          "Value": "straight"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "struct_complex_fields",
+        "ReferredType": "ConnectionPath"
       }
     },
     "SomeOtherStruct": {


### PR DESCRIPTION
See the test case.

Cog currently generates invalid code for struct fields defined as a reference to a constant.