### PR TITLE
Set a compiler pass to mark common.TableFieldOptions.CellOptions as not required

### DIFF
--- a/config/compiler/common_passes.yaml
+++ b/config/compiler/common_passes.yaml
@@ -80,6 +80,13 @@ passes:
       field: testdata.SimulationQuery.key
       as: Key
 
+  ###############
+  # table panel #
+  ###############
+
+  - fields_set_not_required:
+      fields: [ common.TableFieldOptions.CellOptions ]
+
   ##########
   # Others #
   ##########

--- a/examples/_go/disk.go
+++ b/examples/_go/disk.go
@@ -43,11 +43,6 @@ func diskSpaceUsageTable() *table.PanelBuilder {
 	return table.NewPanelBuilder().
 		Title("Disk Space Usage").
 		Align(common.FieldTextAlignmentAuto).
-		CellOptions(common.TableCellOptions{
-			TableAutoCellOptions: &common.TableAutoCellOptions{
-				Type: "auto",
-			},
-		}).
 		Unit("decbytes").
 		CellHeight(common.TableCellHeightSm).
 		Footer(common.NewTableFooterOptionsBuilder().CountRows(false).Reducer([]string{"sum"})).

--- a/internal/ast/compiler/fields_set_not_required.go
+++ b/internal/ast/compiler/fields_set_not_required.go
@@ -1,0 +1,48 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*FieldsSetNotRequired)(nil)
+
+// FieldsSetNotRequired rewrites the definition of given fields to mark them as nullable and not required.
+type FieldsSetNotRequired struct {
+	Fields []FieldReference
+}
+
+func (pass *FieldsSetNotRequired) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for i, schema := range schemas {
+		schemas[i] = pass.processSchema(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *FieldsSetNotRequired) processSchema(schema *ast.Schema) *ast.Schema {
+	schema.Objects = schema.Objects.Map(pass.processObject)
+
+	return schema
+}
+
+func (pass *FieldsSetNotRequired) processObject(_ string, object ast.Object) ast.Object {
+	if !object.Type.IsStruct() {
+		return object
+	}
+
+	for i, field := range object.Type.AsStruct().Fields {
+		for _, fieldRef := range pass.Fields {
+			if !fieldRef.Matches(object, field) {
+				continue
+			}
+
+			field.Type.Nullable = true
+			field.Required = false
+			field.AddToPassesTrail("FieldsSetNotRequired[nullable=true, required=false]")
+
+			object.Type.Struct.Fields[i] = field
+		}
+	}
+
+	return object
+}

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -12,6 +12,7 @@ type CompilerPass struct {
 	Unspec                  *Unspec                  `yaml:"unspec"`
 	FieldsSetDefault        *FieldsSetDefault        `yaml:"fields_set_default"`
 	FieldsSetRequired       *FieldsSetRequired       `yaml:"fields_set_required"`
+	FieldsSetNotRequired    *FieldsSetNotRequired    `yaml:"fields_set_not_required"`
 	Omit                    *Omit                    `yaml:"omit"`
 	AddFields               *AddFields               `yaml:"add_fields"`
 	NameAnonymousStruct     *NameAnonymousStruct     `yaml:"name_anonymous_struct"`
@@ -39,6 +40,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 	}
 	if pass.FieldsSetRequired != nil {
 		return pass.FieldsSetRequired.AsCompilerPass()
+	}
+	if pass.FieldsSetNotRequired != nil {
+		return pass.FieldsSetNotRequired.AsCompilerPass()
 	}
 	if pass.Omit != nil {
 		return pass.Omit.AsCompilerPass()
@@ -126,6 +130,25 @@ func (pass FieldsSetRequired) AsCompilerPass() (compiler.Pass, error) {
 	}
 
 	return &compiler.FieldsSetRequired{Fields: fieldRefs}, nil
+}
+
+type FieldsSetNotRequired struct {
+	Fields []string // Expected format: [package].[object].[field]
+}
+
+func (pass FieldsSetNotRequired) AsCompilerPass() (compiler.Pass, error) {
+	fieldRefs := make([]compiler.FieldReference, 0, len(pass.Fields))
+
+	for _, ref := range pass.Fields {
+		fieldRef, err := compiler.FieldReferenceFromString(ref)
+		if err != nil {
+			return nil, err
+		}
+
+		fieldRefs = append(fieldRefs, fieldRef)
+	}
+
+	return &compiler.FieldsSetNotRequired{Fields: fieldRefs}, nil
 }
 
 type Omit struct {


### PR DESCRIPTION
Fixes grafana/grafana-foundation-sdk#50