### PR TITLE
Better support for empty objects/any types in jsonschema

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -420,6 +420,10 @@ func (g *generator) walkObject(schema *schemaparser.Schema) (ast.Type, error) {
 			return ast.Type{}, err
 		}
 
+		if valueType.IsAny() {
+			return ast.Any(), nil
+		}
+
 		return ast.NewMap(ast.String(), valueType), nil
 	}
 

--- a/testdata/jsonschema/basic_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/basic_object/GenerateAST/ir.json
@@ -137,6 +137,63 @@
               "Required": false
             },
             {
+              "Name": "objectAdditionalPropertiesAny",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "any"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "objectAdditionalPropertiesTyped",
+              "Type": {
+                "Kind": "map",
+                "Nullable": false,
+                "Map": {
+                  "IndexType": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "ValueType": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "objectEmptyPropertiesIsAny",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "any"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "objectNoPropertiesIsAny",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "any"
+                }
+              },
+              "Required": false
+            },
+            {
               "Name": "string",
               "Type": {
                 "Kind": "scalar",

--- a/testdata/jsonschema/basic_object/schema.json
+++ b/testdata/jsonschema/basic_object/schema.json
@@ -30,6 +30,26 @@
             "foo": {}
           }
         },
+        "objectEmptyPropertiesIsAny": {
+          "type": "object",
+          "properties": {
+          }
+        },
+        "objectNoPropertiesIsAny": {
+          "type": "object"
+        },
+        "objectAdditionalPropertiesAny": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "objectAdditionalPropertiesTyped": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "array": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Fixes a few edge cases where our jsonschema parser incorrectly interpreted object definitions.