### PR TITLE
Do not generate an option for fields defined as refs to a constant

### DIFF
--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -427,8 +427,15 @@ func (generator *BuilderGenerator) structObjectToBuilder(schemas Schemas, schema
 	}
 
 	for _, field := range structType.Fields {
-		if generator.fieldHasStaticValue(field) {
+		if field.Type.IsScalar() && field.Type.AsScalar().IsConcrete() {
 			constantAssignment := ConstantAssignment(PathFromStructField(field), field.Type.AsScalar().Value)
+			builder.Initializations = append(builder.Initializations, constantAssignment)
+			continue
+		}
+		if field.Required && !field.Type.Nullable && generator.fieldIsRefToConcrete(schemas, field) {
+			referredObj, _ := schemas.LocateObject(field.Type.Ref.ReferredPkg, field.Type.Ref.ReferredType)
+
+			constantAssignment := ConstantAssignment(PathFromStructField(field), referredObj.Type.AsScalar().Value)
 			builder.Initializations = append(builder.Initializations, constantAssignment)
 			continue
 		}
@@ -439,12 +446,17 @@ func (generator *BuilderGenerator) structObjectToBuilder(schemas Schemas, schema
 	return builder
 }
 
-func (generator *BuilderGenerator) fieldHasStaticValue(field StructField) bool {
-	if field.Type.Kind != KindScalar {
+func (generator *BuilderGenerator) fieldIsRefToConcrete(schemas Schemas, field StructField) bool {
+	if !field.Type.IsRef() {
 		return false
 	}
 
-	return field.Type.AsScalar().IsConcrete()
+	referredObj, found := schemas.LocateObject(field.Type.Ref.ReferredPkg, field.Type.Ref.ReferredType)
+	if !found {
+		return false
+	}
+
+	return referredObj.Type.IsScalar() && referredObj.Type.AsScalar().IsConcrete()
 }
 
 func (generator *BuilderGenerator) structFieldToOption(field StructField) Option {


### PR DESCRIPTION
If a field is defined as a required reference to a constant, then we shouldn't define an option for it in builders.