### PR TITLE
Shared veneer trail handling

### DIFF
--- a/cmd/cli/generate/command.go
+++ b/cmd/cli/generate/command.go
@@ -90,7 +90,8 @@ func (opts Options) veneers() (*rewrite.Rewriter, error) {
 		return nil, err
 	}
 
-	return yaml.NewVeneersLoader().RewriterFrom(veneerFiles)
+	config := rewrite.Config{Debug: opts.JenniesConfig.Debug}
+	return yaml.NewVeneersLoader().RewriterFrom(veneerFiles, config)
 }
 
 func (opts Options) commonCompilerPasses() (compiler.Passes, error) {

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -66,14 +66,6 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 		buildObjectSignature = jenny.typeFormatter.variantInterface(builder.For.Type.ImplementedVariant())
 	}
 
-	comments := builder.For.Comments
-	if jenny.Config.Debug {
-		veneerTrail := tools.Map(builder.VeneerTrail, func(veneer string) string {
-			return fmt.Sprintf("Modified by veneer '%s'", veneer)
-		})
-		comments = append(comments, veneerTrail...)
-	}
-
 	err := templates.
 		Funcs(map[string]any{
 			"formatPath": jenny.formatFieldPath,
@@ -93,7 +85,7 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 			Imports:              imports,
 			BuilderName:          tools.UpperCamelCase(builder.Name),
 			ObjectName:           fullObjectName,
-			Comments:             comments,
+			Comments:             builder.For.Comments,
 			Constructor:          jenny.generateConstructor(builder),
 			Properties:           builder.Properties,
 			Defaults:             jenny.genDefaultOptionsCalls(context, builder),
@@ -217,18 +209,9 @@ func (jenny *Builder) formatFieldPath(fieldPath ast.Path) string {
 }
 
 func (jenny *Builder) generateOption(def ast.Option) template.Option {
-	comments := def.Comments
-
-	if jenny.Config.Debug {
-		veneerTrail := tools.Map(def.VeneerTrail, func(veneer string) string {
-			return fmt.Sprintf("Modified by veneer '%s'", veneer)
-		})
-		comments = append(comments, veneerTrail...)
-	}
-
 	return template.Option{
 		Name:        tools.UpperCamelCase(def.Name),
-		Comments:    comments,
+		Comments:    def.Comments,
 		Args:        def.Args,
 		Assignments: tools.Map(def.Assignments, jenny.generateAssignment),
 	}

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -13,8 +13,6 @@ import (
 const LanguageRef = "go"
 
 type Config struct {
-	Debug bool
-
 	// GenerateGoMod indicates whether a go.mod file should be generated.
 	// If enabled, PackageRoot is used as module path.
 	GenerateGoMod bool
@@ -22,13 +20,6 @@ type Config struct {
 	// Root path for imports.
 	// Ex: github.com/grafana/cog/generated
 	PackageRoot string
-}
-
-func (config Config) MergeWithGlobal(global common.Config) Config {
-	newConfig := config
-	newConfig.Debug = global.Debug
-
-	return newConfig
 }
 
 func (config Config) importPath(suffix string) string {
@@ -52,21 +43,19 @@ func (language *Language) RegisterCliFlags(cmd *cobra.Command) {
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	config := language.config.MergeWithGlobal(globalConfig)
-
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		Runtime{Config: config},
-		VariantsPlugins{Config: config},
+		Runtime{Config: language.config},
+		VariantsPlugins{Config: language.config},
 
-		common.If[common.Context](language.config.GenerateGoMod, GoMod{Config: config}),
+		common.If[common.Context](language.config.GenerateGoMod, GoMod{Config: language.config}),
 
-		common.If[common.Context](globalConfig.Types, RawTypes{Config: config}),
-		common.If[common.Context](globalConfig.Types, JSONMarshalling{Config: config}),
+		common.If[common.Context](globalConfig.Types, RawTypes{Config: language.config}),
+		common.If[common.Context](globalConfig.Types, JSONMarshalling{Config: language.config}),
 
-		common.If[common.Context](globalConfig.Builders, &Builder{Config: config}),
+		common.If[common.Context](globalConfig.Builders, &Builder{Config: language.config}),
 	)
 	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -10,20 +10,11 @@ import (
 const LanguageRef = "java"
 
 type Config struct {
-	Debug bool
-
 	GenGettersAndSetters bool
 }
 
 type Language struct {
 	config Config
-}
-
-func (config Config) MergeWithGlobal(global common.Config) Config {
-	newConfig := config
-	newConfig.Debug = global.Debug
-
-	return newConfig
 }
 
 func New() *Language {
@@ -35,15 +26,13 @@ func (language *Language) RegisterCliFlags(cmd *cobra.Command) {
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	config := language.config.MergeWithGlobal(globalConfig)
-
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
 
 	jenny.AppendOneToMany(
 		Runtime{},
-		common.If[common.Context](globalConfig.Types, RawTypes{config: config}),
+		common.If[common.Context](globalConfig.Types, RawTypes{config: language.config}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -9,33 +9,17 @@ import (
 
 const LanguageRef = "typescript"
 
-type Config struct {
-	Debug bool
-}
-
-func (config Config) MergeWithGlobal(global common.Config) Config {
-	newConfig := config
-	newConfig.Debug = global.Debug
-
-	return newConfig
-}
-
 type Language struct {
-	config Config
 }
 
 func New() *Language {
-	return &Language{
-		config: Config{},
-	}
+	return &Language{}
 }
 
 func (language *Language) RegisterCliFlags(_ *cobra.Command) {
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	config := language.config.MergeWithGlobal(globalConfig)
-
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
@@ -43,7 +27,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 		Runtime{},
 
 		common.If[common.Context](globalConfig.Types, RawTypes{}),
-		common.If[common.Context](globalConfig.Builders, &Builder{Config: config}),
+		common.If[common.Context](globalConfig.Builders, &Builder{}),
 
 		Index{Targets: globalConfig},
 	)

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -224,6 +224,24 @@ func Rename(selector Selector, newName string) RewriteRule {
 	}
 }
 
+func VeneerTrailAsComments(selector Selector) RewriteRule {
+	return func(builders ast.Builders) (ast.Builders, error) {
+		for i, builder := range builders {
+			if !selector(builder) {
+				continue
+			}
+
+			veneerTrail := tools.Map(builder.VeneerTrail, func(veneer string) string {
+				return fmt.Sprintf("Modified by veneer '%s'", veneer)
+			})
+
+			builders[i].For.Comments = append(builders[i].For.Comments, veneerTrail...)
+		}
+
+		return builders, nil
+	}
+}
+
 func Properties(selector Selector, properties []ast.StructField) RewriteRule {
 	return func(builders ast.Builders) (ast.Builders, error) {
 		for i, builder := range builders {

--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -8,6 +8,13 @@ import (
 
 type Selector func(builder ast.Builder) bool
 
+// EveryBuilder accepts any given builder.
+func EveryBuilder() Selector {
+	return func(_ ast.Builder) bool {
+		return true
+	}
+}
+
 // ByObjectName matches builders for the given the object (referred to by its
 // package and name).
 // Note: the comparison on object name is case-insensitive.

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -88,6 +88,19 @@ func OmitAction() RewriteAction {
 	}
 }
 
+// VeneerTrailAsCommentsAction removes an option.
+func VeneerTrailAsCommentsAction() RewriteAction {
+	return func(_ ast.Builder, opt ast.Option) []ast.Option {
+		veneerTrail := tools.Map(opt.VeneerTrail, func(veneer string) string {
+			return fmt.Sprintf("Modified by veneer '%s'", veneer)
+		})
+
+		opt.Comments = append(opt.Comments, veneerTrail...)
+
+		return []ast.Option{opt}
+	}
+}
+
 // PromoteToConstructorAction flag the arguments of the given option as "constructor arguments".
 // This flag indicates builder jennies that the arguments and assignments described by this option
 // should be exposed by the builder's constructor.

--- a/internal/veneers/option/rules.go
+++ b/internal/veneers/option/rules.go
@@ -26,6 +26,13 @@ func Omit(selector Selector) RewriteRule {
 	}
 }
 
+func VeneerTrailAsComments(selector Selector) RewriteRule {
+	return RewriteRule{
+		Selector: selector,
+		Action:   VeneerTrailAsCommentsAction(),
+	}
+}
+
 func UnfoldBoolean(selector Selector, unfoldOpts BooleanUnfold) RewriteRule {
 	return RewriteRule{
 		Selector: selector,

--- a/internal/veneers/option/selectors.go
+++ b/internal/veneers/option/selectors.go
@@ -9,6 +9,13 @@ import (
 
 type Selector func(builder ast.Builder, option ast.Option) bool
 
+// EveryOption accepts any given option.
+func EveryOption() Selector {
+	return func(_ ast.Builder, _ ast.Option) bool {
+		return true
+	}
+}
+
 // ByName matches options by their name, defined for builders for the given
 // object (referred to by its package and name).
 // Note: the comparison on object and options names is case-insensitive.

--- a/internal/veneers/rewrite/rewrite_test.go
+++ b/internal/veneers/rewrite/rewrite_test.go
@@ -228,7 +228,7 @@ func TestRewriter_ApplyTo(t *testing.T) {
 					BuilderRules: tc.builderRules,
 					OptionRules:  tc.optionRules,
 				},
-			})
+			}, Config{Debug: false})
 
 			// save our original/expected states
 			originalBuildersJSONBeforeApply := mustMarshalJSON(t, tc.inputBuilders)

--- a/internal/yaml/veneers.go
+++ b/internal/yaml/veneers.go
@@ -25,7 +25,7 @@ func NewVeneersLoader() *VeneersLoader {
 	return &VeneersLoader{}
 }
 
-func (loader *VeneersLoader) RewriterFrom(filenames []string) (*rewrite.Rewriter, error) {
+func (loader *VeneersLoader) RewriterFrom(filenames []string, config rewrite.Config) (*rewrite.Rewriter, error) {
 	readers := make([]io.Reader, 0, len(filenames))
 	for _, filename := range filenames {
 		reader, err := os.Open(filename)
@@ -41,7 +41,7 @@ func (loader *VeneersLoader) RewriterFrom(filenames []string) (*rewrite.Rewriter
 		return nil, err
 	}
 
-	return rewrite.NewRewrite(rules), nil
+	return rewrite.NewRewrite(rules, config), nil
 }
 
 func (loader *VeneersLoader) LoadAll(readers []io.Reader) ([]rewrite.LanguageRules, error) {


### PR DESCRIPTION
Move veneer trail handling to a veneer (!) instead of duplicating its implementation in every jenny.

By having this done in a "debug" veneer, every jenny can benefit from this trail without knowing anything about it. That's one thing less in the list of many things to worry about when implementing a jenny.