### PR TITLE
Dirty fix for incorrectly parsed candlestick and heatmap objects

### DIFF
--- a/config/compiler/common_passes.yaml
+++ b/config/compiler/common_passes.yaml
@@ -87,6 +87,42 @@ passes:
   - fields_set_not_required:
       fields: [ common.TableFieldOptions.CellOptions ]
 
+  #####################
+  # candlestick panel #
+  #####################
+
+  # This field is parsed incorrectly from the CUE schema: its definition and
+  # defaults are merged for some reason.
+  # TODO: remove once the parser is fixed.
+  # See: https://github.com/grafana/cog/issues/292
+  - retype_field:
+      field: candlestick.Options.colors
+      as:
+        kind: ref
+        ref: { referred_pkg: candlestick, referred_type: CandlestickColors }
+        default: { down: "red", up: "green", flat: "gray" }
+
+  #################
+  # heatmap panel #
+  #################
+
+  # These fields are parsed incorrectly from the CUE schema: their definitions and
+  # defaults are merged for some reason.
+  # TODO: remove once the parser is fixed.
+  # See: https://github.com/grafana/cog/issues/292
+  - retype_field:
+      field: heatmap.Options.legend
+      as:
+        kind: ref
+        ref: { referred_pkg: heatmap, referred_type: HeatmapLegend }
+        default: { show: true }
+  - retype_field:
+      field: heatmap.Options.exemplars
+      as:
+        kind: ref
+        ref: { referred_pkg: heatmap, referred_type: ExemplarConfig }
+        default: { color: "rgba(255,0,255,0.7)" }
+
   ##########
   # Others #
   ##########

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -752,8 +752,8 @@ func NewStructField(name string, fieldType Type, opts ...StructFieldOption) Stru
 }
 
 type RefType struct {
-	ReferredPkg  string
-	ReferredType string
+	ReferredPkg  string `yaml:"referred_pkg"`
+	ReferredType string `yaml:"referred_type"`
 }
 
 func (t RefType) String() string {


### PR DESCRIPTION
See https://github.com/grafana/cog/issues/292

The fix doesn't appear to be trivial, so in the meantime I use compiler passes to "fix" the IR.