### PR TITLE
Add "Rename Object" compiler pass

### DIFF
--- a/internal/ast/compiler/anonymous_enum_test.go
+++ b/internal/ast/compiler/anonymous_enum_test.go
@@ -58,7 +58,7 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInStruct(t *testing.T) {
 			ast.NewObject("with_enums", "PanelType", ast.NewEnum([]ast.EnumValue{
 				{Name: "Foo", Value: "foo", Type: ast.String()},
 				{Name: "Bar", Value: "bar", Type: ast.String()},
-			})),
+			}), "AnonymousEnumToExplicitType"),
 		),
 	}
 
@@ -92,7 +92,7 @@ func TestAnonymousEnumToExplicitType_withAnonymousEnumInArray(t *testing.T) {
 			ast.NewObject("in_array", "TypesListEnum", ast.NewEnum([]ast.EnumValue{
 				{Name: "Foo", Value: "foo", Type: ast.String()},
 				{Name: "Bar", Value: "bar", Type: ast.String()},
-			})),
+			}), "AnonymousEnumToExplicitType"),
 		),
 	}
 

--- a/internal/ast/compiler/disjunctions_test.go
+++ b/internal/ast/compiler/disjunctions_test.go
@@ -294,7 +294,7 @@ func TestDisjunctionToType_WithDisjunctionOfRefs_AsAnObject_WithDiscriminatorFie
 		ast.NewObject("test", "ADisjunctionOfRefs", ast.NewRef("test", "SomeStructOrOtherStruct", ast.Trail("DisjunctionToType[disjunction → ref]"))),
 		objects[1],
 		objects[2],
-		ast.NewObject("test", "SomeStructOrOtherStruct", disjunctionStructType),
+		ast.NewObject("test", "SomeStructOrOtherStruct", disjunctionStructType, "DisjunctionToType[created]"),
 	}
 
 	// Call the compiler pass

--- a/internal/ast/compiler/name_anonymous_struct_test.go
+++ b/internal/ast/compiler/name_anonymous_struct_test.go
@@ -27,7 +27,7 @@ func TestNameAnonymousStruct(t *testing.T) {
 			)),
 			ast.NewObject("name_anonymous_struct", "Inner", ast.NewStruct(
 				ast.NewStructField("title", ast.String()),
-			)),
+			), "NameAnonymousStruct"),
 		),
 	}
 

--- a/internal/ast/compiler/prefix_enum_values_test.go
+++ b/internal/ast/compiler/prefix_enum_values_test.go
@@ -22,7 +22,7 @@ func TestPrefixEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "VariableRefresh", ast.NewEnum([]ast.EnumValue{
 			{Name: "VariableRefreshNever", Value: "never", Type: ast.String()},
 			{Name: "VariableRefreshAlways", Value: "always", Type: ast.String()},
-		})),
+		}), "PrefixEnumValues"),
 
 		ast.NewObject("pkg", "SomeType", ast.String()),
 	}
@@ -45,7 +45,7 @@ func TestPrefixEnumValuesWithNegativeIntegerName(t *testing.T) {
 		ast.NewObject("pkg", "BarAlignment", ast.NewEnum([]ast.EnumValue{
 			{Name: "BarAlignment1", Value: 1, Type: ast.NewScalar(ast.KindInt64)},
 			{Name: "BarAlignmentNegative1", Value: -1, Type: ast.NewScalar(ast.KindInt64)},
-		})),
+		}), "PrefixEnumValues"),
 	}
 
 	// Run the compiler pass

--- a/internal/ast/compiler/rename_numeric_enum_values_test.go
+++ b/internal/ast/compiler/rename_numeric_enum_values_test.go
@@ -12,34 +12,14 @@ func TestRenameNumericEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "NotAnEnumStruct", ast.String()),
 
 		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "-1",
-				Value: -1,
-			},
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "1",
-				Value: 1,
-			},
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "2",
-				Value: 2,
-			},
+			{Type: ast.NewScalar(ast.KindInt64), Name: "-1", Value: -1},
+			{Type: ast.NewScalar(ast.KindInt64), Name: "1", Value: 1},
+			{Type: ast.NewScalar(ast.KindInt64), Name: "2", Value: 2},
 		})),
 
 		ast.NewObject("pkg", "AnEnumWithNoNumericValues", ast.NewEnum([]ast.EnumValue{
-			{
-				Type:  ast.String(),
-				Name:  "Hide",
-				Value: "hide",
-			},
-			{
-				Type:  ast.String(),
-				Name:  "DontHide",
-				Value: "dont_hide",
-			},
+			{Type: ast.String(), Name: "Hide", Value: "hide"},
+			{Type: ast.String(), Name: "DontHide", Value: "dont_hide"},
 		})),
 	}
 
@@ -48,34 +28,14 @@ func TestRenameNumericEnumValues(t *testing.T) {
 		ast.NewObject("pkg", "NotAnEnumStruct", ast.String()),
 
 		ast.NewObject("pkg", "AnEnumWithNumericValues", ast.NewEnum([]ast.EnumValue{
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "Negative1",
-				Value: -1,
-			},
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "N1",
-				Value: 1,
-			},
-			{
-				Type:  ast.NewScalar(ast.KindInt64),
-				Name:  "N2",
-				Value: 2,
-			},
-		})),
+			{Type: ast.NewScalar(ast.KindInt64), Name: "Negative1", Value: -1},
+			{Type: ast.NewScalar(ast.KindInt64), Name: "N1", Value: 1},
+			{Type: ast.NewScalar(ast.KindInt64), Name: "N2", Value: 2},
+		}), "RenameNumericEnumValues"),
 
 		ast.NewObject("pkg", "AnEnumWithNoNumericValues", ast.NewEnum([]ast.EnumValue{
-			{
-				Type:  ast.String(),
-				Name:  "Hide",
-				Value: "hide",
-			},
-			{
-				Type:  ast.String(),
-				Name:  "DontHide",
-				Value: "dont_hide",
-			},
+			{Type: ast.String(), Name: "Hide", Value: "hide"},
+			{Type: ast.String(), Name: "DontHide", Value: "dont_hide"},
 		})),
 	}
 

--- a/internal/ast/compiler/rename_object.go
+++ b/internal/ast/compiler/rename_object.go
@@ -1,0 +1,118 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*RenameObject)(nil)
+
+type RenameObject struct {
+	From ObjectReference
+	To   string
+}
+
+func (pass *RenameObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for i, schema := range schemas {
+		schemas[i] = pass.processSchema(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *RenameObject) processSchema(schema *ast.Schema) *ast.Schema {
+	var renamedObject ast.Object
+
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		if pass.From.Matches(object) {
+			// object.AddToPassesTrail(fmt.Sprintf("RenameObject[%s → %s]", object.Name, pass.To))
+			object.Name = pass.To
+			object.SelfRef.ReferredType = pass.To
+
+			renamedObject = object
+		}
+
+		object.Type = pass.processType(object.Type)
+
+		return object
+	})
+
+	if renamedObject.Name != "" {
+		schema.Objects.Remove(pass.From.Object)
+		schema.AddObject(renamedObject)
+	}
+
+	return schema
+}
+
+func (pass *RenameObject) processType(def ast.Type) ast.Type {
+	if def.Kind == ast.KindArray {
+		return pass.processArray(def)
+	}
+
+	if def.Kind == ast.KindMap {
+		return pass.processMap(def)
+	}
+
+	if def.Kind == ast.KindStruct {
+		return pass.processStruct(def)
+	}
+
+	if def.Kind == ast.KindDisjunction {
+		return pass.processDisjunction(def)
+	}
+
+	if def.Kind == ast.KindIntersection {
+		return pass.processIntersection(def)
+	}
+
+	if def.Kind == ast.KindRef {
+		return pass.processRef(def)
+	}
+
+	return def
+}
+
+func (pass *RenameObject) processArray(def ast.Type) ast.Type {
+	def.Array.ValueType = pass.processType(def.Array.ValueType)
+
+	return def
+}
+
+func (pass *RenameObject) processMap(def ast.Type) ast.Type {
+	def.Map.IndexType = pass.processType(def.Map.IndexType)
+	def.Map.ValueType = pass.processType(def.Map.ValueType)
+
+	return def
+}
+
+func (pass *RenameObject) processDisjunction(def ast.Type) ast.Type {
+	for i, branch := range def.Disjunction.Branches {
+		def.Disjunction.Branches[i] = pass.processType(branch)
+	}
+
+	return def
+}
+
+func (pass *RenameObject) processIntersection(def ast.Type) ast.Type {
+	for i, branch := range def.Intersection.Branches {
+		def.Intersection.Branches[i] = pass.processType(branch)
+	}
+
+	return def
+}
+
+func (pass *RenameObject) processRef(def ast.Type) ast.Type {
+	if def.Ref.ReferredType == pass.From.Object {
+		def.Ref.ReferredType = pass.To
+	}
+
+	return def
+}
+
+func (pass *RenameObject) processStruct(def ast.Type) ast.Type {
+	for i, field := range def.Struct.Fields {
+		def.Struct.Fields[i].Type = pass.processType(field.Type)
+	}
+
+	return def
+}

--- a/internal/ast/compiler/rename_object.go
+++ b/internal/ast/compiler/rename_object.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -24,7 +26,8 @@ func (pass *RenameObject) processSchema(schema *ast.Schema) *ast.Schema {
 
 	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
 		if pass.From.Matches(object) {
-			// object.AddToPassesTrail(fmt.Sprintf("RenameObject[%s → %s]", object.Name, pass.To))
+			object.AddToPassesTrail(fmt.Sprintf("RenameObject[%s → %s]", object.Name, pass.To))
+
 			object.Name = pass.To
 			object.SelfRef.ReferredType = pass.To
 

--- a/internal/ast/compiler/rename_object_test.go
+++ b/internal/ast/compiler/rename_object_test.go
@@ -30,7 +30,7 @@ func TestRenameObject(t *testing.T) {
 			)),
 			ast.NewObject("rename_object", "ReallyNiceName", ast.NewStruct(
 				ast.NewStructField("AString", ast.String(ast.Nullable())),
-			)),
+			), "RenameObject[NotANiceName → ReallyNiceName]"),
 		),
 	}
 

--- a/internal/ast/compiler/rename_object_test.go
+++ b/internal/ast/compiler/rename_object_test.go
@@ -1,0 +1,44 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestRenameObject(t *testing.T) {
+	// Prepare test input
+	schema := &ast.Schema{
+		Package: "rename_object",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("rename_object", "SomeObject", ast.NewStruct(
+				ast.NewStructField("foo", ast.String(ast.Nullable())),
+				ast.NewStructField("ref_to_nice_object", ast.NewRef("rename_object", "NotANiceName")),
+			)),
+			ast.NewObject("rename_object", "NotANiceName", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable())),
+			)),
+		),
+	}
+	expected := &ast.Schema{
+		Package: "rename_object",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("rename_object", "SomeObject", ast.NewStruct(
+				ast.NewStructField("foo", ast.String(ast.Nullable())),
+				ast.NewStructField("ref_to_nice_object", ast.NewRef("rename_object", "ReallyNiceName")),
+			)),
+			ast.NewObject("rename_object", "ReallyNiceName", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable())),
+			)),
+		),
+	}
+
+	pass := &RenameObject{
+		From: ObjectReference{Package: schema.Package, Object: "NotANiceName"},
+		To:   "ReallyNiceName",
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, pass, schema, expected)
+}

--- a/internal/ast/compiler/unspec_test.go
+++ b/internal/ast/compiler/unspec_test.go
@@ -60,7 +60,7 @@ func TestUnspec(t *testing.T) {
 			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_no_meta_id", "with_spec_no_meta_id", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
-				)),
+				), "Unspec[Spec → with_spec_no_meta_id]"),
 			),
 		},
 
@@ -73,7 +73,7 @@ func TestUnspec(t *testing.T) {
 			Objects: testutils.ObjectsMap(
 				ast.NewObject("with_spec_and_meta_id", "Dashboard", ast.NewStruct(
 					ast.NewStructField("title", ast.String()),
-				)),
+				), "Unspec[Spec → Dashboard]"),
 			),
 		},
 	}

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -502,7 +502,8 @@ func (object Object) Equal(other Object) bool {
 	return object.Name == other.Name &&
 		cmp.Equal(object.Comments, other.Comments) &&
 		cmp.Equal(object.Type, other.Type) &&
-		cmp.Equal(object.SelfRef, other.SelfRef)
+		cmp.Equal(object.SelfRef, other.SelfRef) &&
+		cmp.Equal(object.PassesTrail, other.PassesTrail)
 }
 
 func (object Object) DeepCopy() Object {

--- a/internal/orderedmap/map.go
+++ b/internal/orderedmap/map.go
@@ -69,6 +69,21 @@ func (orderedMap *Map[K, V]) Has(key K) bool {
 	return exists
 }
 
+func (orderedMap *Map[K, V]) Remove(key K) {
+	delete(orderedMap.records, key)
+
+	newOrder := make([]K, 0, len(orderedMap.order)-1)
+	for _, elem := range orderedMap.order {
+		if elem == key {
+			continue
+		}
+
+		newOrder = append(newOrder, elem)
+	}
+
+	orderedMap.order = newOrder
+}
+
 func (orderedMap *Map[K, V]) Len() int {
 	return len(orderedMap.order)
 }

--- a/internal/orderedmap/map_test.go
+++ b/internal/orderedmap/map_test.go
@@ -23,6 +23,12 @@ func TestMap_Basic(t *testing.T) {
 	req.False(orderedMap.Has("unknown-key"))
 	req.Equal("", orderedMap.Get("unknown-key"))
 
+	orderedMap.Set("fourth-key", "fourth-value")
+	req.Equal(4, orderedMap.Len())
+
+	orderedMap.Remove("fourth-key")
+	req.Equal(3, orderedMap.Len())
+
 	iteratedKeyOrder := make([]string, 0, orderedMap.Len())
 	orderedMap.Iterate(func(key string, value string) {
 		req.Equal(orderedMap.Get(key), value)

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -14,6 +14,7 @@ type CompilerPass struct {
 	Omit                    *Omit                    `yaml:"omit"`
 	AddFields               *AddFields               `yaml:"add_fields"`
 	NameAnonymousStruct     *NameAnonymousStruct     `yaml:"name_anonymous_struct"`
+	RenameObject            *RenameObject            `yaml:"rename_object"`
 	RetypeField             *RetypeField             `yaml:"retype_field"`
 	SchemaSetIdentifier     *SchemaSetIdentifier     `yaml:"schema_set_identifier"`
 
@@ -43,6 +44,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 	}
 	if pass.NameAnonymousStruct != nil {
 		return pass.NameAnonymousStruct.AsCompilerPass()
+	}
+	if pass.RenameObject != nil {
+		return pass.RenameObject.AsCompilerPass()
 	}
 	if pass.RetypeField != nil {
 		return pass.RetypeField.AsCompilerPass()
@@ -151,6 +155,23 @@ func (pass NameAnonymousStruct) AsCompilerPass() (compiler.Pass, error) {
 	return &compiler.NameAnonymousStruct{
 		Field: fieldRef,
 		As:    pass.As,
+	}, nil
+}
+
+type RenameObject struct {
+	From string // Expected format: [package].[object]
+	To   string
+}
+
+func (pass RenameObject) AsCompilerPass() (compiler.Pass, error) {
+	objectRef, err := compiler.ObjectReferenceFromString(pass.From)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compiler.RenameObject{
+		From: objectRef,
+		To:   pass.To,
 	}, nil
 }
 


### PR DESCRIPTION
https://github.com/vega/ts-json-schema-generator/ can sometimes generate object definitions with weird names (especially when the original type involves using generics).

As a result, having a way to rename some objects while maintaining the state of their references can be useful.

This PR adds a compiler pass to do just that.