### PR TITLE
Bootstrap jsonschema jenny

### DIFF
--- a/internal/ast/compiler/infer_entrypoint.go
+++ b/internal/ast/compiler/infer_entrypoint.go
@@ -1,0 +1,36 @@
+package compiler
+
+import (
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*InferEntrypoint)(nil)
+
+type InferEntrypoint struct {
+}
+
+func (pass *InferEntrypoint) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for _, schema := range schemas {
+		if schema.EntryPoint != "" {
+			continue
+		}
+
+		schema.EntryPoint = pass.inferEntrypoint(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *InferEntrypoint) inferEntrypoint(schema *ast.Schema) string {
+	entrypoint := ""
+
+	schema.Objects.Iterate(func(_ string, object ast.Object) {
+		if strings.EqualFold(schema.Package, object.Name) {
+			entrypoint = object.Name
+		}
+	})
+
+	return entrypoint
+}

--- a/internal/ast/schema.go
+++ b/internal/ast/schema.go
@@ -71,9 +71,10 @@ func (schemas Schemas) DeepCopy() []*Schema {
 }
 
 type Schema struct { //nolint: musttag
-	Package  string
-	Metadata SchemaMeta `json:",omitempty"`
-	Objects  *orderedmap.Map[string, Object]
+	Package    string
+	Metadata   SchemaMeta `json:",omitempty"`
+	EntryPoint string     `json:",omitempty"`
+	Objects    *orderedmap.Map[string, Object]
 }
 
 func NewSchema(pkg string, metadata SchemaMeta) *Schema {

--- a/internal/jennies/all.go
+++ b/internal/jennies/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/java"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
+	"github.com/grafana/cog/internal/jennies/openapi"
 	"github.com/grafana/cog/internal/jennies/python"
 	"github.com/grafana/cog/internal/jennies/typescript"
 	"github.com/spf13/cobra"
@@ -53,6 +54,7 @@ func All() LanguageJennies {
 		golang.LanguageRef:     golang.New(),
 		java.LanguageRef:       java.New(),
 		jsonschema.LanguageRef: jsonschema.New(),
+		openapi.LanguageRef:    openapi.New(),
 		python.LanguageRef:     python.New(),
 		typescript.LanguageRef: typescript.New(),
 	}

--- a/internal/jennies/all.go
+++ b/internal/jennies/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/java"
+	"github.com/grafana/cog/internal/jennies/jsonschema"
 	"github.com/grafana/cog/internal/jennies/python"
 	"github.com/grafana/cog/internal/jennies/typescript"
 	"github.com/spf13/cobra"
@@ -50,8 +51,9 @@ func (languageJennies LanguageJennies) AsLanguageRefs() []string {
 func All() LanguageJennies {
 	return LanguageJennies{
 		golang.LanguageRef:     golang.New(),
+		java.LanguageRef:       java.New(),
+		jsonschema.LanguageRef: jsonschema.New(),
 		python.LanguageRef:     python.New(),
 		typescript.LanguageRef: typescript.New(),
-		java.LanguageRef:       java.New(),
 	}
 }

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -1,9 +1,13 @@
 package jsonschema
 
 import (
+	"bytes"
+	"strings"
+
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/jennies/common"
+	schemaparser "github.com/santhosh-tekuri/jsonschema"
 	"github.com/spf13/cobra"
 )
 
@@ -35,14 +39,15 @@ func (language *Language) RegisterCliFlags(_ *cobra.Command) {
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
-
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
 
-	jenny.AppendOneToMany(
-		Schema{Config: config},
-	)
+	jenny.AppendOneToMany(Schema{Config: config})
+
+	if config.Debug {
+		jenny.AddPostprocessors(ValidateSchemas)
+	}
 
 	return jenny
 }
@@ -52,4 +57,19 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.InferEntrypoint{},
 	}
+}
+
+func ValidateSchemas(file codejen.File) (codejen.File, error) {
+	if !strings.HasSuffix(file.RelativePath, ".json") {
+		return file, nil
+	}
+
+	schemaReader := bytes.NewReader(file.Data)
+	schemaCompiler := schemaparser.NewCompiler()
+
+	if err := schemaCompiler.AddResource("schema", schemaReader); err != nil {
+		return file, err
+	}
+
+	return file, nil
 }

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -50,5 +50,6 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
 		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.InferEntrypoint{},
 	}
 }

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -1,0 +1,54 @@
+package jsonschema
+
+import (
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/spf13/cobra"
+)
+
+const LanguageRef = "jsonschema"
+
+type Config struct {
+	Debug bool
+}
+
+func (config Config) MergeWithGlobal(global common.Config) Config {
+	newConfig := config
+	newConfig.Debug = global.Debug
+
+	return newConfig
+}
+
+type Language struct {
+	config Config
+}
+
+func New() *Language {
+	return &Language{
+		config: Config{},
+	}
+}
+
+func (language *Language) RegisterCliFlags(_ *cobra.Command) {
+}
+
+func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+	config := language.config.MergeWithGlobal(globalConfig)
+
+	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+		return LanguageRef
+	})
+
+	jenny.AppendOneToMany(
+		Schema{Config: config},
+	)
+
+	return jenny
+}
+
+func (language *Language) CompilerPasses() compiler.Passes {
+	return compiler.Passes{
+		&compiler.DisjunctionWithNullToOptional{},
+	}
+}

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -46,6 +46,13 @@ func (jenny Schema) GenerateSchema(schema *ast.Schema) Definition {
 	jsonSchema := orderedmap.New[string, any]()
 	jsonSchema.Set("$schema", "http://json-schema.org/draft-07/schema#")
 
+	if schema.EntryPoint != "" {
+		jsonSchema.Set("$ref", jenny.ReferenceFormatter(ast.RefType{
+			ReferredPkg:  schema.Package,
+			ReferredType: schema.EntryPoint,
+		}))
+	}
+
 	definitions := orderedmap.New[string, Definition]()
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -1,0 +1,226 @@
+package jsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/orderedmap"
+	"github.com/grafana/cog/internal/tools"
+)
+
+type objectDefinition = *orderedmap.Map[string, any]
+
+type Schema struct {
+	Config Config
+}
+
+func (jenny Schema) JennyName() string {
+	return "JSONSchema"
+}
+
+func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0, len(context.Schemas))
+
+	for _, schema := range context.Schemas {
+		output, err := jenny.generateSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, *codejen.NewFile(schema.Package+".json", output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny Schema) generateSchema(schema *ast.Schema) ([]byte, error) {
+	jsonSchema := orderedmap.New[string, any]()
+	jsonSchema.Set("$schema", "http://json-schema.org/draft-07/schema#")
+
+	definitions := orderedmap.New[string, objectDefinition]()
+
+	schema.Objects.Iterate(func(_ string, object ast.Object) {
+		definitions.Set(object.Name, jenny.objectToDefinition(object))
+	})
+
+	jsonSchema.Set("definitions", definitions)
+
+	return json.Marshal(jsonSchema)
+}
+
+func (jenny Schema) objectToDefinition(object ast.Object) objectDefinition {
+	definition := jenny.formatType(object.Type)
+
+	if comments := jenny.objectComments(object); len(comments) != 0 {
+		definition.Set("description", comments)
+	}
+
+	return definition
+}
+
+func (jenny Schema) formatType(typeDef ast.Type) objectDefinition {
+	switch typeDef.Kind {
+	case ast.KindStruct:
+		return jenny.formatStruct(typeDef)
+	case ast.KindScalar:
+		return jenny.formatScalar(typeDef)
+	case ast.KindRef:
+		return jenny.formatRef(typeDef)
+	case ast.KindEnum:
+		return jenny.formatEnum(typeDef)
+	case ast.KindArray:
+		return jenny.formatArray(typeDef)
+	case ast.KindMap:
+		return jenny.formatMap(typeDef)
+	case ast.KindDisjunction:
+		return jenny.formatDisjunction(typeDef)
+	case ast.KindComposableSlot:
+		return jenny.formatComposableSlot()
+	}
+
+	return orderedmap.New[string, any]()
+}
+
+func (jenny Schema) formatScalar(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	switch typeDef.AsScalar().ScalarKind {
+	case ast.KindNull:
+		definition.Set("type", "null")
+	case ast.KindAny:
+		definition.Set("type", "object")
+		definition.Set("additionalProperties", map[string]any{})
+	case ast.KindBytes, ast.KindString:
+		definition.Set("type", "string")
+		// TODO: constraints
+	case ast.KindBool:
+		definition.Set("type", "boolean")
+	case ast.KindFloat32, ast.KindFloat64:
+		definition.Set("type", "number")
+		// TODO: constraints
+	case ast.KindUint8, ast.KindUint16, ast.KindUint32, ast.KindUint64,
+		ast.KindInt8, ast.KindInt16, ast.KindInt32, ast.KindInt64:
+		definition.Set("type", "integer")
+		// TODO: constraints
+	}
+
+	// constant value?
+	if typeDef.AsScalar().IsConcrete() {
+		definition.Set("const", typeDef.AsScalar().Value)
+	}
+
+	return definition
+}
+
+func (jenny Schema) formatStruct(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	definition.Set("type", "object")
+	definition.Set("additionalProperties", false)
+
+	properties := orderedmap.New[string, any]()
+	var required []string
+
+	for _, field := range typeDef.AsStruct().Fields {
+		fieldDef := jenny.formatType(field.Type)
+
+		// TODO: correctly handle passes trail
+
+		if comments := strings.Join(field.Comments, "\n"); len(comments) != 0 {
+			definition.Set("description", comments)
+		}
+
+		properties.Set(field.Name, fieldDef)
+
+		if field.Required {
+			required = append(required, field.Name)
+		}
+
+		// TODO: review defaults management
+		if field.Type.Default != nil {
+			fieldDef.Set("default", field.Type.Default)
+		}
+	}
+
+	if len(required) != 0 {
+		definition.Set("required", required)
+	}
+
+	definition.Set("properties", properties)
+
+	return definition
+}
+
+func (jenny Schema) formatRef(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	// TODO: handle foreign refs
+	definition.Set("$ref", "#/definitions/"+typeDef.AsRef().ReferredType)
+
+	return definition
+}
+
+func (jenny Schema) formatEnum(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	values := tools.Map(typeDef.AsEnum().Values, func(value ast.EnumValue) any {
+		return value.Value
+	})
+
+	definition.Set("enum", values)
+
+	return definition
+}
+
+func (jenny Schema) formatArray(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	definition.Set("type", "array")
+	definition.Set("items", jenny.formatType(typeDef.AsArray().ValueType))
+
+	return definition
+}
+
+func (jenny Schema) formatMap(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	definition.Set("type", "object")
+	definition.Set("additionalProperties", jenny.formatType(typeDef.AsMap().ValueType))
+
+	return definition
+}
+
+func (jenny Schema) formatDisjunction(typeDef ast.Type) objectDefinition {
+	definition := orderedmap.New[string, any]()
+	branches := tools.Map(typeDef.AsDisjunction().Branches, jenny.formatType)
+
+	definition.Set("anyOf", branches)
+
+	return definition
+}
+
+func (jenny Schema) formatComposableSlot() objectDefinition {
+	definition := orderedmap.New[string, any]()
+
+	// Same as "any"
+	definition.Set("type", "object")
+	definition.Set("additionalProperties", map[string]any{})
+
+	return definition
+}
+
+func (jenny Schema) objectComments(object ast.Object) string {
+	comments := object.Comments
+	if jenny.Config.Debug {
+		passesTrail := tools.Map(object.PassesTrail, func(trail string) string {
+			return fmt.Sprintf("Modified by compiler pass '%s'", trail)
+		})
+		comments = append(comments, passesTrail...)
+	}
+
+	return strings.Join(comments, "\n")
+}

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -1,0 +1,42 @@
+package jsonschema
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite{
+		TestDataRoot: "../../../testdata/jennies/rawtypes",
+		Name:         "JSONSchema",
+	}
+
+	jenny := Schema{
+		Config: Config{
+			Debug: true,
+		},
+	}
+	compilerPasses := New().CompilerPasses()
+
+	test.Run(t, func(tc *testutils.Test) {
+		req := require.New(tc)
+
+		// We run the compiler passes defined fo JSONSchema since without them, we
+		// might not be able to translate some of the IR's semantics.
+		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		req.NoError(err)
+
+		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
+
+		files, err := jenny.Generate(common.Context{
+			Schemas: processedAsts,
+		})
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -51,5 +51,6 @@ func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
 		// should be a superset of the compiler passes defined for jsonschema jennies
 		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.InferEntrypoint{},
 	}
 }

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -1,0 +1,55 @@
+package openapi
+
+import (
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/spf13/cobra"
+)
+
+const LanguageRef = "openapi"
+
+type Config struct {
+	Debug bool
+}
+
+func (config Config) MergeWithGlobal(global common.Config) Config {
+	newConfig := config
+	newConfig.Debug = global.Debug
+
+	return newConfig
+}
+
+type Language struct {
+	config Config
+}
+
+func New() *Language {
+	return &Language{
+		config: Config{},
+	}
+}
+
+func (language *Language) RegisterCliFlags(_ *cobra.Command) {
+}
+
+func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+	config := language.config.MergeWithGlobal(globalConfig)
+
+	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+		return LanguageRef
+	})
+
+	jenny.AppendOneToMany(
+		Schema{Config: config},
+	)
+
+	return jenny
+}
+
+func (language *Language) CompilerPasses() compiler.Passes {
+	return compiler.Passes{
+		// should be a superset of the compiler passes defined for jsonschema jennies
+		&compiler.DisjunctionWithNullToOptional{},
+	}
+}

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -35,14 +35,11 @@ func (language *Language) RegisterCliFlags(_ *cobra.Command) {
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
-
 	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
 		return LanguageRef
 	})
 
-	jenny.AppendOneToMany(
-		Schema{Config: config},
-	)
+	jenny.AppendOneToMany(Schema{Config: config})
 
 	return jenny
 }

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -1,0 +1,67 @@
+package openapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/jennies/jsonschema"
+	"github.com/grafana/cog/internal/orderedmap"
+)
+
+type Schema struct {
+	Config Config
+}
+
+func (jenny Schema) JennyName() string {
+	return "OpenAPI"
+}
+
+func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0, len(context.Schemas))
+
+	for _, schema := range context.Schemas {
+		output, err := jenny.generateSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, *codejen.NewFile(schema.Package+".openapi.json", output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny Schema) generateSchema(schema *ast.Schema) ([]byte, error) {
+	jsonschemaJenny := jsonschema.Schema{
+		Config: jsonschema.Config{
+			Debug: jenny.Config.Debug,
+		},
+		ReferenceFormatter: func(ref ast.RefType) string {
+			return fmt.Sprintf("#/components/schemas/%s", ref.ReferredType)
+		},
+	}
+
+	jsonSchema := jsonschemaJenny.GenerateSchema(schema)
+
+	info := orderedmap.New[string, any]()
+	info.Set("title", schema.Package)
+	info.Set("version", "0.0.0")
+	info.Set("x-schema-identifier", schema.Metadata.Identifier)
+	info.Set("x-schema-kind", schema.Metadata.Kind)
+	if schema.Metadata.Variant != "" {
+		info.Set("x-schema-variant", schema.Metadata.Variant)
+	}
+
+	openapiSchema := orderedmap.New[string, any]()
+	openapiSchema.Set("openapi", "3.0.0")
+	openapiSchema.Set("info", info)
+	openapiSchema.Set("paths", map[string]any{})
+	openapiSchema.Set("components", map[string]any{
+		"schemas": jsonSchema.Get("definitions"),
+	})
+
+	return json.Marshal(openapiSchema)
+}

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -23,7 +23,7 @@ func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
-		output, err := jenny.generateSchema(schema)
+		output, err := jenny.generateSchema(context, schema)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +34,7 @@ func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny Schema) generateSchema(schema *ast.Schema) ([]byte, error) {
+func (jenny Schema) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
 	jsonschemaJenny := jsonschema.Schema{
 		Config: jsonschema.Config{
 			Debug: jenny.Config.Debug,
@@ -44,7 +44,7 @@ func (jenny Schema) generateSchema(schema *ast.Schema) ([]byte, error) {
 		},
 	}
 
-	jsonSchema := jsonschemaJenny.GenerateSchema(schema)
+	jsonSchema := jsonschemaJenny.GenerateSchema(context, schema)
 
 	info := orderedmap.New[string, any]()
 	info.Set("title", schema.Package)

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -63,5 +63,13 @@ func (jenny Schema) generateSchema(schema *ast.Schema) ([]byte, error) {
 		"schemas": jsonSchema.Get("definitions"),
 	})
 
-	return json.Marshal(openapiSchema)
+	return jenny.toJSON(openapiSchema)
+}
+
+func (jenny Schema) toJSON(input any) ([]byte, error) {
+	if jenny.Config.Debug {
+		return json.MarshalIndent(input, "", "  ")
+	}
+
+	return json.Marshal(input)
 }

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -1,0 +1,42 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchema_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite{
+		TestDataRoot: "../../../testdata/jennies/rawtypes",
+		Name:         "OpenAPI",
+	}
+
+	jenny := Schema{
+		Config: Config{
+			Debug: true,
+		},
+	}
+	compilerPasses := New().CompilerPasses()
+
+	test.Run(t, func(tc *testutils.Test) {
+		req := require.New(tc)
+
+		// We run the compiler passes defined fo OpenAPI since without them, we
+		// might not be able to translate some of the IR's semantics.
+		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		req.NoError(err)
+
+		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
+
+		files, err := jenny.Generate(common.Context{
+			Schemas: processedAsts,
+		})
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -75,6 +75,8 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 		g.schema.Objects.Get(rootObjectName).Type.Hints[ast.HintImplementsVariant] = string(c.SchemaMetadata.Variant)
 	}
 
+	g.schema.EntryPoint = rootObjectName
+
 	// To ensure a consistent output, since github.com/santhosh-tekuri/jsonschema
 	// doesn't guarantee the order of the definitions it parses.
 	g.schema.Objects.Sort(orderedmap.SortStrings)

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -105,6 +105,8 @@ func (g *generator) walkCueSchemaWithVariantEnvelope(v cue.Value) error {
 		},
 	})
 
+	g.schema.EntryPoint = string(g.schema.Metadata.Variant)
+
 	return nil
 }
 

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -75,8 +75,9 @@ function run_codegen() {
     --go-mod \
     --go-package-root github.com/grafana/grafana-foundation-sdk/go \
     --language go \
-    --language typescript
-
+    --language typescript \
+    --language jsonschema \
+    --language openapi
     #--python-path-prefix grafana_foundation_sdk \
     #--language python \
 }

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -75,9 +75,9 @@ function run_codegen() {
     --go-mod \
     --go-package-root github.com/grafana/grafana-foundation-sdk/go \
     --language go \
-    --language typescript \
-    --language jsonschema \
-    --language openapi
+    --language typescript
+    #--language jsonschema \
+    #--language openapi
     #--python-path-prefix grafana_foundation_sdk \
     #--language python \
 }

--- a/testdata/jennies/rawtypes/arrays/JSONSchema/arrays.jsonschema.json
+++ b/testdata/jennies/rawtypes/arrays/JSONSchema/arrays.jsonschema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ArrayOfStrings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of tags, maybe?"
+    },
+    "someStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "ArrayOfRefs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/someStruct"
+      }
+    },
+    "ArrayOfArrayOfNumbers": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/arrays/OpenAPI/arrays.openapi.json
+++ b/testdata/jennies/rawtypes/arrays/OpenAPI/arrays.openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "arrays",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ArrayOfStrings": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of tags, maybe?"
+      },
+      "someStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "ArrayOfRefs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/someStruct"
+        }
+      },
+      "ArrayOfArrayOfNumbers": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/dashboard/JSONSchema/dashboard.jsonschema.json
+++ b/testdata/jennies/rawtypes/dashboard/JSONSchema/dashboard.jsonschema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Dashboard",
+  "definitions": {
+    "Dashboard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "panels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Panel"
+          }
+        }
+      }
+    },
+    "DataSourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        }
+      }
+    },
+    "FieldConfigSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "defaults": {
+          "$ref": "#/definitions/FieldConfig"
+        }
+      }
+    },
+    "FieldConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unit": {
+          "type": "string"
+        },
+        "custom": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "Panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "type"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "datasource": {
+          "$ref": "#/definitions/DataSourceRef"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "targets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        },
+        "fieldConfig": {
+          "$ref": "#/definitions/FieldConfigSource"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/dashboard/OpenAPI/dashboard.openapi.json
+++ b/testdata/jennies/rawtypes/dashboard/OpenAPI/dashboard.openapi.json
@@ -1,0 +1,99 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "dashboard",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": "core"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Dashboard": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "panels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Panel"
+            }
+          }
+        }
+      },
+      "DataSourceRef": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        }
+      },
+      "FieldConfigSource": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "defaults": {
+            "$ref": "#/components/schemas/FieldConfig"
+          }
+        }
+      },
+      "FieldConfig": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "unit": {
+            "type": "string"
+          },
+          "custom": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "Panel": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "type"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "datasource": {
+            "$ref": "#/components/schemas/DataSourceRef"
+          },
+          "options": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "fieldConfig": {
+            "$ref": "#/components/schemas/FieldConfigSource"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/disjunctions/JSONSchema/disjunctions.jsonschema.json
+++ b/testdata/jennies/rawtypes/disjunctions/JSONSchema/disjunctions.jsonschema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "RefreshRate": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ],
+      "description": "Refresh rate or disabled."
+    },
+    "StringOrNull": {
+      "type": "string"
+    },
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Type",
+        "FieldAny"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "const": "some-struct"
+        },
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "BoolOrRef": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/SomeStruct"
+        }
+      ]
+    },
+    "SomeOtherStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Type",
+        "Foo"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "const": "some-other-struct"
+        },
+        "Foo": {
+          "type": "string"
+        }
+      }
+    },
+    "YetAnotherStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "Type",
+        "Bar"
+      ],
+      "properties": {
+        "Type": {
+          "type": "string",
+          "const": "yet-another-struct"
+        },
+        "Bar": {
+          "type": "integer"
+        }
+      }
+    },
+    "SeveralRefs": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SomeStruct"
+        },
+        {
+          "$ref": "#/definitions/SomeOtherStruct"
+        },
+        {
+          "$ref": "#/definitions/YetAnotherStruct"
+        }
+      ]
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/disjunctions/OpenAPI/disjunctions.openapi.json
+++ b/testdata/jennies/rawtypes/disjunctions/OpenAPI/disjunctions.openapi.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "disjunctions",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "RefreshRate": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          }
+        ],
+        "description": "Refresh rate or disabled."
+      },
+      "StringOrNull": {
+        "type": "string"
+      },
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Type",
+          "FieldAny"
+        ],
+        "properties": {
+          "Type": {
+            "type": "string",
+            "const": "some-struct"
+          },
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "BoolOrRef": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/SomeStruct"
+          }
+        ]
+      },
+      "SomeOtherStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Type",
+          "Foo"
+        ],
+        "properties": {
+          "Type": {
+            "type": "string",
+            "const": "some-other-struct"
+          },
+          "Foo": {
+            "type": "string"
+          }
+        }
+      },
+      "YetAnotherStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "Type",
+          "Bar"
+        ],
+        "properties": {
+          "Type": {
+            "type": "string",
+            "const": "yet-another-struct"
+          },
+          "Bar": {
+            "type": "integer"
+          }
+        }
+      },
+      "SeveralRefs": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/SomeStruct"
+          },
+          {
+            "$ref": "#/components/schemas/SomeOtherStruct"
+          },
+          {
+            "$ref": "#/components/schemas/YetAnotherStruct"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/enums/JSONSchema/enums.jsonschema.json
+++ b/testdata/jennies/rawtypes/enums/JSONSchema/enums.jsonschema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Operator": {
+      "enum": [
+        "\u003e",
+        "\u003c"
+      ],
+      "description": "This is a very interesting string enum."
+    },
+    "TableSortOrder": {
+      "enum": [
+        "asc",
+        "desc"
+      ]
+    },
+    "LogsSortOrder": {
+      "enum": [
+        "time_asc",
+        "time_desc"
+      ]
+    },
+    "DashboardCursorSync": {
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "description": "0 for no shared crosshair or tooltip (default).\n1 for shared crosshair.\n2 for shared crosshair AND shared tooltip."
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/enums/OpenAPI/enums.openapi.json
+++ b/testdata/jennies/rawtypes/enums/OpenAPI/enums.openapi.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "enums",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Operator": {
+        "enum": [
+          "\u003e",
+          "\u003c"
+        ],
+        "description": "This is a very interesting string enum."
+      },
+      "TableSortOrder": {
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "LogsSortOrder": {
+        "enum": [
+          "time_asc",
+          "time_desc"
+        ]
+      },
+      "DashboardCursorSync": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "description": "0 for no shared crosshair or tooltip (default).\n1 for shared crosshair.\n2 for shared crosshair AND shared tooltip."
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JSONSchema/defaults.jsonschema.json
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JSONSchema/defaults.jsonschema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "NestedStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stringVal",
+        "intVal"
+      ],
+      "properties": {
+        "stringVal": {
+          "type": "string"
+        },
+        "intVal": {
+          "type": "integer"
+        }
+      }
+    },
+    "Struct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "allFields",
+        "partialFields",
+        "emptyFields",
+        "complexField",
+        "partialComplexField"
+      ],
+      "properties": {
+        "allFields": {
+          "$ref": "#/definitions/NestedStruct",
+          "default": {
+            "intVal": 3,
+            "stringVal": "hello"
+          }
+        },
+        "partialFields": {
+          "$ref": "#/definitions/NestedStruct",
+          "default": {
+            "intVal": 3
+          }
+        },
+        "emptyFields": {
+          "$ref": "#/definitions/NestedStruct"
+        },
+        "complexField": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "uid",
+            "nested",
+            "array"
+          ],
+          "properties": {
+            "uid": {
+              "type": "string"
+            },
+            "nested": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "nestedVal"
+              ],
+              "properties": {
+                "nestedVal": {
+                  "type": "string"
+                }
+              }
+            },
+            "array": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "array": [
+              "hello"
+            ],
+            "nested": {
+              "nestedVal": "nested"
+            },
+            "uid": "myUID"
+          }
+        },
+        "partialComplexField": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "uid",
+            "intVal"
+          ],
+          "properties": {
+            "uid": {
+              "type": "string"
+            },
+            "intVal": {
+              "type": "integer"
+            }
+          },
+          "default": {
+            "xxxx": "myUID"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/OpenAPI/defaults.openapi.json
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/OpenAPI/defaults.openapi.json
@@ -1,0 +1,119 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "defaults",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "NestedStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "stringVal",
+          "intVal"
+        ],
+        "properties": {
+          "stringVal": {
+            "type": "string"
+          },
+          "intVal": {
+            "type": "integer"
+          }
+        }
+      },
+      "Struct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "allFields",
+          "partialFields",
+          "emptyFields",
+          "complexField",
+          "partialComplexField"
+        ],
+        "properties": {
+          "allFields": {
+            "$ref": "#/components/schemas/NestedStruct",
+            "default": {
+              "intVal": 3,
+              "stringVal": "hello"
+            }
+          },
+          "partialFields": {
+            "$ref": "#/components/schemas/NestedStruct",
+            "default": {
+              "intVal": 3
+            }
+          },
+          "emptyFields": {
+            "$ref": "#/components/schemas/NestedStruct"
+          },
+          "complexField": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "uid",
+              "nested",
+              "array"
+            ],
+            "properties": {
+              "uid": {
+                "type": "string"
+              },
+              "nested": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "nestedVal"
+                ],
+                "properties": {
+                  "nestedVal": {
+                    "type": "string"
+                  }
+                }
+              },
+              "array": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "default": {
+              "array": [
+                "hello"
+              ],
+              "nested": {
+                "nestedVal": "nested"
+              },
+              "uid": "myUID"
+            }
+          },
+          "partialComplexField": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "uid",
+              "intVal"
+            ],
+            "properties": {
+              "uid": {
+                "type": "string"
+              },
+              "intVal": {
+                "type": "integer"
+              }
+            },
+            "default": {
+              "xxxx": "myUID"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/intersections/JSONSchema/intersections.jsonschema.json
+++ b/testdata/jennies/rawtypes/intersections/JSONSchema/intersections.jsonschema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Intersections",
+  "definitions": {
+    "Intersections": {},
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fieldBool"
+      ],
+      "properties": {
+        "fieldBool": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/intersections/OpenAPI/intersections.openapi.json
+++ b/testdata/jennies/rawtypes/intersections/OpenAPI/intersections.openapi.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "intersections",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Intersections": {},
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "fieldBool"
+        ],
+        "properties": {
+          "fieldBool": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/maps/JSONSchema/maps.jsonschema.json
+++ b/testdata/jennies/rawtypes/maps/JSONSchema/maps.jsonschema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MapOfStringToAny": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "description": "String to... something."
+    },
+    "MapOfStringToString": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "MapOfStringToRef": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SomeStruct"
+      }
+    },
+    "MapOfStringToMapOfStringToBool": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/maps/OpenAPI/maps.openapi.json
+++ b/testdata/jennies/rawtypes/maps/OpenAPI/maps.openapi.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "maps",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "MapOfStringToAny": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "description": "String to... something."
+      },
+      "MapOfStringToString": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "MapOfStringToRef": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/SomeStruct"
+        }
+      },
+      "MapOfStringToMapOfStringToBool": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/JSONSchema/with-dashes.jsonschema.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/JSONSchema/with-dashes.jsonschema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "someStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "RefreshRate": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ],
+      "description": "Refresh rate or disabled."
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/OpenAPI/with-dashes.openapi.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/OpenAPI/with-dashes.openapi.json
@@ -1,0 +1,38 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "with-dashes",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "someStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "RefreshRate": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          }
+        ],
+        "description": "Refresh rate or disabled."
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/refs/JSONSchema/refs.jsonschema.json
+++ b/testdata/jennies/rawtypes/refs/JSONSchema/refs.jsonschema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    },
+    "RefToSomeStruct": {
+      "$ref": "#/definitions/SomeStruct"
+    },
+    "RefToSomeStructFromOtherPackage": {
+      "$ref": "#/definitions/SomeDistantStruct"
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/refs/OpenAPI/refs.openapi.json
+++ b/testdata/jennies/rawtypes/refs/OpenAPI/refs.openapi.json
@@ -1,0 +1,33 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "refs",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "RefToSomeStruct": {
+        "$ref": "#/components/schemas/SomeStruct"
+      },
+      "RefToSomeStructFromOtherPackage": {
+        "$ref": "#/components/schemas/SomeDistantStruct"
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/scalars/JSONSchema/scalars.jsonschema.json
+++ b/testdata/jennies/rawtypes/scalars/JSONSchema/scalars.jsonschema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "constTypeString": {
+      "type": "string",
+      "const": "foo"
+    },
+    "scalarTypeAny": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "ScalarTypeBool": {
+      "type": "boolean"
+    },
+    "ScalarTypeBytes": {
+      "type": "string"
+    },
+    "ScalarTypeString": {
+      "type": "string"
+    },
+    "ScalarTypeFloat32": {
+      "type": "number"
+    },
+    "ScalarTypeFloat64": {
+      "type": "number"
+    },
+    "ScalarTypeUint8": {
+      "type": "integer"
+    },
+    "ScalarTypeUint16": {
+      "type": "integer"
+    },
+    "ScalarTypeUint32": {
+      "type": "integer"
+    },
+    "ScalarTypeUint64": {
+      "type": "integer"
+    },
+    "ScalarTypeInt8": {
+      "type": "integer"
+    },
+    "ScalarTypeInt16": {
+      "type": "integer"
+    },
+    "ScalarTypeInt32": {
+      "type": "integer"
+    },
+    "ScalarTypeInt64": {
+      "type": "integer"
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/scalars/OpenAPI/scalars.openapi.json
+++ b/testdata/jennies/rawtypes/scalars/OpenAPI/scalars.openapi.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "scalars",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "constTypeString": {
+        "type": "string",
+        "const": "foo"
+      },
+      "scalarTypeAny": {
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ScalarTypeBool": {
+        "type": "boolean"
+      },
+      "ScalarTypeBytes": {
+        "type": "string"
+      },
+      "ScalarTypeString": {
+        "type": "string"
+      },
+      "ScalarTypeFloat32": {
+        "type": "number"
+      },
+      "ScalarTypeFloat64": {
+        "type": "number"
+      },
+      "ScalarTypeUint8": {
+        "type": "integer"
+      },
+      "ScalarTypeUint16": {
+        "type": "integer"
+      },
+      "ScalarTypeUint32": {
+        "type": "integer"
+      },
+      "ScalarTypeUint64": {
+        "type": "integer"
+      },
+      "ScalarTypeInt8": {
+        "type": "integer"
+      },
+      "ScalarTypeInt16": {
+        "type": "integer"
+      },
+      "ScalarTypeInt32": {
+        "type": "integer"
+      },
+      "ScalarTypeInt64": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldRef",
+        "FieldDisjunctionOfScalars",
+        "FieldMixedDisjunction",
+        "FieldDisjunctionWithNull",
+        "Operator",
+        "FieldArrayOfStrings",
+        "FieldMapOfStringToString",
+        "FieldAnonymousStruct",
+        "fieldRefToConstant"
+      ],
+      "properties": {
+        "FieldRef": {
+          "$ref": "#/definitions/SomeOtherStruct"
+        },
+        "FieldDisjunctionOfScalars": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "FieldMixedDisjunction": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/SomeOtherStruct"
+            }
+          ]
+        },
+        "FieldDisjunctionWithNull": {
+          "type": "string",
+          "description": "Modified by compiler pass 'DisjunctionWithNullToOptional[String|null → String?]'"
+        },
+        "Operator": {
+          "enum": [
+            "\u003e",
+            "\u003c"
+          ]
+        },
+        "FieldArrayOfStrings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FieldMapOfStringToString": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "FieldAnonymousStruct": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "FieldAny"
+          ],
+          "properties": {
+            "FieldAny": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          }
+        },
+        "fieldRefToConstant": {
+          "$ref": "#/definitions/ConnectionPath"
+        }
+      },
+      "description": "This struct does things."
+    },
+    "ConnectionPath": {
+      "type": "string",
+      "const": "straight"
+    },
+    "SomeOtherStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
@@ -1,0 +1,110 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "struct_complex_fields",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldRef",
+          "FieldDisjunctionOfScalars",
+          "FieldMixedDisjunction",
+          "FieldDisjunctionWithNull",
+          "Operator",
+          "FieldArrayOfStrings",
+          "FieldMapOfStringToString",
+          "FieldAnonymousStruct",
+          "fieldRefToConstant"
+        ],
+        "properties": {
+          "FieldRef": {
+            "$ref": "#/components/schemas/SomeOtherStruct"
+          },
+          "FieldDisjunctionOfScalars": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "FieldMixedDisjunction": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/SomeOtherStruct"
+              }
+            ]
+          },
+          "FieldDisjunctionWithNull": {
+            "type": "string",
+            "description": "Modified by compiler pass 'DisjunctionWithNullToOptional[String|null → String?]'"
+          },
+          "Operator": {
+            "enum": [
+              "\u003e",
+              "\u003c"
+            ]
+          },
+          "FieldArrayOfStrings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "FieldMapOfStringToString": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "FieldAnonymousStruct": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "FieldAny"
+            ],
+            "properties": {
+              "FieldAny": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          },
+          "fieldRefToConstant": {
+            "$ref": "#/components/schemas/ConnectionPath"
+          }
+        },
+        "description": "This struct does things."
+      },
+      "ConnectionPath": {
+        "type": "string",
+        "const": "straight"
+      },
+      "SomeOtherStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_defaults/JSONSchema/defaults.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_defaults/JSONSchema/defaults.jsonschema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fieldBool",
+        "fieldString",
+        "FieldStringWithConstantValue",
+        "FieldFloat32",
+        "FieldInt32"
+      ],
+      "properties": {
+        "fieldBool": {
+          "type": "boolean",
+          "default": true
+        },
+        "fieldString": {
+          "type": "string",
+          "default": "foo"
+        },
+        "FieldStringWithConstantValue": {
+          "type": "string",
+          "const": "auto"
+        },
+        "FieldFloat32": {
+          "type": "number",
+          "default": 42.42
+        },
+        "FieldInt32": {
+          "type": "integer",
+          "default": 42
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_defaults/OpenAPI/defaults.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_defaults/OpenAPI/defaults.openapi.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "defaults",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "fieldBool",
+          "fieldString",
+          "FieldStringWithConstantValue",
+          "FieldFloat32",
+          "FieldInt32"
+        ],
+        "properties": {
+          "fieldBool": {
+            "type": "boolean",
+            "default": true
+          },
+          "fieldString": {
+            "type": "string",
+            "default": "foo"
+          },
+          "FieldStringWithConstantValue": {
+            "type": "string",
+            "const": "auto"
+          },
+          "FieldFloat32": {
+            "type": "number",
+            "default": 42.42
+          },
+          "FieldInt32": {
+            "type": "integer",
+            "default": 42
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JSONSchema/struct_optional_fields.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JSONSchema/struct_optional_fields.jsonschema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "FieldRef": {
+          "$ref": "#/definitions/SomeOtherStruct"
+        },
+        "FieldString": {
+          "type": "string"
+        },
+        "Operator": {
+          "enum": [
+            "\u003e",
+            "\u003c"
+          ]
+        },
+        "FieldArrayOfStrings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "FieldAnonymousStruct": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "FieldAny"
+          ],
+          "properties": {
+            "FieldAny": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          }
+        }
+      }
+    },
+    "SomeOtherStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {}
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/OpenAPI/struct_optional_fields.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/OpenAPI/struct_optional_fields.openapi.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "struct_optional_fields",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "FieldRef": {
+            "$ref": "#/components/schemas/SomeOtherStruct"
+          },
+          "FieldString": {
+            "type": "string"
+          },
+          "Operator": {
+            "enum": [
+              "\u003e",
+              "\u003c"
+            ]
+          },
+          "FieldArrayOfStrings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "FieldAnonymousStruct": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "FieldAny"
+            ],
+            "properties": {
+              "FieldAny": {
+                "type": "object",
+                "additionalProperties": {}
+              }
+            }
+          }
+        }
+      },
+      "SomeOtherStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/JSONSchema/basic.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/JSONSchema/basic.jsonschema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "FieldAny",
+        "FieldBool",
+        "FieldBytes",
+        "FieldString",
+        "FieldStringWithConstantValue",
+        "FieldFloat32",
+        "FieldFloat64",
+        "FieldUint8",
+        "FieldUint16",
+        "FieldUint32",
+        "FieldUint64",
+        "FieldInt8",
+        "FieldInt16",
+        "FieldInt32",
+        "FieldInt64"
+      ],
+      "properties": {
+        "FieldAny": {
+          "type": "object",
+          "additionalProperties": {},
+          "description": "Anything can go in there.\nReally, anything."
+        },
+        "FieldBool": {
+          "type": "boolean"
+        },
+        "FieldBytes": {
+          "type": "string"
+        },
+        "FieldString": {
+          "type": "string"
+        },
+        "FieldStringWithConstantValue": {
+          "type": "string",
+          "const": "auto"
+        },
+        "FieldFloat32": {
+          "type": "number"
+        },
+        "FieldFloat64": {
+          "type": "number"
+        },
+        "FieldUint8": {
+          "type": "integer"
+        },
+        "FieldUint16": {
+          "type": "integer"
+        },
+        "FieldUint32": {
+          "type": "integer"
+        },
+        "FieldUint64": {
+          "type": "integer"
+        },
+        "FieldInt8": {
+          "type": "integer"
+        },
+        "FieldInt16": {
+          "type": "integer"
+        },
+        "FieldInt32": {
+          "type": "integer"
+        },
+        "FieldInt64": {
+          "type": "integer"
+        }
+      },
+      "description": "This\nis\na\ncomment"
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/OpenAPI/basic.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/OpenAPI/basic.openapi.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basic",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "FieldAny",
+          "FieldBool",
+          "FieldBytes",
+          "FieldString",
+          "FieldStringWithConstantValue",
+          "FieldFloat32",
+          "FieldFloat64",
+          "FieldUint8",
+          "FieldUint16",
+          "FieldUint32",
+          "FieldUint64",
+          "FieldInt8",
+          "FieldInt16",
+          "FieldInt32",
+          "FieldInt64"
+        ],
+        "properties": {
+          "FieldAny": {
+            "type": "object",
+            "additionalProperties": {},
+            "description": "Anything can go in there.\nReally, anything."
+          },
+          "FieldBool": {
+            "type": "boolean"
+          },
+          "FieldBytes": {
+            "type": "string"
+          },
+          "FieldString": {
+            "type": "string"
+          },
+          "FieldStringWithConstantValue": {
+            "type": "string",
+            "const": "auto"
+          },
+          "FieldFloat32": {
+            "type": "number"
+          },
+          "FieldFloat64": {
+            "type": "number"
+          },
+          "FieldUint8": {
+            "type": "integer"
+          },
+          "FieldUint16": {
+            "type": "integer"
+          },
+          "FieldUint32": {
+            "type": "integer"
+          },
+          "FieldUint64": {
+            "type": "integer"
+          },
+          "FieldInt8": {
+            "type": "integer"
+          },
+          "FieldInt16": {
+            "type": "integer"
+          },
+          "FieldInt32": {
+            "type": "integer"
+          },
+          "FieldInt64": {
+            "type": "integer"
+          }
+        },
+        "description": "This\nis\na\ncomment"
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_dataquery/JSONSchema/variant_dataquery.jsonschema.json
+++ b/testdata/jennies/rawtypes/variant_dataquery/JSONSchema/variant_dataquery.jsonschema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Query": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expr"
+      ],
+      "properties": {
+        "expr": {
+          "type": "string"
+        },
+        "instant": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_dataquery/OpenAPI/variant_dataquery.openapi.json
+++ b/testdata/jennies/rawtypes/variant_dataquery/OpenAPI/variant_dataquery.openapi.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "variant_dataquery",
+    "version": "0.0.0",
+    "x-schema-identifier": "prometheus",
+    "x-schema-kind": "composable",
+    "x-schema-variant": "dataquery"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Query": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "expr"
+        ],
+        "properties": {
+          "expr": {
+            "type": "string"
+          },
+          "instant": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JSONSchema/variant_panelcfg_full.jsonschema.json
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JSONSchema/variant_panelcfg_full.jsonschema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timeseries_option"
+      ],
+      "properties": {
+        "timeseries_option": {
+          "type": "string"
+        }
+      }
+    },
+    "FieldConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timeseries_field_config_option"
+      ],
+      "properties": {
+        "timeseries_field_config_option": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/OpenAPI/variant_panelcfg_full.openapi.json
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/OpenAPI/variant_panelcfg_full.openapi.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "variant_panelcfg_full",
+    "version": "0.0.0",
+    "x-schema-identifier": "timeseries",
+    "x-schema-kind": "composable",
+    "x-schema-variant": "panelcfg"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Options": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "timeseries_option"
+        ],
+        "properties": {
+          "timeseries_option": {
+            "type": "string"
+          }
+        }
+      },
+      "FieldConfig": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "timeseries_field_config_option"
+        ],
+        "properties": {
+          "timeseries_field_config_option": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/JSONSchema/variant_panelcfg_only_options.jsonschema.json
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/JSONSchema/variant_panelcfg_only_options.jsonschema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "content": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/OpenAPI/variant_panelcfg_only_options.openapi.json
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/OpenAPI/variant_panelcfg_only_options.openapi.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "variant_panelcfg_only_options",
+    "version": "0.0.0",
+    "x-schema-identifier": "text",
+    "x-schema-kind": "composable",
+    "x-schema-variant": "panelcfg"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Options": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jsonschema/allof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/allof_object/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "AllOf",
   "Objects": {
     "AllOf": {
       "Name": "AllOf",

--- a/testdata/jsonschema/anyof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_object/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "AnyOf",
   "Objects": {
     "AnyOf": {
       "Name": "AnyOf",

--- a/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "AnyOfField",
   "Objects": {
     "AnyOfField": {
       "Name": "AnyOfField",

--- a/testdata/jsonschema/array_any/GenerateAST/ir.json
+++ b/testdata/jsonschema/array_any/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/basic_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/basic_object/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/consts/GenerateAST/ir.json
+++ b/testdata/jsonschema/consts/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/defaults/GenerateAST/ir.json
+++ b/testdata/jsonschema/defaults/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/enum/GenerateAST/ir.json
+++ b/testdata/jsonschema/enum/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
+++ b/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "InfluxQuery",
   "Objects": {
     "AdHocVariableFilter": {
       "Name": "AdHocVariableFilter",

--- a/testdata/jsonschema/number_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/number_constraints/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
+++ b/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "Entrypoint",
   "Objects": {
     "Entrypoint": {
       "Name": "Entrypoint",

--- a/testdata/jsonschema/oneof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_object/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "OneOf",
   "Objects": {
     "OneOf": {
       "Name": "OneOf",

--- a/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "OneOfField",
   "Objects": {
     "OneOfField": {
       "Name": "OneOfField",

--- a/testdata/jsonschema/recursive/GenerateAST/ir.json
+++ b/testdata/jsonschema/recursive/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "Node",
   "Objects": {
     "Node": {
       "Name": "Node",

--- a/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "grafanatest",
   "Objects": {
     "grafanatest": {
       "Name": "grafanatest",

--- a/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
@@ -1,6 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPoint": "SomeObject",
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",


### PR DESCRIPTION
Being able to generate JSONSchema/OpenAPI from a mixed set of input schemas could be useful, especially to remove grafonnet's dependency on grok.

ToDo:

* [x] identify schema entrypoint
* [x] properly handle comments + compiler passes trail
* [x] resolve + expand foreign references
* [x] ~~check if this could be useful to replace grok-generated schemas in grafonnet (if so: bye-bye grok 🫡)~~ @Duologic agrees: this could work.
* [x] constraints
* [x] tests!
  * [x] ensure that generated schemas are valid
  * [x] ensure that cog can parse the jsonschemas it generates
  * [x] txtar tests