### PR TITLE
Define compiler pass trails and display them in Go

### DIFF
--- a/internal/ast/compiler/add_fields.go
+++ b/internal/ast/compiler/add_fields.go
@@ -44,6 +44,8 @@ func (pass *AddFields) processObject(object ast.Object) ast.Object {
 			continue
 		}
 
+		field.AddToPassesTrail("AddFields[created]")
+
 		object.Type.Struct.Fields = append(object.Type.Struct.Fields, field)
 	}
 

--- a/internal/ast/compiler/add_fields_test.go
+++ b/internal/ast/compiler/add_fields_test.go
@@ -24,7 +24,7 @@ func TestAddFields(t *testing.T) {
 			ast.NewObject("add_fields", "AString", ast.String()),
 			ast.NewObject("add_fields", "SomeObject", ast.NewStruct(
 				ast.NewStructField("AString", ast.String()),
-				ast.NewStructField("addedByPass", ast.Bool()),
+				ast.NewStructField("addedByPass", ast.Bool(), ast.PassesTrail("AddFields[created]")),
 			)),
 		),
 	}

--- a/internal/ast/compiler/anonymous_enum.go
+++ b/internal/ast/compiler/anonymous_enum.go
@@ -117,7 +117,10 @@ func (pass *AnonymousEnumToExplicitType) processAnonymousEnum(pkg string, parent
 		})
 	}
 
-	pass.newObjects = append(pass.newObjects, ast.NewObject(pkg, enumTypeName, ast.NewEnum(values)))
+	newObject := ast.NewObject(pkg, enumTypeName, ast.NewEnum(values))
+	newObject.AddToPassesTrail("AnonymousEnumToExplicitType")
+
+	pass.newObjects = append(pass.newObjects, newObject)
 
 	return ast.NewRef(pass.currentPackage, enumTypeName)
 }

--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -120,7 +120,10 @@ func (pass *AnonymousStructsToNamed) processStruct(pkg string, parentName string
 		def.Struct.Fields[i].Type = pass.processType(pkg, name, field.Type)
 	}
 
-	pass.newObjects = append(pass.newObjects, ast.NewObject(pkg, parentName, def))
+	newObject := ast.NewObject(pkg, parentName, def)
+	newObject.AddToPassesTrail("AnonymousStructsToNamed")
+
+	pass.newObjects = append(pass.newObjects, newObject)
 
 	ref := ast.NewRef(pkg, parentName)
 	ref.Nullable = def.Nullable

--- a/internal/ast/compiler/dashboardpanels.go
+++ b/internal/ast/compiler/dashboardpanels.go
@@ -80,21 +80,14 @@ func (pass *DashboardPanelsRewrite) processSchema(schema *ast.Schema) (*ast.Sche
 }
 
 func (pass *DashboardPanelsRewrite) overwritePanelsFieldType(object ast.Object, newPanelsFieldType ast.Type) ast.Object {
-	newFields := make([]ast.StructField, len(object.Type.AsStruct().Fields))
-	for i, field := range object.Type.AsStruct().Fields {
+	for i, field := range object.Type.Struct.Fields {
 		if field.Name != dashboardPanelsField {
-			newFields[i] = field
 			continue
 		}
 
-		newField := field
-		newField.Type = newPanelsFieldType
-
-		newFields[i] = newField
+		object.Type.Struct.Fields[i].Type = newPanelsFieldType
+		object.Type.Struct.Fields[i].AddToPassesTrail("DashboardPanelsRewrite[changed type]")
 	}
 
-	newObject := object
-	newObject.Type.Struct.Fields = newFields
-
-	return newObject
+	return object
 }

--- a/internal/ast/compiler/dashboardpanels_test.go
+++ b/internal/ast/compiler/dashboardpanels_test.go
@@ -66,7 +66,7 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 				ast.NewObject("dashboard", "RowPanel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
 					ast.NewStructField("Type", ast.String(ast.Value("row"))),
-					ast.NewStructField("panels", ast.NewArray(ast.NewRef("dashboard", "Panel"))),
+					ast.NewStructField("panels", ast.NewArray(ast.NewRef("dashboard", "Panel")), ast.PassesTrail("DashboardPanelsRewrite[changed type]")),
 				)),
 				ast.NewObject("dashboard", "GraphPanel", ast.NewStruct(
 					ast.NewStructField("Title", ast.String()),
@@ -80,7 +80,7 @@ func TestDashboardPanelsRewrite(t *testing.T) {
 					}, ast.Discriminator("type", map[string]string{
 						"row":                     "RowPanel",
 						ast.DiscriminatorCatchAll: "Panel",
-					})))),
+					}))), ast.PassesTrail("DashboardPanelsRewrite[changed type]")),
 				)),
 			),
 		},

--- a/internal/ast/compiler/dataquery_identification.go
+++ b/internal/ast/compiler/dataquery_identification.go
@@ -46,6 +46,7 @@ func (pass *DataqueryIdentification) processObject(object ast.Object, commonData
 
 	if pass.structsIntersect(typeDef, commonDataquery.Type) {
 		object.Type.Hints[ast.HintImplementsVariant] = string(ast.SchemaVariantDataQuery)
+		object.AddToPassesTrail("DataqueryIdentification[hint.ImplementsVariant=VariantDataQuery]")
 	}
 
 	return object

--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -200,6 +200,7 @@ func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Ty
 	// a reference to it.
 	if pass.newObjects.Has(newTypeName) {
 		ref := ast.NewRef(schema.Package, newTypeName, ast.Hints(def.Hints))
+		ref.AddToPassesTrail("DisjunctionToType[disjunction → ref]")
 		if def.Nullable || disjunction.Branches.HasNullType() {
 			ref.Nullable = true
 		}
@@ -246,16 +247,13 @@ func (pass *DisjunctionToType) processDisjunction(schema *ast.Schema, def ast.Ty
 		structType.Hints[ast.HintDiscriminatedDisjunctionOfRefs] = disjunction
 	}
 
-	pass.newObjects.Set(newTypeName, ast.Object{
-		Name: newTypeName,
-		Type: structType,
-		SelfRef: ast.RefType{
-			ReferredPkg:  schema.Package,
-			ReferredType: newTypeName,
-		},
-	})
+	newObject := ast.NewObject(schema.Package, newTypeName, structType)
+	newObject.AddToPassesTrail("DisjunctionToType[created]")
+
+	pass.newObjects.Set(newTypeName, newObject)
 
 	ref := ast.NewRef(schema.Package, newTypeName, ast.Hints(def.Hints))
+	ref.AddToPassesTrail("DisjunctionToType[disjunction → ref]")
 	if def.Nullable || disjunction.Branches.HasNullType() {
 		ref.Nullable = true
 	}

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -54,8 +54,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnObject(t *testing.T) {
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = objects[0].Type.AsDisjunction()
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("test", "ADisjunctionOfScalars", ast.NewRef("test", "StringOrBool")),
-		ast.NewObject("test", "StringOrBool", disjunctionStructType),
+		ast.NewObject("test", "ADisjunctionOfScalars", ast.NewRef("test", "StringOrBool", ast.Trail("DisjunctionToType[disjunction → ref]"))),
+		ast.NewObject("test", "StringOrBool", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass
@@ -85,9 +85,9 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAMapValueType(t *testing.T
 	expectedObjects := []ast.Object{
 		ast.NewObject("test", "ADisjunctionOfScalars", ast.NewMap(
 			ast.String(),
-			ast.NewRef("test", "StringOrBool"),
+			ast.NewRef("test", "StringOrBool", ast.Trail("DisjunctionToType[disjunction → ref]")),
 		)),
-		ast.NewObject("test", "StringOrBool", disjunctionStructType),
+		ast.NewObject("test", "StringOrBool", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass
@@ -116,9 +116,9 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAStructField(t *testing.T)
 
 	expectedObjects := []ast.Object{
 		ast.NewObject("test", "AStructWithADisjunctionOfScalars", ast.NewStruct(
-			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("test", "StringOrBool")),
+			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("test", "StringOrBool", ast.Trail("DisjunctionToType[disjunction → ref]"))),
 		)),
-		ast.NewObject("test", "StringOrBool", disjunctionStructType),
+		ast.NewObject("test", "StringOrBool", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass
@@ -147,9 +147,9 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsNullableAStructField(t *te
 
 	expectedObjects := []ast.Object{
 		ast.NewObject("test", "AStructWithADisjunctionOfScalars", ast.NewStruct(
-			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("test", "StringOrBool", ast.Nullable())),
+			ast.NewStructField("AFieldWithADisjunctionOfScalars", ast.NewRef("test", "StringOrBool", ast.Nullable(), ast.Trail("DisjunctionToType[disjunction → ref]"))),
 		)),
-		ast.NewObject("test", "StringOrBool", disjunctionStructType),
+		ast.NewObject("test", "StringOrBool", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass
@@ -175,8 +175,8 @@ func TestDisjunctionToType_WithDisjunctionOfScalars_AsAnArrayValueType(t *testin
 	disjunctionStructType.Hints[ast.HintDisjunctionOfScalars] = disjunctionType.AsDisjunction()
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("test", "AnArrayWithADisjunctionOfScalars", ast.NewArray(ast.NewRef("test", "StringOrBool"))),
-		ast.NewObject("test", "StringOrBool", disjunctionStructType),
+		ast.NewObject("test", "AnArrayWithADisjunctionOfScalars", ast.NewArray(ast.NewRef("test", "StringOrBool", ast.Trail("DisjunctionToType[disjunction → ref]")))),
+		ast.NewObject("test", "StringOrBool", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass
@@ -291,7 +291,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 	disjunctionStructType.Hints[ast.HintDiscriminatedDisjunctionOfRefs] = disjunctionTypeWithDiscriminatorMeta
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct")),
+		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct", ast.Trail("DisjunctionToType[disjunction → ref]"))),
 		objects[1],
 		objects[2],
 		ast.NewObject("test", "SomeStructOrOtherStruct", disjunctionStructType),

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -101,6 +101,7 @@ func (pass *DisjunctionWithNullToOptional) processDisjunction(def ast.Type) ast.
 	if len(disjunction.Branches) == 2 && disjunction.Branches.HasNullType() {
 		finalType := disjunction.Branches.NonNullTypes()[0]
 		finalType.Nullable = true
+		finalType.AddToPassesTrail(fmt.Sprintf("DisjunctionWithNullToOptional[%[1]s|null → %[1]s?]", ast.TypeName(finalType)))
 
 		return finalType
 	}

--- a/internal/ast/compiler/disjunctions_with_null_to_optional_test.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional_test.go
@@ -20,8 +20,8 @@ func TestDisjunctionWithNullToOptional_WithDisjunctionOfTypeAndNull_AsAnObject(t
 	}
 
 	expectedObjects := []ast.Object{
-		ast.NewObject("test", "ScalarWithNull", ast.String(ast.Nullable())),
-		ast.NewObject("test", "RefWithNull", ast.NewRef("test", "SomeType", ast.Nullable())),
+		ast.NewObject("test", "ScalarWithNull", ast.String(ast.Nullable(), ast.Trail("DisjunctionWithNullToOptional[String|null → String?]"))),
+		ast.NewObject("test", "RefWithNull", ast.NewRef("test", "SomeType", ast.Nullable(), ast.Trail("DisjunctionWithNullToOptional[SomeType|null → SomeType?]"))),
 	}
 
 	// Call the compiler pass
@@ -47,10 +47,10 @@ func TestDisjunctionWithNullToOptional_WithDisjunctionOfTypeAndNull_AsAStructFie
 
 	expectedObjects := []ast.Object{
 		ast.NewObject("test", "StructWithScalarWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.String(ast.Nullable())),
+			ast.NewStructField("Field", ast.String(ast.Nullable(), ast.Trail("DisjunctionWithNullToOptional[String|null → String?]"))),
 		)),
 		ast.NewObject("test", "StructWithRefWithNull", ast.NewStruct(
-			ast.NewStructField("Field", ast.NewRef("test", "SomeType", ast.Nullable())),
+			ast.NewStructField("Field", ast.NewRef("test", "SomeType", ast.Nullable(), ast.Trail("DisjunctionWithNullToOptional[SomeType|null → SomeType?]"))),
 		)),
 	}
 

--- a/internal/ast/compiler/fields_set_required.go
+++ b/internal/ast/compiler/fields_set_required.go
@@ -38,6 +38,7 @@ func (pass *FieldsSetRequired) processObject(_ string, object ast.Object) ast.Ob
 
 			field.Type.Nullable = false
 			field.Required = true
+			field.AddToPassesTrail("FieldsSetRequired[nullable=false, required=true]")
 
 			object.Type.Struct.Fields[i] = field
 		}

--- a/internal/ast/compiler/fields_set_required_test.go
+++ b/internal/ast/compiler/fields_set_required_test.go
@@ -25,9 +25,9 @@ func TestFieldsSetRequired(t *testing.T) {
 		Objects: testutils.ObjectsMap(
 			ast.NewObject("set_required", "AString", ast.String()),
 			ast.NewObject("set_required", "SomeObject", ast.NewStruct(
-				ast.NewStructField("AString", ast.String(), ast.Required()),
+				ast.NewStructField("AString", ast.String(), ast.Required(), ast.PassesTrail("FieldsSetRequired[nullable=false, required=true]")),
 				ast.NewStructField("AnotherString", ast.String(ast.Nullable())),
-				ast.NewStructField("ABool", ast.String(), ast.Required()),
+				ast.NewStructField("ABool", ast.String(), ast.Required(), ast.PassesTrail("FieldsSetRequired[nullable=false, required=true]")),
 			)),
 		),
 	}

--- a/internal/ast/compiler/googlecloudmonitoring.go
+++ b/internal/ast/compiler/googlecloudmonitoring.go
@@ -20,11 +20,8 @@ type GoogleCloudMonitoring struct {
 }
 
 func (pass *GoogleCloudMonitoring) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	newSchemas := make([]*ast.Schema, 0, len(schemas))
-
-	for _, schema := range schemas {
+	for i, schema := range schemas {
 		if schema.Package != "googlecloudmonitoring" {
-			newSchemas = append(newSchemas, schema)
 			continue
 		}
 
@@ -33,10 +30,10 @@ func (pass *GoogleCloudMonitoring) Process(schemas []*ast.Schema) ([]*ast.Schema
 			return nil, err
 		}
 
-		newSchemas = append(newSchemas, newSchema)
+		schemas[i] = newSchema
 	}
 
-	return newSchemas, nil
+	return schemas, nil
 }
 
 func (pass *GoogleCloudMonitoring) processSchema(schema *ast.Schema) (*ast.Schema, error) {
@@ -77,6 +74,7 @@ func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object
 		// to `timeSeriesList?: #TimeSeriesList`
 		newField := field.DeepCopy()
 		newField.Type = newField.Type.Disjunction.Branches[0]
+		newField.AddToPassesTrail("GoogleCloudMonitoring[removed disjunction]")
 
 		fields = append(fields, newField)
 	}
@@ -96,12 +94,14 @@ func (pass *GoogleCloudMonitoring) processTimeSeriesList(object ast.Object) ast.
 	if _, found := structDef.FieldByName("title"); !found {
 		field := ast.NewStructField("title", ast.String(ast.Nullable()))
 		field.Comments = []string{"Annotation title."}
+		field.AddToPassesTrail("GoogleCloudMonitoring[created]")
 
 		structDef.Fields = append(structDef.Fields, field)
 	}
 	if _, found := structDef.FieldByName("text"); !found {
 		field := ast.NewStructField("text", ast.String(ast.Nullable()))
 		field.Comments = []string{"Annotation text."}
+		field.AddToPassesTrail("GoogleCloudMonitoring[created]")
 
 		structDef.Fields = append(structDef.Fields, field)
 	}

--- a/internal/ast/compiler/librarypanels.go
+++ b/internal/ast/compiler/librarypanels.go
@@ -69,6 +69,8 @@ func (pass *LibraryPanels) processLibraryPanel(object ast.Object, dashboardPanel
 		}
 
 		structDef.Fields[i].Type = pass.buildModelType(dashboardPanel)
+		structDef.Fields[i].AddToPassesTrail("LibraryPanels[changed type]")
+
 		break
 	}
 

--- a/internal/ast/compiler/librarypanels_test.go
+++ b/internal/ast/compiler/librarypanels_test.go
@@ -81,7 +81,7 @@ func TestLibraryPanels_rewrite(t *testing.T) {
 					ast.NewStructField(libraryPanelModelField, ast.NewStruct(
 						ast.NewStructField(dashboardPanelTypeField, ast.String()),
 						ast.NewStructField(dashboardPanelsField, ast.NewArray(ast.Any())),
-					)),
+					), ast.PassesTrail("LibraryPanels[changed type]")),
 				)),
 			),
 		},

--- a/internal/ast/compiler/name_anonymous_struct.go
+++ b/internal/ast/compiler/name_anonymous_struct.go
@@ -61,6 +61,8 @@ func (pass *NameAnonymousStruct) processObject(object ast.Object) (ast.Object, a
 		}
 
 		newObject = ast.NewObject(pkg, pass.As, field.Type)
+		newObject.AddToPassesTrail("NameAnonymousStruct")
+
 		object.Type.AsStruct().Fields[i].Type = ast.NewRef(pkg, pass.As)
 	}
 

--- a/internal/ast/compiler/not_required_as_nullable.go
+++ b/internal/ast/compiler/not_required_as_nullable.go
@@ -81,8 +81,9 @@ func (pass *NotRequiredFieldAsNullableType) processDisjunction(def ast.Type) ast
 func (pass *NotRequiredFieldAsNullableType) processStruct(def ast.Type) ast.Type {
 	for i, field := range def.Struct.Fields {
 		def.Struct.Fields[i].Type = pass.processType(field.Type)
-		if !field.Required {
+		if !field.Required && !def.Struct.Fields[i].Type.Nullable {
 			def.Struct.Fields[i].Type.Nullable = true
+			def.Struct.Fields[i].AddToPassesTrail("NotRequiredFieldAsNullableType[nullable=true]")
 		}
 	}
 

--- a/internal/ast/compiler/not_required_as_nullable_test.go
+++ b/internal/ast/compiler/not_required_as_nullable_test.go
@@ -41,20 +41,20 @@ func TestNotRequiredFieldAsNullableType(t *testing.T) {
 		ast.NewObject("pkg", "AStruct", ast.NewStruct(
 			ast.NewStructField("RequiredString", ast.String(), ast.Required()),
 			ast.NewStructField("RequiredNullableString", ast.String(ast.Nullable()), ast.Required()),
-			ast.NewStructField("NotRequiredString", ast.String(ast.Nullable())), // should become nullable
+			ast.NewStructField("NotRequiredString", ast.String(ast.Nullable()), ast.PassesTrail("NotRequiredFieldAsNullableType[nullable=true]")), // should become nullable
 
 			ast.NewStructField("RequiredRef", ast.NewRef("test", "SomeStruct"), ast.Required()),
 			ast.NewStructField("RequiredNullableRef", ast.NewRef("test", "SomeStruct", ast.Nullable()), ast.Required()),
-			ast.NewStructField("NotRequiredRef", ast.NewRef("test", "SomeStruct", ast.Nullable())), // should become nullable
+			ast.NewStructField("NotRequiredRef", ast.NewRef("test", "SomeStruct", ast.Nullable()), ast.PassesTrail("NotRequiredFieldAsNullableType[nullable=true]")), // should become nullable
 
-			ast.NewStructField("NotRequiredArray", ast.NewArray(ast.String(), ast.Nullable())), // should become nullable
+			ast.NewStructField("NotRequiredArray", ast.NewArray(ast.String(), ast.Nullable()), ast.PassesTrail("NotRequiredFieldAsNullableType[nullable=true]")), // should become nullable
 			ast.NewStructField("RequiredArray", ast.NewArray(ast.String()), ast.Required()),
 
-			ast.NewStructField("NotRequiredMap", ast.NewMap(
+			ast.NewStructField("NotRequiredMap", ast.NewMap( // should become nullable
 				ast.String(),
 				ast.Bool(),
-				ast.Nullable(), // should become nullable
-			)),
+				ast.Nullable(),
+			), ast.PassesTrail("NotRequiredFieldAsNullableType[nullable=true]")),
 			ast.NewStructField("RequiredMap", ast.NewMap(
 				ast.String(),
 				ast.Bool(),

--- a/internal/ast/compiler/prefix_enum_values.go
+++ b/internal/ast/compiler/prefix_enum_values.go
@@ -36,20 +36,17 @@ func (pass *PrefixEnumValues) Process(schemas []*ast.Schema) ([]*ast.Schema, err
 
 func (pass *PrefixEnumValues) processSchema(schema *ast.Schema) *ast.Schema {
 	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		object.Type = pass.processType(object.Name, object.Type)
+		if !object.Type.IsEnum() {
+			return object
+		}
+
+		object.Type = pass.processEnum(object.Name, object.Type)
+		object.AddToPassesTrail("PrefixEnumValues")
 
 		return object
 	})
 
 	return schema
-}
-
-func (pass *PrefixEnumValues) processType(parentObjectName string, def ast.Type) ast.Type {
-	if def.Kind != ast.KindEnum {
-		return def
-	}
-
-	return pass.processEnum(parentObjectName, def)
 }
 
 func (pass *PrefixEnumValues) processEnum(parentName string, def ast.Type) ast.Type {

--- a/internal/ast/compiler/retype_field.go
+++ b/internal/ast/compiler/retype_field.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -37,6 +39,7 @@ func (pass *RetypeField) processObject(object ast.Object) ast.Object {
 			continue
 		}
 
+		object.Type.Struct.Fields[i].AddToPassesTrail(fmt.Sprintf("RetypeField[%s → %s]", ast.TypeName(field.Type), ast.TypeName(pass.As)))
 		object.Type.Struct.Fields[i].Type = pass.As
 	}
 

--- a/internal/ast/compiler/retype_field_test.go
+++ b/internal/ast/compiler/retype_field_test.go
@@ -21,7 +21,7 @@ func TestRetypeField(t *testing.T) {
 		Package: "retype_field",
 		Objects: testutils.ObjectsMap(
 			ast.NewObject("retype_field", "SomeObject", ast.NewStruct(
-				ast.NewStructField("AString", ast.Bool()),
+				ast.NewStructField("AString", ast.Bool(), ast.PassesTrail("RetypeField[String → Bool]")),
 			)),
 		),
 	}

--- a/internal/ast/compiler/unspec.go
+++ b/internal/ast/compiler/unspec.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
@@ -32,13 +33,14 @@ func (pass *Unspec) processSchema(schema *ast.Schema) *ast.Schema {
 	schema.Objects = orderedmap.New[string, ast.Object]()
 
 	originalObjects.Iterate(func(name string, object ast.Object) {
-		if strings.EqualFold(object.Name, "spec") && object.Type.Kind == ast.KindStruct {
+		if strings.EqualFold(object.Name, "spec") && object.Type.IsStruct() {
 			object.Name = schema.Package
 			if schema.Metadata.Identifier != "" {
 				object.Name = schema.Metadata.Identifier
 			}
 
 			object.SelfRef.ReferredType = object.Name
+			object.AddToPassesTrail(fmt.Sprintf("Unspec[%s → %s]", name, object.Name))
 		}
 
 		schema.AddObject(object)

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -55,7 +55,7 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = builderTypeFormatter(context, jenny.typeImportMapper)
+	jenny.typeFormatter = builderTypeFormatter(jenny.Config, context, jenny.typeImportMapper)
 
 	// every builder has a dependency on cog's runtime, so let's make sure it's declared.
 	jenny.typeImportMapper("cog")

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -13,6 +13,8 @@ import (
 const LanguageRef = "go"
 
 type Config struct {
+	Debug bool
+
 	// GenerateGoMod indicates whether a go.mod file should be generated.
 	// If enabled, PackageRoot is used as module path.
 	GenerateGoMod bool
@@ -20,6 +22,13 @@ type Config struct {
 	// Root path for imports.
 	// Ex: github.com/grafana/cog/generated
 	PackageRoot string
+}
+
+func (config Config) MergeWithGlobal(global common.Config) Config {
+	newConfig := config
+	newConfig.Debug = global.Debug
+
+	return newConfig
 }
 
 func (config Config) importPath(suffix string) string {
@@ -43,19 +52,21 @@ func (language *Language) RegisterCliFlags(cmd *cobra.Command) {
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+	config := language.config.MergeWithGlobal(globalConfig)
+
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		Runtime{Config: language.config},
-		VariantsPlugins{Config: language.config},
+		Runtime{Config: config},
+		VariantsPlugins{Config: config},
 
-		common.If[common.Context](language.config.GenerateGoMod, GoMod{Config: language.config}),
+		common.If[common.Context](config.GenerateGoMod, GoMod{Config: config}),
 
-		common.If[common.Context](globalConfig.Types, RawTypes{Config: language.config}),
-		common.If[common.Context](globalConfig.Types, JSONMarshalling{Config: language.config}),
+		common.If[common.Context](globalConfig.Types, RawTypes{Config: config}),
+		common.If[common.Context](globalConfig.Types, JSONMarshalling{Config: config}),
 
-		common.If[common.Context](globalConfig.Builders, &Builder{Config: language.config}),
+		common.If[common.Context](globalConfig.Builders, &Builder{Config: config}),
 	)
 	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -58,7 +58,7 @@ func (jenny JSONMarshalling) generateSchema(context common.Context, schema *ast.
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = defaultTypeFormatter(context, jenny.packageMapper)
+	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, jenny.packageMapper)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		if jenny.objectNeedsCustomMarshal(object) {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -46,7 +46,7 @@ func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema)
 	var err error
 
 	imports := NewImportMap()
-	jenny.typeFormatter = defaultTypeFormatter(context, func(pkg string) string {
+	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, func(pkg string) string {
 		if imports.IsIdentical(pkg, schema.Package) {
 			return ""
 		}
@@ -83,7 +83,15 @@ func (jenny RawTypes) formatObject(def ast.Object) ([]byte, error) {
 
 	defName := tools.UpperCamelCase(def.Name)
 
-	for _, commentLine := range def.Comments {
+	comments := def.Comments
+	if jenny.Config.Debug {
+		passesTrail := tools.Map(def.PassesTrail, func(trail string) string {
+			return fmt.Sprintf("Modified by compiler pass '%s'", trail)
+		})
+		comments = append(comments, passesTrail...)
+	}
+
+	for _, commentLine := range comments {
 		buffer.WriteString(fmt.Sprintf("// %s\n", commentLine))
 	}
 


### PR DESCRIPTION
As we add more compiler pass and make them configurable, keeping track of why a given object/type looks the way it does becomes harder.

With this PR, I try to give us a way to track the modifications made by compiler passes and display them directly in the generated code (if `debug` is enabled).

ToDo:

* render compiler pass trails for Typescript, Python and Java (will be done in different PRs)