### PR TITLE
Sort packages list in GoVariantsPlugins jenny

### DIFF
--- a/internal/jennies/golang/templates/runtime/variant_plugins.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_plugins.tmpl
@@ -6,12 +6,12 @@ func RegisterDefaultPlugins() {
 	runtime := cog.NewRuntime()
 
     // Panelcfg variants
-{{- range $schema := index .init_map "panelcfg" }}
+{{- range $schema := .panel_schemas }}
 	runtime.RegisterPanelcfgVariant({{ $schema.Package | formatPackageName }}.VariantConfig())
 {{- end }}
 
     // Dataquery variants
-{{- range $schema := index .init_map "dataquery" }}
+{{- range $schema := .dataquery_schemas }}
 	runtime.RegisterDataqueryVariant({{ $schema.Package | formatPackageName }}.VariantConfig())
 {{- end }}
 }


### PR DESCRIPTION
Similar to #282

To guarantee a consistent output, we sort packages in the `GoVariantsPlugins` jenny.