### PR TITLE
Add "Fields set default" compiler pass

### DIFF
--- a/internal/ast/compiler/fields_set_default.go
+++ b/internal/ast/compiler/fields_set_default.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -37,6 +39,7 @@ func (pass *FieldsSetDefault) processObject(_ string, object ast.Object) ast.Obj
 			}
 
 			field.Type.Default = value
+			field.AddToPassesTrail(fmt.Sprintf("FieldsSetDefault[default=%v]", value))
 
 			object.Type.Struct.Fields[i] = field
 		}

--- a/internal/ast/compiler/fields_set_default.go
+++ b/internal/ast/compiler/fields_set_default.go
@@ -1,0 +1,46 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*FieldsSetDefault)(nil)
+
+// FieldsSetDefault sets the default value for the given fields.
+type FieldsSetDefault struct {
+	DefaultValues map[FieldReference]any
+}
+
+func (pass *FieldsSetDefault) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for i, schema := range schemas {
+		schemas[i] = pass.processSchema(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *FieldsSetDefault) processSchema(schema *ast.Schema) *ast.Schema {
+	schema.Objects = schema.Objects.Map(pass.processObject)
+
+	return schema
+}
+
+func (pass *FieldsSetDefault) processObject(_ string, object ast.Object) ast.Object {
+	if !object.Type.IsStruct() {
+		return object
+	}
+
+	for i, field := range object.Type.AsStruct().Fields {
+		for fieldRef, value := range pass.DefaultValues {
+			if !fieldRef.Matches(object, field) {
+				continue
+			}
+
+			field.Type.Default = value
+
+			object.Type.Struct.Fields[i] = field
+		}
+	}
+
+	return object
+}

--- a/internal/ast/compiler/fields_set_default_test.go
+++ b/internal/ast/compiler/fields_set_default_test.go
@@ -1,0 +1,42 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestFieldsSetDefault(t *testing.T) {
+	// Prepare test input
+	schema := &ast.Schema{
+		Package: "set_required",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("set_required", "SomeObject", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable())),
+				ast.NewStructField("AnotherString", ast.String(ast.Nullable())),
+				ast.NewStructField("ABool", ast.String(ast.Nullable())),
+			)),
+		),
+	}
+	expected := &ast.Schema{
+		Package: "set_required",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("set_required", "SomeObject", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable(), ast.Default("default-foo"))),
+				ast.NewStructField("AnotherString", ast.String(ast.Nullable())),
+				ast.NewStructField("ABool", ast.String(ast.Nullable(), ast.Default(true))),
+			)),
+		),
+	}
+
+	pass := &FieldsSetDefault{
+		DefaultValues: map[FieldReference]any{
+			{Package: schema.Package, Object: "SomeObject", Field: "AString"}: "default-foo",
+			{Package: schema.Package, Object: "SomeObject", Field: "ABool"}:   true,
+		},
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, pass, schema, expected)
+}

--- a/internal/ast/compiler/fields_set_default_test.go
+++ b/internal/ast/compiler/fields_set_default_test.go
@@ -23,9 +23,9 @@ func TestFieldsSetDefault(t *testing.T) {
 		Package: "set_required",
 		Objects: testutils.ObjectsMap(
 			ast.NewObject("set_required", "SomeObject", ast.NewStruct(
-				ast.NewStructField("AString", ast.String(ast.Nullable(), ast.Default("default-foo"))),
+				ast.NewStructField("AString", ast.String(ast.Nullable(), ast.Default("default-foo")), ast.PassesTrail("FieldsSetDefault[default=default-foo]")),
 				ast.NewStructField("AnotherString", ast.String(ast.Nullable())),
-				ast.NewStructField("ABool", ast.String(ast.Nullable(), ast.Default(true))),
+				ast.NewStructField("ABool", ast.String(ast.Nullable(), ast.Default(true)), ast.PassesTrail("FieldsSetDefault[default=true]")),
 			)),
 		),
 	}


### PR DESCRIPTION
Figuring out default values when generating a JSON schema with https://github.com/vega/ts-json-schema-generator/ is currently an unsolved topic.

As a result, having a way to explicitly set some useful default values in cog can be useful.

This PR adds a compiler pass to do just that.
