### PR TITLE
Fix rename_numeric_enum_values compiler pass to handle negative values

### DIFF
--- a/internal/ast/compiler/rename_numeric_enum_values.go
+++ b/internal/ast/compiler/rename_numeric_enum_values.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/grafana/cog/internal/ast"
@@ -57,8 +58,16 @@ func (pass *RenameNumericEnumValues) processEnum(def ast.Type) ast.Type {
 			continue
 		}
 
-		def.AsEnum().Values[i].Name = "N" + tools.UpperCamelCase(val.Name)
+		def.Enum.Values[i].Name = pass.enumMemberNameFromValue(val)
 	}
 
 	return def
+}
+
+func (pass *RenameNumericEnumValues) enumMemberNameFromValue(member ast.EnumValue) string {
+	if member.Name[0] == '-' {
+		return tools.UpperCamelCase(fmt.Sprintf("negative%s", member.Name[1:]))
+	}
+
+	return "N" + tools.UpperCamelCase(member.Name)
 }

--- a/internal/ast/compiler/rename_numeric_enum_values_test.go
+++ b/internal/ast/compiler/rename_numeric_enum_values_test.go
@@ -14,6 +14,11 @@ func TestRenameNumericEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
 			{
 				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "-1",
+				Value: -1,
+			},
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
 				Name:  "1",
 				Value: 1,
 			},
@@ -43,6 +48,11 @@ func TestRenameNumericEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "NotAnEnumStruct", ast.String()),
 
 		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
+			{
+				Type:  ast.NewScalar(ast.KindInt64),
+				Name:  "Negative1",
+				Value: -1,
+			},
 			{
 				Type:  ast.NewScalar(ast.KindInt64),
 				Name:  "N1",


### PR DESCRIPTION
Without this fix, the pass generates `N1` for both `-1` and `1`