### PR TITLE
Exclude READMEs from the preview diff generated against grafana-foundation-sdk

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -43,10 +43,10 @@ jobs:
           echo -e "</summary>\n" >> preview.md
           echo '```patch' >> preview.md
           
-          git diff next+cog-v0.0.x..HEAD >> preview.md
+          git diff next+cog-v0.0.x..HEAD ':(exclude,glob)*/README.md' >> preview.md
           
           echo '```' >> preview.md
-          echo "\n" >> preview.md
+          echo -e "\n" >> preview.md
           echo -e "</details>\n\n" >> preview.md
 
       - name: Find preview comment


### PR DESCRIPTION
READMEs contain markdown that can break the output in PR comments and they don't provide meaningful information in that context. So we should be able to safely exclude them from the diff.