### PR TITLE
Consolidate kind-registry to temporarily accomodate for deleted schemas

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,12 @@ jobs:
       - name: Clone kind-registry
         run: git clone --depth=1 https://github.com/grafana/kind-registry.git ../kind-registry
 
+      - name: Consolidate kind-registry
+        run: ./scripts/consolidate-schema-registry.sh
+        env:
+          GRAFANA_VERSION: ${{ matrix.kind_version }}
+          LOG_LEVEL: '7' # debug
+
       - name: Run code generation
         run: |
           go run cmd/cli/main.go generate \
@@ -122,6 +128,11 @@ jobs:
 
       - name: Clone kind-registry
         run: git clone --depth=1 https://github.com/grafana/kind-registry.git ../kind-registry
+
+      - name: Consolidate kind-registry
+        run: ./scripts/consolidate-schema-registry.sh
+        env:
+          LOG_LEVEL: '7' # debug
 
       - name: Run code generation
         run: |

--- a/schemas/composable/prometheus/dataquery.cue
+++ b/schemas/composable/prometheus/dataquery.cue
@@ -1,0 +1,44 @@
+// This schema was deleted from grafana/grafana in https://github.com/grafana/grafana/pull/83808
+// Until a proper alternative is published, we cheat slightly by copy-pasting it here.
+package grafanaplugin
+
+import (
+	"github.com/grafana/kindsys"
+	"github.com/grafana/grafana/packages/grafana-schema/src/common"
+)
+
+kindsys.Composable & {
+	maturity:        "experimental"
+	name:            "Prometheus" + "DataQuery"
+	schemaInterface: "DataQuery"
+	lineage: {
+		schemas: [{
+			version: [0, 0]
+			schema: {
+				common.DataQuery
+
+				// The actual expression/query that will be evaluated by Prometheus
+				expr: string
+				// Returns only the latest value that Prometheus has scraped for the requested time series
+				instant?: bool
+				// Returns a Range vector, comprised of a set of time series containing a range of data points over time for each time series
+				range?: bool
+				// Execute an additional query to identify interesting raw samples relevant for the given expr
+				exemplar?: bool
+				// Specifies which editor is being used to prepare the query. It can be "code" or "builder"
+				editorMode?: #QueryEditorMode
+				// Query format to determine how to display data points in panel. It can be "time_series", "table", "heatmap"
+				format?: #PromQueryFormat
+				// Series name override or template. Ex. {{hostname}} will be replaced with label value for hostname
+				legendFormat?: string
+				// @deprecated Used to specify how many times to divide max data points by. We use max data points under query options
+				// See https://github.com/grafana/grafana/issues/48081
+				intervalFactor?:  number
+				#QueryEditorMode: "code" | "builder"                  @cuetsy(kind="enum")
+				#PromQueryFormat: "time_series" | "table" | "heatmap" @cuetsy(kind="type")
+			}
+		}]
+		name: "Prometheus" + "DataQuery"
+		lenses: []
+	}
+}

--- a/scripts/consolidate-schema-registry.sh
+++ b/scripts/consolidate-schema-registry.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append "|| true" if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${__dir}/libs/logs.sh"
+
+GRAFANA_VERSION=${GRAFANA_VERSION:-"next"} # version of the schemas/grafana to consolidate.
+KIND_REGISTRY_PATH=${KIND_REGISTRY_PATH:-'../kind-registry'} # Path to the kind-registry
+COG_EMBEDDED_SCHEMAS_PATH=${COG_EMBEDDED_SCHEMAS_PATH:-'./schemas'} # Path to the kind-registry
+
+#################
+### Utilities ###
+#################
+
+function copy_prometheus_schema() {
+  local kind_registry_path=${1}
+  shift
+  local target_version=${1}
+  shift
+  local embedded_schemas_path=${1}
+  shift
+
+  rm -rf "${kind_registry_path}/grafana/${target_version}/composable/prometheus"
+  cp -R "${embedded_schemas_path}/composable/prometheus" "${kind_registry_path}/grafana/${target_version}/composable"
+}
+
+###########################
+### Consolidation cases ###
+###########################
+
+if [ "${GRAFANA_VERSION}" == "next" ]; then
+  debug "Consolidating schemas for ${GRAFANA_VERSION}"
+
+  debug " → copy_prometheus_schema"
+  copy_prometheus_schema "${KIND_REGISTRY_PATH}" "${GRAFANA_VERSION}" "${COG_EMBEDDED_SCHEMAS_PATH}"
+fi

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -138,6 +138,9 @@ if [ ! -d "${FOUNDATION_SDK_PATH}" ]; then
   clone_foundation_sdk "${FOUNDATION_SDK_PATH}"
 fi
 
+info "Consolidating kind-registry"
+GRAFANA_VERSION=${GRAFANA_VERSION} KIND_REGISTRY_PATH=${KIND_REGISTRY_PATH} "${__dir}/consolidate-schema-registry.sh"
+
 info "Running cog"
 run_codegen "${KIND_REGISTRY_PATH}" "${GRAFANA_VERSION}" "${codegen_output_path}" "GrafanaVersion=${GRAFANA_VERSION},CogVersion=${COG_VERSION},ReleaseBranch=${release_branch},BuildTimestamp=${build_timestamp}"
 


### PR DESCRIPTION
CUE [schemas for prometheus dataqueries have been removed from Grafana](https://github.com/grafana/grafana/pull/83808).

As a result, they're not present in kind-registry in the `next` version (but the list of impacted versions will grow).

Until we figure out better ways to get schemas, I propose that we cheat a bit and "consolidate" what we get from the kind-registry to retain the ability to generate grafana-foundation-sdk.