### PR TITLE
Sort packages list in PackageTemplate jenny

### DIFF
--- a/internal/jennies/common/packagetemplate.go
+++ b/internal/jennies/common/packagetemplate.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -80,6 +81,8 @@ func (jenny PackageTemplate) templateData(context Context) map[string]any {
 	for _, schema := range context.Schemas {
 		packages = append(packages, schema.Package)
 	}
+
+	sort.Strings(packages)
 
 	extra := map[string]string{}
 	if jenny.ExtraData != nil {


### PR DESCRIPTION
To ensure that the output is deterministic and doesn't depend on the order with which schemas are parsed, let's sort the package list it gives to templates.