### PR TITLE
Improve support for disjunctions as option arguments in builders

### DIFF
--- a/internal/jennies/common/context.go
+++ b/internal/jennies/common/context.go
@@ -21,12 +21,12 @@ func (context *Context) ResolveToBuilder(def ast.Type) bool {
 
 	if def.Kind == ast.KindDisjunction {
 		for _, branch := range def.AsDisjunction().Branches {
-			if !context.ResolveToBuilder(branch) {
-				return false
+			if context.ResolveToBuilder(branch) {
+				return true
 			}
 		}
 
-		return true
+		return false
 	}
 
 	if def.Kind != ast.KindRef {
@@ -37,6 +37,20 @@ func (context *Context) ResolveToBuilder(def ast.Type) bool {
 	_, found := context.Builders.LocateByObject(ref.ReferredPkg, ref.ReferredType)
 
 	return found
+}
+
+func (context *Context) IsDisjunctionOfBuilders(def ast.Type) bool {
+	if def.Kind != ast.KindDisjunction {
+		return false
+	}
+
+	for _, branch := range def.AsDisjunction().Branches {
+		if !context.ResolveToBuilder(branch) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (context *Context) ResolveToComposableSlot(def ast.Type) (ast.Type, bool) {

--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -11,6 +11,9 @@ func TestBuilder_Generate(t *testing.T) {
 	test := testutils.GoldenFilesTestSuite{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "GoBuilder",
+		Skip: map[string]string{
+			"builder_delegation_in_disjunction": "disjunctions are eliminated with compiler passes",
+		},
 	}
 
 	jenny := Builder{

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -64,8 +64,9 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 
 	err := templates.
 		Funcs(map[string]any{
-			"typeHasBuilder": context.ResolveToBuilder,
-			"formatType":     jenny.typeFormatter.formatType,
+			"typeHasBuilder":              context.ResolveToBuilder,
+			"typeIsDisjunctionOfBuilders": context.IsDisjunctionOfBuilders,
+			"formatType":                  jenny.typeFormatter.formatType,
 			"resolvesToComposableSlot": func(typeDef ast.Type) bool {
 				_, found := context.ResolveToComposableSlot(typeDef)
 				return found
@@ -86,7 +87,7 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 		}).
 		ExecuteTemplate(&buffer, "builder.tmpl", template.Builder{
 			BuilderName:          builder.Name,
-			ObjectName:           builder.For.Name,
+			ObjectName:           tools.CleanupNames(builder.For.Name),
 			BuilderSignatureType: buildObjectSignature,
 			Imports:              jenny.imports,
 			ImportAlias:          jenny.importType(builder.For.SelfRef),

--- a/internal/jennies/typescript/runtime.go
+++ b/internal/jennies/typescript/runtime.go
@@ -38,5 +38,16 @@ func (jenny Runtime) generateOptionsBuilderFile() string {
 	return `export interface Builder<T> {
   build: () => T;
 }
+
+export function isBuilder<T>(input: Builder<T> | any): input is Builder<T> {
+  if (input === null) {
+    return false;
+  }
+  if (!input?.build) {
+    return false;
+  }
+
+  return typeof input.build === "function";
+}
 `
 }

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -55,6 +55,10 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
 {{- define "unfold_builders" }}
     {{- if .InputType.IsArray -}}
         {{ .InputVar }}.map(builder{{ .Depth }} => {{ template "unfold_builders" (dict "InputType" .InputType.Array.ValueType "InputVar" (print "builder" .Depth ) "Depth" (add1 .Depth)) }})
+    {{- else if typeIsDisjunctionOfBuilders .InputType -}}
+        {{ .InputVar }}.build()
+    {{- else if .InputType.IsDisjunction -}}
+        cog.isBuilder({{ .InputVar }}) ? {{ .InputVar }}.build() : {{ .InputVar }}
     {{- else -}}
         {{ .InputVar }}.build()
     {{- end -}}
@@ -75,7 +79,6 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
     {{- end }}
 {{- end }}
-
 
 {{- define "value_envelope" -}}
     {

--- a/internal/jennies/typescript/tmpl.go
+++ b/internal/jennies/typescript/tmpl.go
@@ -28,6 +28,9 @@ func init() {
 			"formatType": func(_ ast.Type) string {
 				panic("formatType() needs to be overridden by a jenny")
 			},
+			"typeIsDisjunctionOfBuilders": func(_ ast.Type) string {
+				panic("typeIsDisjunctionOfBuilders() needs to be overridden by a jenny")
+			},
 			"defaultValueForType": func(_ ast.Type) string {
 				panic("defaultValueForType() needs to be overridden by a jenny")
 			},

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
@@ -1,0 +1,75 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import builder_delegation_in_disjunction
+
+
+class DashboardLink(cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink]):    
+    __internal: builder_delegation_in_disjunction.DashboardLink
+
+    def __init__(self):
+        self.__internal = builder_delegation_in_disjunction.DashboardLink()
+
+    def build(self) -> builder_delegation_in_disjunction.DashboardLink:
+        return self.__internal    
+    
+    def title(self, title: str) -> typing.Self:        
+        self.__internal.title = title
+    
+        return self
+    
+    def url(self, url: str) -> typing.Self:        
+        self.__internal.url = url
+    
+        return self
+    
+
+class ExternalLink(cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]):    
+    __internal: builder_delegation_in_disjunction.ExternalLink
+
+    def __init__(self):
+        self.__internal = builder_delegation_in_disjunction.ExternalLink()
+
+    def build(self) -> builder_delegation_in_disjunction.ExternalLink:
+        return self.__internal    
+    
+    def url(self, url: str) -> typing.Self:        
+        self.__internal.url = url
+    
+        return self
+    
+
+class Dashboard(cogbuilder.Builder[builder_delegation_in_disjunction.Dashboard]):    
+    __internal: builder_delegation_in_disjunction.Dashboard
+
+    def __init__(self):
+        self.__internal = builder_delegation_in_disjunction.Dashboard()
+
+    def build(self) -> builder_delegation_in_disjunction.Dashboard:
+        return self.__internal    
+    
+    def single_link_or_string(self, single_link_or_string: typing.Union[cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink], str]) -> typing.Self:    
+        """
+        will be expanded to cog.Builder<DashboardLink> | string
+        """
+            
+        single_link_or_string_resource = single_link_or_string.build()
+        self.__internal.single_link_or_string = single_link_or_string_resource
+    
+        return self
+    
+    def links_or_strings(self, links_or_strings: list[typing.Union[cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink], str]]) -> typing.Self:    
+        """
+        will be expanded to [](cog.Builder<DashboardLink> | string)
+        """
+            
+        links_or_strings_resources = [r1.build() for r1 in links_or_strings]
+        self.__internal.links_or_strings = links_or_strings_resources
+    
+        return self
+    
+    def disjunction_of_builders(self, disjunction_of_builders: typing.Union[cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink], cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]]) -> typing.Self:        
+        disjunction_of_builders_resource = disjunction_of_builders.build()
+        self.__internal.disjunction_of_builders = disjunction_of_builders_resource
+    
+        return self
+    

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/dashboardBuilder.gen.ts
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/dashboardBuilder.gen.ts
@@ -1,0 +1,34 @@
+import * as cog from '../cog';
+import * as builderDelegationInDisjunction from '../builderDelegationInDisjunction';
+
+export class DashboardBuilder implements cog.Builder<builderDelegationInDisjunction.Dashboard> {
+    private readonly internal: builderDelegationInDisjunction.Dashboard;
+
+    constructor() {
+        this.internal = builderDelegationInDisjunction.defaultDashboard();
+    }
+
+    build(): builderDelegationInDisjunction.Dashboard {
+        return this.internal;
+    }
+
+    // will be expanded to cog.Builder<DashboardLink> | string
+    singleLinkOrString(singleLinkOrString: cog.Builder<builderDelegationInDisjunction.DashboardLink> | string): this {
+        const singleLinkOrStringResource = cog.isBuilder(singleLinkOrString) ? singleLinkOrString.build() : singleLinkOrString;
+        this.internal.singleLinkOrString = singleLinkOrStringResource;
+        return this;
+    }
+
+    // will be expanded to [](cog.Builder<DashboardLink> | string)
+    linksOrStrings(linksOrStrings: (cog.Builder<builderDelegationInDisjunction.DashboardLink> | string)[]): this {
+        const linksOrStringsResources = linksOrStrings.map(builder1 => cog.isBuilder(builder1) ? builder1.build() : builder1);
+        this.internal.linksOrStrings = linksOrStringsResources;
+        return this;
+    }
+
+    disjunctionOfBuilders(disjunctionOfBuilders: cog.Builder<builderDelegationInDisjunction.DashboardLink> | cog.Builder<builderDelegationInDisjunction.ExternalLink>): this {
+        const disjunctionOfBuildersResource = disjunctionOfBuilders.build();
+        this.internal.disjunctionOfBuilders = disjunctionOfBuildersResource;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/dashboardLinkBuilder.gen.ts
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/dashboardLinkBuilder.gen.ts
@@ -1,0 +1,24 @@
+import * as cog from '../cog';
+import * as builderDelegationInDisjunction from '../builderDelegationInDisjunction';
+
+export class DashboardLinkBuilder implements cog.Builder<builderDelegationInDisjunction.DashboardLink> {
+    private readonly internal: builderDelegationInDisjunction.DashboardLink;
+
+    constructor() {
+        this.internal = builderDelegationInDisjunction.defaultDashboardLink();
+    }
+
+    build(): builderDelegationInDisjunction.DashboardLink {
+        return this.internal;
+    }
+
+    title(title: string): this {
+        this.internal.title = title;
+        return this;
+    }
+
+    url(url: string): this {
+        this.internal.url = url;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/externalLinkBuilder.gen.ts
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/externalLinkBuilder.gen.ts
@@ -1,0 +1,19 @@
+import * as cog from '../cog';
+import * as builderDelegationInDisjunction from '../builderDelegationInDisjunction';
+
+export class ExternalLinkBuilder implements cog.Builder<builderDelegationInDisjunction.ExternalLink> {
+    private readonly internal: builderDelegationInDisjunction.ExternalLink;
+
+    constructor() {
+        this.internal = builderDelegationInDisjunction.defaultExternalLink();
+    }
+
+    build(): builderDelegationInDisjunction.ExternalLink {
+        return this.internal;
+    }
+
+    url(url: string): this {
+        this.internal.url = url;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/builders_context.json
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/builders_context.json
@@ -1,0 +1,1349 @@
+{
+  "Schemas": [
+    {
+      "Package": "builder_delegation_in_disjunction",
+      "Metadata": {},
+      "Objects": {
+        "DashboardLink": {
+          "Name": "DashboardLink",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "builder_delegation_in_disjunction",
+            "ReferredType": "DashboardLink"
+          }
+        },
+        "ExternalLink": {
+          "Name": "ExternalLink",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "builder_delegation_in_disjunction",
+            "ReferredType": "ExternalLink"
+          }
+        },
+        "Dashboard": {
+          "Name": "Dashboard",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "singleLinkOrString",
+                  "Comments": [
+                    "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+                  ],
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "linksOrStrings",
+                  "Comments": [
+                    "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+                  ],
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "disjunction",
+                        "Nullable": false,
+                        "Disjunction": {
+                          "Branches": [
+                            {
+                              "Kind": "ref",
+                              "Nullable": false,
+                              "Ref": {
+                                "ReferredPkg": "builder_delegation_in_disjunction",
+                                "ReferredType": "DashboardLink"
+                              }
+                            },
+                            {
+                              "Kind": "scalar",
+                              "Nullable": false,
+                              "Scalar": {
+                                "ScalarKind": "string"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "disjunctionOfBuilders",
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "ExternalLink"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "builder_delegation_in_disjunction",
+            "ReferredType": "Dashboard"
+          }
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "Schema": {
+        "Package": "builder_delegation_in_disjunction",
+        "Metadata": {},
+        "Objects": {
+          "DashboardLink": {
+            "Name": "DashboardLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "title",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "DashboardLink"
+            }
+          },
+          "ExternalLink": {
+            "Name": "ExternalLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "ExternalLink"
+            }
+          },
+          "Dashboard": {
+            "Name": "Dashboard",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "singleLinkOrString",
+                    "Comments": [
+                      "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+                    ],
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "linksOrStrings",
+                    "Comments": [
+                      "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+                    ],
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "disjunction",
+                          "Nullable": false,
+                          "Disjunction": {
+                            "Branches": [
+                              {
+                                "Kind": "ref",
+                                "Nullable": false,
+                                "Ref": {
+                                  "ReferredPkg": "builder_delegation_in_disjunction",
+                                  "ReferredType": "DashboardLink"
+                                }
+                              },
+                              {
+                                "Kind": "scalar",
+                                "Nullable": false,
+                                "Scalar": {
+                                  "ScalarKind": "string"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "disjunctionOfBuilders",
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "ExternalLink"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "Dashboard"
+            }
+          }
+        }
+      },
+      "For": {
+        "Name": "DashboardLink",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "url",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "builder_delegation_in_disjunction",
+          "ReferredType": "DashboardLink"
+        }
+      },
+      "Package": "builder_delegation_in_disjunction",
+      "Name": "DashboardLink",
+      "Options": [
+        {
+          "Name": "title",
+          "Args": [
+            {
+              "Name": "title",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        },
+        {
+          "Name": "url",
+          "Args": [
+            {
+              "Name": "url",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        }
+      ]
+    },
+    {
+      "Schema": {
+        "Package": "builder_delegation_in_disjunction",
+        "Metadata": {},
+        "Objects": {
+          "DashboardLink": {
+            "Name": "DashboardLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "title",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "DashboardLink"
+            }
+          },
+          "ExternalLink": {
+            "Name": "ExternalLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "ExternalLink"
+            }
+          },
+          "Dashboard": {
+            "Name": "Dashboard",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "singleLinkOrString",
+                    "Comments": [
+                      "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+                    ],
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "linksOrStrings",
+                    "Comments": [
+                      "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+                    ],
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "disjunction",
+                          "Nullable": false,
+                          "Disjunction": {
+                            "Branches": [
+                              {
+                                "Kind": "ref",
+                                "Nullable": false,
+                                "Ref": {
+                                  "ReferredPkg": "builder_delegation_in_disjunction",
+                                  "ReferredType": "DashboardLink"
+                                }
+                              },
+                              {
+                                "Kind": "scalar",
+                                "Nullable": false,
+                                "Scalar": {
+                                  "ScalarKind": "string"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "disjunctionOfBuilders",
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "ExternalLink"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "Dashboard"
+            }
+          }
+        }
+      },
+      "For": {
+        "Name": "ExternalLink",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "url",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "builder_delegation_in_disjunction",
+          "ReferredType": "ExternalLink"
+        }
+      },
+      "Package": "builder_delegation_in_disjunction",
+      "Name": "ExternalLink",
+      "Options": [
+        {
+          "Name": "url",
+          "Args": [
+            {
+              "Name": "url",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "url",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        }
+      ]
+    },
+    {
+      "Schema": {
+        "Package": "builder_delegation_in_disjunction",
+        "Metadata": {},
+        "Objects": {
+          "DashboardLink": {
+            "Name": "DashboardLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "title",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "DashboardLink"
+            }
+          },
+          "ExternalLink": {
+            "Name": "ExternalLink",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "url",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "ExternalLink"
+            }
+          },
+          "Dashboard": {
+            "Name": "Dashboard",
+            "Type": {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "singleLinkOrString",
+                    "Comments": [
+                      "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+                    ],
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "linksOrStrings",
+                    "Comments": [
+                      "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+                    ],
+                    "Type": {
+                      "Kind": "array",
+                      "Nullable": false,
+                      "Array": {
+                        "ValueType": {
+                          "Kind": "disjunction",
+                          "Nullable": false,
+                          "Disjunction": {
+                            "Branches": [
+                              {
+                                "Kind": "ref",
+                                "Nullable": false,
+                                "Ref": {
+                                  "ReferredPkg": "builder_delegation_in_disjunction",
+                                  "ReferredType": "DashboardLink"
+                                }
+                              },
+                              {
+                                "Kind": "scalar",
+                                "Nullable": false,
+                                "Scalar": {
+                                  "ScalarKind": "string"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "Required": true
+                  },
+                  {
+                    "Name": "disjunctionOfBuilders",
+                    "Type": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "ExternalLink"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            "SelfRef": {
+              "ReferredPkg": "builder_delegation_in_disjunction",
+              "ReferredType": "Dashboard"
+            }
+          }
+        }
+      },
+      "For": {
+        "Name": "Dashboard",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "singleLinkOrString",
+                "Comments": [
+                  "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+                ],
+                "Type": {
+                  "Kind": "disjunction",
+                  "Nullable": false,
+                  "Disjunction": {
+                    "Branches": [
+                      {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "builder_delegation_in_disjunction",
+                          "ReferredType": "DashboardLink"
+                        }
+                      },
+                      {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "linksOrStrings",
+                "Comments": [
+                  "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+                ],
+                "Type": {
+                  "Kind": "array",
+                  "Nullable": false,
+                  "Array": {
+                    "ValueType": {
+                      "Kind": "disjunction",
+                      "Nullable": false,
+                      "Disjunction": {
+                        "Branches": [
+                          {
+                            "Kind": "ref",
+                            "Nullable": false,
+                            "Ref": {
+                              "ReferredPkg": "builder_delegation_in_disjunction",
+                              "ReferredType": "DashboardLink"
+                            }
+                          },
+                          {
+                            "Kind": "scalar",
+                            "Nullable": false,
+                            "Scalar": {
+                              "ScalarKind": "string"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "disjunctionOfBuilders",
+                "Type": {
+                  "Kind": "disjunction",
+                  "Nullable": false,
+                  "Disjunction": {
+                    "Branches": [
+                      {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "builder_delegation_in_disjunction",
+                          "ReferredType": "DashboardLink"
+                        }
+                      },
+                      {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "builder_delegation_in_disjunction",
+                          "ReferredType": "ExternalLink"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "builder_delegation_in_disjunction",
+          "ReferredType": "Dashboard"
+        }
+      },
+      "Package": "builder_delegation_in_disjunction",
+      "Name": "Dashboard",
+      "Options": [
+        {
+          "Name": "singleLinkOrString",
+          "Comments": [
+            "will be expanded to cog.Builder\u003cDashboardLink\u003e | string"
+          ],
+          "Args": [
+            {
+              "Name": "singleLinkOrString",
+              "Type": {
+                "Kind": "disjunction",
+                "Nullable": false,
+                "Disjunction": {
+                  "Branches": [
+                    {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "builder_delegation_in_disjunction",
+                        "ReferredType": "DashboardLink"
+                      }
+                    },
+                    {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "singleLinkOrString",
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "singleLinkOrString",
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        },
+        {
+          "Name": "linksOrStrings",
+          "Comments": [
+            "will be expanded to [](cog.Builder\u003cDashboardLink\u003e | string)"
+          ],
+          "Args": [
+            {
+              "Name": "linksOrStrings",
+              "Type": {
+                "Kind": "array",
+                "Nullable": false,
+                "Array": {
+                  "ValueType": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "scalar",
+                          "Nullable": false,
+                          "Scalar": {
+                            "ScalarKind": "string"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "linksOrStrings",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "disjunction",
+                        "Nullable": false,
+                        "Disjunction": {
+                          "Branches": [
+                            {
+                              "Kind": "ref",
+                              "Nullable": false,
+                              "Ref": {
+                                "ReferredPkg": "builder_delegation_in_disjunction",
+                                "ReferredType": "DashboardLink"
+                              }
+                            },
+                            {
+                              "Kind": "scalar",
+                              "Nullable": false,
+                              "Scalar": {
+                                "ScalarKind": "string"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "linksOrStrings",
+                  "Type": {
+                    "Kind": "array",
+                    "Nullable": false,
+                    "Array": {
+                      "ValueType": {
+                        "Kind": "disjunction",
+                        "Nullable": false,
+                        "Disjunction": {
+                          "Branches": [
+                            {
+                              "Kind": "ref",
+                              "Nullable": false,
+                              "Ref": {
+                                "ReferredPkg": "builder_delegation_in_disjunction",
+                                "ReferredType": "DashboardLink"
+                              }
+                            },
+                            {
+                              "Kind": "scalar",
+                              "Nullable": false,
+                              "Scalar": {
+                                "ScalarKind": "string"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        },
+        {
+          "Name": "disjunctionOfBuilders",
+          "Args": [
+            {
+              "Name": "disjunctionOfBuilders",
+              "Type": {
+                "Kind": "disjunction",
+                "Nullable": false,
+                "Disjunction": {
+                  "Branches": [
+                    {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "builder_delegation_in_disjunction",
+                        "ReferredType": "DashboardLink"
+                      }
+                    },
+                    {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "builder_delegation_in_disjunction",
+                        "ReferredType": "ExternalLink"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "disjunctionOfBuilders",
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "ExternalLink"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "disjunctionOfBuilders",
+                  "Type": {
+                    "Kind": "disjunction",
+                    "Nullable": false,
+                    "Disjunction": {
+                      "Branches": [
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "DashboardLink"
+                          }
+                        },
+                        {
+                          "Kind": "ref",
+                          "Nullable": false,
+                          "Ref": {
+                            "ReferredPkg": "builder_delegation_in_disjunction",
+                            "ReferredType": "ExternalLink"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "IsConstructorArg": false
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/schema.cue
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/schema.cue
@@ -1,0 +1,16 @@
+package builder_delegation_in_disjunction
+
+#DashboardLink: {
+		title: string
+		url: string
+}
+
+#ExternalLink: {
+	url: string
+}
+
+Dashboard: {
+	singleLinkOrString: #DashboardLink | string // will be expanded to cog.Builder<DashboardLink> | string
+	linksOrStrings: [...(#DashboardLink | string)] // will be expanded to [](cog.Builder<DashboardLink> | string)
+	disjunctionOfBuilders: #DashboardLink | #ExternalLink
+}


### PR DESCRIPTION
Cog generates invalid code in builders accepting a disjunction as arguments, if branches of that disjunction reference builders.

A few failing cases can be found in [testdata/jennies/builders/builder_delegation_in_disjunction/TypescriptBuilder/src/builderDelegationInDisjunction/dashboardBuilder.gen.ts](https://github.com/grafana/cog/pull/281/files#diff-2a945905c61362e677aba34c1db6348e7717bb652365285b70279f8374a3bfbe)

Note: this PR fixes a few cases, but there are still other cases where cog would generate incorrect code. For example:

```cue
broken: #DashboardLink | [...#DashboardLink]
otherBroken: [...#DashboardLink] | string
```

Would generate:

```patch
+    broken(broken: cog.Builder<builderDelegationInDisjunction.DashboardLink> | cog.Builder<builderDelegationInDisjunction.DashboardLink>[]): this {
+        const brokenResource = broken.build();
+        this.internal.broken = brokenResource;
+        return this;
+    }
+
+    otherBroken(otherBroken: cog.Builder<builderDelegationInDisjunction.DashboardLink>[] | string): this {
+        const otherBrokenResource = cog.isBuilder(otherBroken) ? otherBroken.build() : otherBroken;
+        this.internal.otherBroken = otherBrokenResource;
+        return this;
+    }
```

I'll create an issue to describe these cases, fixing them isn't trivial and we don't currently have any schema with such disjunctions.