### PR TITLE
Support arbitrary nesting levels of arrays of builders in Go

### DIFF
--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -47,29 +47,47 @@
     {{- end }}
     {{- with .Value.Argument }}
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
+        {{- $builtResultName := (print (formatArgName .Name) "Resource") }}
         {{- if .Type.IsArray }}
         {{ formatArgName .Name}}Resources := make({{ .Type | formatTypeNoBuilder }}, 0, len({{ formatArgName .Name}}))
-        for _, r := range {{ formatArgName .Name}} {
-            {{ formatArgName .Name}}Resource, err := r.Build()
-            if err != nil {
-                builder.errors["{{ $.Assignment.Path }}"] = err.(cog.BuildErrors)
-                return builder
-            }
-            {{ formatArgName .Name}}Resources = append({{ formatArgName .Name}}Resources, {{ formatArgName .Name}}Resource)
-        }
-        {{- else }}
-        {{ formatArgName .Name}}Resource, err := {{ formatArgName .Name}}.Build()
-        if err != nil {
-            builder.errors["{{ $.Assignment.Path }}"] = err.(cog.BuildErrors)
-            return builder
-        }
+        {{- $builtResultName = (print (formatArgName .Name) "Resources") }}
         {{- end }}
+
+        {{- template "unfold_builders" (dict "Depth" 1 "InputType" .Type "OriginalInputVar" (formatArgName .Name) "InputVar" (formatArgName .Name) "AssignmentPath" $.Assignment.Path "ResultVar" $builtResultName) }}
         {{- end }}
     {{- end }}
     {{- with .Value.Envelope }}
         {{- range .Values }}
         {{- template "assignment_setup" (dict "Assignment" $.Assignment "Value" .Value) }}
         {{- end }}
+    {{- end }}
+{{- end }}
+
+
+{{- define "unfold_builders" }}
+    {{- if .InputType.IsArray }}
+        for _, r{{ .Depth }} := range {{ .InputVar}} {
+            {{- if .InputType.Array.ValueType.IsArray }}
+                {{ .OriginalInputVar }}Depth{{ .Depth }} := make({{ .InputType.Array.ValueType | formatTypeNoBuilder }}, 0)
+
+                {{- template "unfold_builders" (dict "Depth" (add1 .Depth) "InputType" .InputType.Array.ValueType "OriginalInputVar" .OriginalInputVar "InputVar" (print "r" .Depth) "AssignmentPath" $.AssignmentPath "ResultVar" (print .OriginalInputVar "Depth" .Depth)) }}
+
+                {{ .ResultVar }} = append({{ .ResultVar}}, {{ .OriginalInputVar }}Depth{{ .Depth }})
+            {{- else }}
+                {{ .OriginalInputVar }}Depth{{ .Depth }}, err := r{{ .Depth }}.Build()
+                if err != nil {
+                    builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                {{ .ResultVar }} = append({{ .ResultVar}}, {{ .OriginalInputVar }}Depth{{ .Depth }})
+            {{- end }}
+        }
+    {{- else }}
+    {{ .ResultVar }}, err := {{ .InputVar}}.Build()
+    if err != nil {
+        builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+        return builder
+    }
     {{- end }}
 {{- end }}
 

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
@@ -52,26 +52,47 @@ func (builder *DashboardBuilder) Title(title string) *DashboardBuilder {
 // will be expanded to []cog.Builder<DashboardLink>
 func (builder *DashboardBuilder) Links(links []cog.Builder[DashboardLink]) *DashboardBuilder {
         linksResources := make([]DashboardLink, 0, len(links))
-        for _, r := range links {
-            linksResource, err := r.Build()
-            if err != nil {
-                builder.errors["links"] = err.(cog.BuildErrors)
-                return builder
-            }
-            linksResources = append(linksResources, linksResource)
+        for _, r1 := range links {
+                linksDepth1, err := r1.Build()
+                if err != nil {
+                    builder.errors["links"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                linksResources = append(linksResources, linksDepth1)
         }
     builder.internal.Links = linksResources
 
     return builder
 }
 
+// will be expanded to [][]cog.Builder<DashboardLink>
+func (builder *DashboardBuilder) LinksOfLinks(linksOfLinks [][]cog.Builder[DashboardLink]) *DashboardBuilder {
+        linksOfLinksResources := make([][]DashboardLink, 0, len(linksOfLinks))
+        for _, r1 := range linksOfLinks {
+                linksOfLinksDepth1 := make([]DashboardLink, 0)
+        for _, r2 := range r1 {
+                linksOfLinksDepth2, err := r2.Build()
+                if err != nil {
+                    builder.errors["linksOfLinks"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                linksOfLinksDepth1 = append(linksOfLinksDepth1, linksOfLinksDepth2)
+        }
+
+                linksOfLinksResources = append(linksOfLinksResources, linksOfLinksDepth1)
+        }
+    builder.internal.LinksOfLinks = linksOfLinksResources
+
+    return builder
+}
+
 // will be expanded to cog.Builder<DashboardLink>
 func (builder *DashboardBuilder) SingleLink(singleLink cog.Builder[DashboardLink]) *DashboardBuilder {
-        singleLinkResource, err := singleLink.Build()
-        if err != nil {
-            builder.errors["singleLink"] = err.(cog.BuildErrors)
-            return builder
-        }
+    singleLinkResource, err := singleLink.Build()
+    if err != nil {
+        builder.errors["singleLink"] = err.(cog.BuildErrors)
+        return builder
+    }
     builder.internal.SingleLink = singleLinkResource
 
     return builder

--- a/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
+++ b/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
@@ -52,6 +52,16 @@ class Dashboard(cogbuilder.Builder[builder_delegation.Dashboard]):
     
         return self
     
+    def links_of_links(self, links_of_links: list[list[cogbuilder.Builder[builder_delegation.DashboardLink]]]) -> typing.Self:    
+        """
+        will be expanded to [][]cog.Builder<DashboardLink>
+        """
+            
+        links_of_links_resources = [r.build() for r in links_of_links]
+        self.__internal.links_of_links = links_of_links_resources
+    
+        return self
+    
     def single_link(self, single_link: cogbuilder.Builder[builder_delegation.DashboardLink]) -> typing.Self:    
         """
         will be expanded to cog.Builder<DashboardLink>

--- a/testdata/jennies/builders/builder_delegation/TypescriptBuilder/src/builder_delegation/dashboard_builder_gen.ts
+++ b/testdata/jennies/builders/builder_delegation/TypescriptBuilder/src/builder_delegation/dashboard_builder_gen.ts
@@ -29,6 +29,13 @@ export class DashboardBuilder implements cog.Builder<builder_delegation.Dashboar
         return this;
     }
 
+    // will be expanded to [][]cog.Builder<DashboardLink>
+    linksOfLinks(linksOfLinks: cog.Builder<builder_delegation.DashboardLink>[][]): this {
+        const linksOfLinksResources = linksOfLinks.map(builder => builder.build());
+        this.internal.linksOfLinks = linksOfLinksResources;
+        return this;
+    }
+
     // will be expanded to cog.Builder<DashboardLink>
     singleLink(singleLink: cog.Builder<builder_delegation.DashboardLink>): this {
         const singleLinkResource = singleLink.build();

--- a/testdata/jennies/builders/builder_delegation/builders_context.json
+++ b/testdata/jennies/builders/builder_delegation/builders_context.json
@@ -92,6 +92,33 @@
                   "Required": true
                 },
                 {
+                  "Name": "linksOfLinks",
+                  "Comments": [
+                    "will be expanded to [][]cog.Builder\u003cDashboardLink\u003e"
+                  ],
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "array",
+                        "Nullable": false,
+                        "Array": {
+                          "ValueType": {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation",
+                              "ReferredType": "DashboardLink"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                },
+                {
                   "Name": "singleLink",
                   "Comments": [
                     "will be expanded to cog.Builder\u003cDashboardLink\u003e"
@@ -204,6 +231,33 @@
                           "Ref": {
                             "ReferredPkg": "builder_delegation",
                             "ReferredType": "DashboardLink"
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "linksOfLinks",
+                    "Comments": [
+                      "will be expanded to [][]cog.Builder\u003cDashboardLink\u003e"
+                    ],
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "array",
+                          "Nullable": false,
+                          "Array": {
+                            "ValueType": {
+                              "Kind": "ref",
+                              "Nullable": false,
+                              "Ref": {
+                                "ReferredPkg": "builder_delegation",
+                                "ReferredType": "DashboardLink"
+                              }
+                            }
                           }
                         }
                       }
@@ -460,6 +514,33 @@
                     "Required": true
                   },
                   {
+                    "Name": "linksOfLinks",
+                    "Comments": [
+                      "will be expanded to [][]cog.Builder\u003cDashboardLink\u003e"
+                    ],
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "array",
+                          "Nullable": false,
+                          "Array": {
+                            "ValueType": {
+                              "Kind": "ref",
+                              "Nullable": false,
+                              "Ref": {
+                                "ReferredPkg": "builder_delegation",
+                                "ReferredType": "DashboardLink"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
                     "Name": "singleLink",
                     "Comments": [
                       "will be expanded to cog.Builder\u003cDashboardLink\u003e"
@@ -528,6 +609,33 @@
                       "Ref": {
                         "ReferredPkg": "builder_delegation",
                         "ReferredType": "DashboardLink"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "linksOfLinks",
+                "Comments": [
+                  "will be expanded to [][]cog.Builder\u003cDashboardLink\u003e"
+                ],
+                "Type": {
+                  "Kind": "array",
+                  "Nullable": false,
+                  "Array": {
+                    "ValueType": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation",
+                            "ReferredType": "DashboardLink"
+                          }
+                        }
                       }
                     }
                   }
@@ -708,6 +816,93 @@
                         "Ref": {
                           "ReferredPkg": "builder_delegation",
                           "ReferredType": "DashboardLink"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        },
+        {
+          "Name": "linksOfLinks",
+          "Comments": [
+            "will be expanded to [][]cog.Builder\u003cDashboardLink\u003e"
+          ],
+          "Args": [
+            {
+              "Name": "linksOfLinks",
+              "Type": {
+                "Kind": "array",
+                "Nullable": false,
+                "Array": {
+                  "ValueType": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "builder_delegation",
+                          "ReferredType": "DashboardLink"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "linksOfLinks",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "array",
+                        "Nullable": false,
+                        "Array": {
+                          "ValueType": {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation",
+                              "ReferredType": "DashboardLink"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "linksOfLinks",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "array",
+                        "Nullable": false,
+                        "Array": {
+                          "ValueType": {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation",
+                              "ReferredType": "DashboardLink"
+                            }
+                          }
                         }
                       }
                     }

--- a/testdata/jennies/builders/builder_delegation/schema.cue
+++ b/testdata/jennies/builders/builder_delegation/schema.cue
@@ -9,5 +9,6 @@ Dashboard: {
 	id: int64
 	title: string
 	links: [...#DashboardLink] // will be expanded to []cog.Builder<DashboardLink>
+	linksOfLinks: [...[...#DashboardLink]] // will be expanded to [][]cog.Builder<DashboardLink>
 	singleLink: #DashboardLink // will be expanded to cog.Builder<DashboardLink>
 }

--- a/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
@@ -39,11 +39,11 @@ func (builder *LokiBuilderBuilder) Build() (Dashboard, error) {
 }
 
 func (builder *LokiBuilderBuilder) Target(target cog.Builder[cogvariants.Dataquery]) *LokiBuilderBuilder {
-        targetResource, err := target.Build()
-        if err != nil {
-            builder.errors["target"] = err.(cog.BuildErrors)
-            return builder
-        }
+    targetResource, err := target.Build()
+    if err != nil {
+        builder.errors["target"] = err.(cog.BuildErrors)
+        return builder
+    }
     builder.internal.Target = targetResource
 
     return builder
@@ -51,13 +51,13 @@ func (builder *LokiBuilderBuilder) Target(target cog.Builder[cogvariants.Dataque
 
 func (builder *LokiBuilderBuilder) Targets(targets []cog.Builder[cogvariants.Dataquery]) *LokiBuilderBuilder {
         targetsResources := make([]cogvariants.Dataquery, 0, len(targets))
-        for _, r := range targets {
-            targetsResource, err := r.Build()
-            if err != nil {
-                builder.errors["targets"] = err.(cog.BuildErrors)
-                return builder
-            }
-            targetsResources = append(targetsResources, targetsResource)
+        for _, r1 := range targets {
+                targetsDepth1, err := r1.Build()
+                if err != nil {
+                    builder.errors["targets"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                targetsResources = append(targetsResources, targetsDepth1)
         }
     builder.internal.Targets = targetsResources
 

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
@@ -38,33 +38,33 @@ func (builder *StructBuilder) Build() (Struct, error) {
 }
 
 func (builder *StructBuilder) AllFields(allFields cog.Builder[NestedStruct]) *StructBuilder {
-        allFieldsResource, err := allFields.Build()
-        if err != nil {
-            builder.errors["allFields"] = err.(cog.BuildErrors)
-            return builder
-        }
+    allFieldsResource, err := allFields.Build()
+    if err != nil {
+        builder.errors["allFields"] = err.(cog.BuildErrors)
+        return builder
+    }
     builder.internal.AllFields = allFieldsResource
 
     return builder
 }
 
 func (builder *StructBuilder) PartialFields(partialFields cog.Builder[NestedStruct]) *StructBuilder {
-        partialFieldsResource, err := partialFields.Build()
-        if err != nil {
-            builder.errors["partialFields"] = err.(cog.BuildErrors)
-            return builder
-        }
+    partialFieldsResource, err := partialFields.Build()
+    if err != nil {
+        builder.errors["partialFields"] = err.(cog.BuildErrors)
+        return builder
+    }
     builder.internal.PartialFields = partialFieldsResource
 
     return builder
 }
 
 func (builder *StructBuilder) EmptyFields(emptyFields cog.Builder[NestedStruct]) *StructBuilder {
-        emptyFieldsResource, err := emptyFields.Build()
-        if err != nil {
-            builder.errors["emptyFields"] = err.(cog.BuildErrors)
-            return builder
-        }
+    emptyFieldsResource, err := emptyFields.Build()
+    if err != nil {
+        builder.errors["emptyFields"] = err.(cog.BuildErrors)
+        return builder
+    }
     builder.internal.EmptyFields = emptyFieldsResource
 
     return builder


### PR DESCRIPTION
```go
func (builder *InfluxQueryBuilder) Select(selectArg [][]cog.Builder[InfluxQueryPart]) *InfluxQueryBuilder {
	selectArgResources := make([][]InfluxQueryPart, 0, len(selectArg))
	for _, r1 := range selectArg {
		selectArgDepth1 := make([]InfluxQueryPart, 0)
		for _, r2 := range r1 {
			selectArgDepth2, err := r2.Build()
			if err != nil {
				builder.errors["select"] = err.(cog.BuildErrors)
				return builder
			}
			selectArgDepth1 = append(selectArgDepth1, selectArgDepth2)
		}

		selectArgResources = append(selectArgResources, selectArgDepth1)
	}
	builder.internal.Select = selectArgResources

	return builder
}
```

Instead of 

```go
func (builder *InfluxQueryBuilder) Select(selectArg [][]cog.Builder[InfluxQueryPart]) *InfluxQueryBuilder {
	selectArgResources := make([][]InfluxQueryPart, 0, len(selectArg))
	for _, r := range selectArg {
		selectArgResource, err := r.Build()
		if err != nil {
			builder.errors["select"] = err.(cog.BuildErrors)
			return builder
		}
		selectArgResources = append(selectArgResources, selectArgResource)
	}
	builder.internal.Select = selectArgResources

	return builder
}
```

ToDo:

* Apply a similar fix for Typescript, Python and Java