### PR TITLE
Enable the `library_panels` compiler pass

### DIFF
--- a/config/compiler/common_passes.yaml
+++ b/config/compiler/common_passes.yaml
@@ -9,5 +9,6 @@ passes:
 
   - cloudwatch: {}
   - google_cloud_monitoring: {}
+  - library_panels: {}
   - prometheus_dataquery: {}
   - test_data: {}


### PR DESCRIPTION
It was disabled by mistake in #255 :facepalm: 