### PR TITLE
Ensure that the UnfoldBoolean veneer does not break the builder, even…

### DIFF
--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -487,6 +487,12 @@ type BooleanUnfold struct {
 //	```
 func UnfoldBooleanAction(unfoldOpts BooleanUnfold) RewriteAction {
 	return func(_ ast.Builder, option ast.Option) []ast.Option {
+		intoType := option.Assignments[0].Path.Last().Type
+
+		if !intoType.IsScalar() || intoType.Scalar.ScalarKind != ast.KindBool {
+			return []ast.Option{option}
+		}
+
 		newOpts := []ast.Option{
 			{
 				Name:     unfoldOpts.OptionTrue,

--- a/internal/veneers/option/actions_test.go
+++ b/internal/veneers/option/actions_test.go
@@ -73,6 +73,28 @@ func TestUnfoldBooleanAction(t *testing.T) {
 	req.Equal(readonlyOpt.Assignments[0].Value.Constant, false)
 }
 
+func TestUnfoldBooleanAction_onNonBooleanDoesNothing(t *testing.T) {
+	req := require.New(t)
+
+	option := ast.Option{
+		Args: []ast.Argument{
+			{Name: "tags", Type: ast.NewArray(ast.String())},
+		},
+		Assignments: []ast.Assignment{
+			ast.ArgumentAssignment(ast.Path{
+				{Identifier: "tags", Type: ast.NewArray(ast.String())},
+			}, ast.Argument{Name: "tags", Type: ast.NewArray(ast.String())}),
+		},
+	}
+	modifiedOpts := UnfoldBooleanAction(BooleanUnfold{
+		OptionTrue:  "TrueOpt",
+		OptionFalse: "FalseOpt",
+	})(ast.Builder{}, option)
+
+	req.Len(modifiedOpts, 1)
+	req.Equal(option, modifiedOpts[0])
+}
+
 func TestDisjunctionAsOptionsAction_withDisjunction(t *testing.T) {
 	req := require.New(t)
 


### PR DESCRIPTION
… if applied on a non-boolean option

Safety check, to make sure that this veneer safer to use.