### PR TITLE
Support decoding from JSON in Python

### DIFF
--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -1,3 +1,4 @@
+import json
 from generated.builders.dashboard import (
     Dashboard,
     TimePicker,
@@ -6,6 +7,7 @@ from generated.builders.dashboard import (
     QueryVariable,
 )
 from generated.models.dashboard import (
+    Dashboard as DashboardModel,
     DashboardCursorSync,
     VariableHide,
     VariableOption,
@@ -17,6 +19,7 @@ from generated.models.common import (
     TimeZoneBrowser,
 )
 from generated.cog.encoder import JSONEncoder
+from generated.cog.plugins import register_default_plugins
 from examples.python.raspberry.cpu import cpu_usage_timeseries, cpu_load_average_timeseries, cpu_temperature_gauge
 from examples.python.raspberry.disk import disk_io_timeseries, disk_space_usage_table
 from examples.python.raspberry.logs import errors_in_system_logs, all_system_logs, auth_logs, kernel_logs
@@ -90,6 +93,14 @@ if __name__ == '__main__':
     dashboard = build_dashboard().build()
     encoder = JSONEncoder(sort_keys=True, indent=2)
 
-    print(
-        encoder.encode(dashboard)
+    dashboard_json = encoder.encode(dashboard)
+
+    print(dashboard_json)
+
+    register_default_plugins()
+
+    decoded_dashboard = DashboardModel.from_json(
+        json.loads(dashboard_json)
     )
+
+    print(decoded_dashboard)

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -223,16 +223,13 @@ func (jenny RawTypes) generateFromJSONMethod(context common.Context, object ast.
 			cogruntime := jenny.importModule("cogruntime", "..cog", "runtime")
 			assignment := fmt.Sprintf(`        if "fieldConfig" in data:
             config = %[1]s.panelcfg_config(data.get("type", ""))
+            field_config = FieldConfigSource.from_json(data["fieldConfig"])
 
             if config is not None and config.field_config_from_json_hook is not None:
-                field_config = FieldConfigSource.from_json(data["fieldConfig"])
-
                 custom_field_config = data["fieldConfig"].get("defaults", {}).get("custom", {})
                 field_config.defaults.custom = config.field_config_from_json_hook(custom_field_config)
 
-                args["%[2]s"] = field_config
-            else:
-                args["%[2]s"] = data["fieldConfig"]`, cogruntime, fieldName)
+            args["%[2]s"] = field_config`, cogruntime, fieldName)
 
 			assignments = append(assignments, assignment)
 			continue

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -307,10 +307,11 @@ func (jenny RawTypes) generateDataqueryVariantConfigFunc(schema *ast.Schema, obj
 	objectName := tools.UpperCamelCase(object.Name)
 	identifier := schema.Metadata.Identifier
 
-	// TODO: the `from_json_hook` needs to be generated differently if `object.Type` is a disjunction
+	// The `from_json_hook` needs to be generated differently if `object.Type` is a disjunction
+	// since there is no "from_json" method to call
 	fromJSONHook := fmt.Sprintf("%s.from_json", objectName)
 	if object.Type.IsDisjunction() {
-		fromJSONHook = `lambda x: {}`
+		fromJSONHook = "lambda data: " + jenny.disjunctionFromJSON(object.Type.AsDisjunction(), "data")
 	}
 
 	return fmt.Sprintf(`def variant_config():

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -246,7 +246,7 @@ func (jenny RawTypes) generateFromJSONMethod(context common.Context, object ast.
 
 		if _, ok := context.ResolveToComposableSlot(field.Type); ok {
 			value = jenny.composableSlotFromJSON(context, object.Type.AsStruct(), field)
-		} else if field.Type.IsRef() {
+		} else if field.Type.IsRef() { //nolint:gocritic
 			ref := field.Type.AsRef()
 			referredObject, found := context.LocateObject(ref.ReferredPkg, ref.ReferredType)
 			if found && referredObject.Type.IsStruct() {

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -342,7 +342,7 @@ func (jenny RawTypes) disjunctionFromJSON(disjunction ast.DisjunctionType, input
 	}
 
 	decodingMap = strings.TrimSuffix(decodingMap, ", ")
-	decodingMap += fmt.Sprintf(`}.get("%s"%s)).from_json(%s)`, disjunction.Discriminator, defaultBranch, inputVar)
+	decodingMap += fmt.Sprintf(`}.get(%[3]s["%[1]s"]%[2]s)).from_json(%[3]s)`, disjunction.Discriminator, defaultBranch, inputVar)
 
 	return decodingMap
 }

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -73,7 +73,7 @@ func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema)
 			buffer.WriteString(jenny.generateInitMethod(context.Schemas, object))
 
 			buffer.WriteString("\n\n")
-			buffer.WriteString(jenny.generateToJSONMethod(context, object))
+			buffer.WriteString(jenny.generateToJSONMethod(object))
 
 			buffer.WriteString("\n\n")
 			buffer.WriteString(jenny.generateFromJSONMethod(context, object))
@@ -147,7 +147,7 @@ func (jenny RawTypes) generateInitMethod(schemas ast.Schemas, object ast.Object)
 	return strings.TrimSuffix(buffer.String(), "\n")
 }
 
-func (jenny RawTypes) generateToJSONMethod(context common.Context, object ast.Object) string {
+func (jenny RawTypes) generateToJSONMethod(object ast.Object) string {
 	var buffer strings.Builder
 
 	buffer.WriteString("    def to_json(self) -> dict[str, object]:\n")

--- a/internal/jennies/python/runtime.go
+++ b/internal/jennies/python/runtime.go
@@ -1,7 +1,10 @@
 package python
 
 import (
+	"sort"
+
 	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 )
 
@@ -12,7 +15,7 @@ func (jenny Runtime) JennyName() string {
 	return "PythonRuntime"
 }
 
-func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny Runtime) Generate(context common.Context) (codejen.Files, error) {
 	builder, err := renderTemplate("runtime/builder.tmpl", map[string]any{})
 	if err != nil {
 		return nil, err
@@ -33,10 +36,56 @@ func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
 		return nil, err
 	}
 
+	plugins, err := jenny.variantPlugins(context)
+	if err != nil {
+		return nil, err
+	}
+
 	return codejen.Files{
 		*codejen.NewFile("cog/builder.py", []byte(builder), jenny),
 		*codejen.NewFile("cog/encoder.py", []byte(encoder), jenny),
 		*codejen.NewFile("cog/variants.py", []byte(models), jenny),
 		*codejen.NewFile("cog/runtime.py", []byte(runtime), jenny),
+		*codejen.NewFile("cog/plugins.py", []byte(plugins), jenny),
 	}, nil
+}
+
+func (jenny Runtime) variantPlugins(context common.Context) (string, error) {
+	imports := NewImportMap()
+	var panelSchemas []string
+	var dataquerySchemas []string
+
+	for _, schema := range context.Schemas {
+		if schema.Metadata.Kind != ast.SchemaKindComposable || schema.Metadata.Identifier == "" {
+			continue
+		}
+
+		importAlias := imports.AddModule(schema.Package, "..models", schema.Package)
+
+		if schema.Metadata.Variant == ast.SchemaVariantPanel {
+			panelSchemas = append(panelSchemas, importAlias)
+		} else if schema.Metadata.Variant == ast.SchemaVariantDataQuery {
+			dataquerySchemas = append(dataquerySchemas, importAlias)
+		}
+	}
+
+	// to guarantee a consistent output for this jenny
+	sort.Strings(panelSchemas)
+	sort.Strings(dataquerySchemas)
+
+	rendered, err := renderTemplate("runtime/plugins.tmpl", map[string]any{
+		"panel_schemas":     panelSchemas,
+		"dataquery_schemas": dataquerySchemas,
+		"imports":           imports,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	importStatements := imports.String()
+	if importStatements != "" {
+		importStatements += "\n"
+	}
+
+	return importStatements + rendered, nil
 }

--- a/internal/jennies/python/runtime.go
+++ b/internal/jennies/python/runtime.go
@@ -28,9 +28,15 @@ func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
 		return nil, err
 	}
 
+	runtime, err := renderTemplate("runtime/runtime.tmpl", map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+
 	return codejen.Files{
 		*codejen.NewFile("cog/builder.py", []byte(builder), jenny),
 		*codejen.NewFile("cog/encoder.py", []byte(encoder), jenny),
 		*codejen.NewFile("cog/variants.py", []byte(models), jenny),
+		*codejen.NewFile("cog/runtime.py", []byte(runtime), jenny),
 	}, nil
 }

--- a/internal/jennies/python/templates/runtime/plugins.tmpl
+++ b/internal/jennies/python/templates/runtime/plugins.tmpl
@@ -4,7 +4,7 @@ from . import runtime as cogruntime
 def register_default_plugins():
     # Panelcfg variants
 {{- range $pkg := .panel_schemas }}
-    #cogruntime.register_panelcfg_variant({{ $pkg }}.variant_config())
+    cogruntime.register_panelcfg_variant({{ $pkg }}.variant_config())
 {{- end }}
 
     # Dataquery variants

--- a/internal/jennies/python/templates/runtime/plugins.tmpl
+++ b/internal/jennies/python/templates/runtime/plugins.tmpl
@@ -1,0 +1,13 @@
+from . import runtime as cogruntime
+
+
+def register_default_plugins():
+    # Panelcfg variants
+{{- range $pkg := .panel_schemas }}
+    #cogruntime.register_panelcfg_variant({{ $pkg }}.variant_config())
+{{- end }}
+
+    # Dataquery variants
+{{- range $pkg := .dataquery_schemas }}
+    cogruntime.register_dataquery_variant({{ $pkg }}.variant_config())
+{{- end }}

--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -4,11 +4,24 @@ from . import variants as cogvariants
 
 class Runtime:
     _instance = None
+    dataquery_variants: dict[str, typing.Type[cogvariants.Dataquery]]
 
     def __new__(cls, *args, **kwargs):
-        if not isinstance(cls._instance, cls):
+        if cls._instance is None:
             cls._instance = object.__new__(cls, *args, **kwargs)
+            cls.dataquery_variants = {}
+
         return cls._instance
+
+    def register_dataquery_variant(self, identifier: str, variant_cls: typing.Type[cogvariants.Dataquery]):
+        self.dataquery_variants[identifier] = variant_cls
+
+    def dataquery_from_json(self, data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
+        if dataquery_type_hint != "" and dataquery_type_hint in self.dataquery_variants:
+            return self.dataquery_variants[dataquery_type_hint].from_json(data)
+
+        # We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
+        return UnknownDataquery(data)
 
 
 class UnknownDataquery(cogvariants.Dataquery):
@@ -20,7 +33,14 @@ class UnknownDataquery(cogvariants.Dataquery):
     def to_json(self) -> dict[str, object]:
         return self.data
 
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        return cls(data)
+
 
 def dataquery_from_json(data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
-    # We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
-    return UnknownDataquery(data)
+    return Runtime().dataquery_from_json(data, dataquery_type_hint)
+
+
+def register_dataquery_variant(identifier: str, variant_cls: typing.Type[cogvariants.Dataquery]):
+    Runtime().register_dataquery_variant(identifier, variant_cls)

--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -1,0 +1,26 @@
+import typing
+from . import variants as cogvariants
+
+
+class Runtime:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not isinstance(cls._instance, cls):
+            cls._instance = object.__new__(cls, *args, **kwargs)
+        return cls._instance
+
+
+class UnknownDataquery(cogvariants.Dataquery):
+    data: dict[str, typing.Any]
+
+    def __init__(self, data: dict[str, typing.Any]):
+        self.data = data
+
+    def to_json(self) -> dict[str, object]:
+        return self.data
+
+
+def dataquery_from_json(data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
+    # We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
+    return UnknownDataquery(data)

--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -1,10 +1,17 @@
 import typing
+from dataclasses import dataclass
 from . import variants as cogvariants
+
+
+@dataclass
+class DataqueryConfig:
+    identifier: str
+    from_json_hook: typing.Callable[[dict[str, typing.Any]], cogvariants.Dataquery]
 
 
 class Runtime:
     _instance = None
-    dataquery_variants: dict[str, typing.Type[cogvariants.Dataquery]]
+    dataquery_variants: dict[str, DataqueryConfig]
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -13,12 +20,12 @@ class Runtime:
 
         return cls._instance
 
-    def register_dataquery_variant(self, identifier: str, variant_cls: typing.Type[cogvariants.Dataquery]):
-        self.dataquery_variants[identifier] = variant_cls
+    def register_dataquery_variant(self, variant: DataqueryConfig):
+        self.dataquery_variants[variant.identifier] = variant
 
     def dataquery_from_json(self, data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
         if dataquery_type_hint != "" and dataquery_type_hint in self.dataquery_variants:
-            return self.dataquery_variants[dataquery_type_hint].from_json(data)
+            return self.dataquery_variants[dataquery_type_hint].from_json_hook(data)
 
         # We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
         return UnknownDataquery(data)
@@ -42,5 +49,5 @@ def dataquery_from_json(data: dict[str, typing.Any], dataquery_type_hint: str) -
     return Runtime().dataquery_from_json(data, dataquery_type_hint)
 
 
-def register_dataquery_variant(identifier: str, variant_cls: typing.Type[cogvariants.Dataquery]):
-    Runtime().register_dataquery_variant(identifier, variant_cls)
+def register_dataquery_variant(variant: DataqueryConfig):
+    Runtime().register_dataquery_variant(variant)

--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -1,29 +1,41 @@
-import typing
 from dataclasses import dataclass
+from typing import Any, Callable, Optional, Self
 from . import variants as cogvariants
 
 
 @dataclass
 class DataqueryConfig:
     identifier: str
-    from_json_hook: typing.Callable[[dict[str, typing.Any]], cogvariants.Dataquery]
+    from_json_hook: Callable[[dict[str, Any]], cogvariants.Dataquery]
+
+
+@dataclass
+class PanelCfgConfig:
+    identifier: str
+    options_from_json_hook: Optional[Callable[[dict[str, Any]], Any]] = None
+    field_config_from_json_hook: Optional[Callable[[dict[str, Any]], Any]] = None
 
 
 class Runtime:
     _instance = None
     dataquery_variants: dict[str, DataqueryConfig]
+    panelcfg_variants: dict[str, PanelCfgConfig]
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = object.__new__(cls, *args, **kwargs)
             cls.dataquery_variants = {}
+            cls.panelcfg_variants = {}
 
         return cls._instance
 
     def register_dataquery_variant(self, variant: DataqueryConfig):
         self.dataquery_variants[variant.identifier] = variant
 
-    def dataquery_from_json(self, data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
+    def register_panelcfg_variant(self, variant: PanelCfgConfig):
+        self.panelcfg_variants[variant.identifier] = variant
+
+    def dataquery_from_json(self, data: dict[str, Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
         if dataquery_type_hint != "" and dataquery_type_hint in self.dataquery_variants:
             return self.dataquery_variants[dataquery_type_hint].from_json_hook(data)
 
@@ -32,21 +44,25 @@ class Runtime:
 
 
 class UnknownDataquery(cogvariants.Dataquery):
-    data: dict[str, typing.Any]
+    data: dict[str, Any]
 
-    def __init__(self, data: dict[str, typing.Any]):
+    def __init__(self, data: dict[str, Any]):
         self.data = data
 
     def to_json(self) -> dict[str, object]:
         return self.data
 
     @classmethod
-    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+    def from_json(cls, data: dict[str, Any]) -> Self:
         return cls(data)
 
 
-def dataquery_from_json(data: dict[str, typing.Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
+def dataquery_from_json(data: dict[str, Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
     return Runtime().dataquery_from_json(data, dataquery_type_hint)
+
+
+def register_panelcfg_variant(variant: PanelCfgConfig):
+    Runtime().register_panelcfg_variant(variant)
 
 
 def register_dataquery_variant(variant: DataqueryConfig):

--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -42,6 +42,9 @@ class Runtime:
         # We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
         return UnknownDataquery(data)
 
+    def panelcfg_config(self, variant: str) -> Optional[PanelCfgConfig]:
+        return self.panelcfg_variants.get(variant, None)
+
 
 class UnknownDataquery(cogvariants.Dataquery):
     data: dict[str, Any]
@@ -59,6 +62,10 @@ class UnknownDataquery(cogvariants.Dataquery):
 
 def dataquery_from_json(data: dict[str, Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
     return Runtime().dataquery_from_json(data, dataquery_type_hint)
+
+
+def panelcfg_config(variant: str) -> Optional[PanelCfgConfig]:
+    return Runtime().panelcfg_config(variant)
 
 
 def register_panelcfg_variant(variant: PanelCfgConfig):

--- a/internal/jennies/python/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/python/templates/runtime/variant_models.tmpl
@@ -1,9 +1,5 @@
-import typing
-from abc import ABC, abstractmethod
+from abc import ABC
 
 
 class Dataquery(ABC):
-    @classmethod
-    @abstractmethod
-    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        ...
+    ...

--- a/internal/jennies/python/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/python/templates/runtime/variant_models.tmpl
@@ -1,5 +1,9 @@
-from abc import ABC
+import typing
+from abc import ABC, abstractmethod
 
- 
+
 class Dataquery(ABC):
-    pass
+    @classmethod
+    @abstractmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        ...

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -160,7 +160,7 @@ func (formatter *typeFormatter) formatStruct(def ast.Object) string {
 	var buffer strings.Builder
 
 	classBases := ""
-	if def.Type.Kind == ast.KindStruct && def.Type.ImplementsVariant() {
+	if def.Type.IsStruct() && def.Type.ImplementsVariant() {
 		cogVariants := formatter.importModule("cogvariants", "..cog", "variants")
 		variant := tools.UpperCamelCase(def.Type.ImplementedVariant())
 

--- a/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
+++ b/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
@@ -19,7 +19,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
+++ b/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
@@ -19,9 +19,11 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
+++ b/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
@@ -25,7 +25,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)
@@ -51,7 +51,7 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "foo": data["Foo"],
         }
         return cls(**args)
@@ -74,7 +74,7 @@ class YetAnotherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "bar": data["Bar"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
+++ b/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
@@ -25,9 +25,11 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 
@@ -51,9 +53,11 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "foo": data["Foo"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "Foo" in data:
+            args["foo"] = data["Foo"]        
+
         return cls(**args)
 
 
@@ -74,9 +78,11 @@ class YetAnotherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "bar": data["Bar"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "Bar" in data:
+            args["bar"] = data["Bar"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -18,10 +18,13 @@ class NestedStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "string_val": data["stringVal"],
-            "int_val": data["intVal"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "stringVal" in data:
+            args["string_val"] = data["stringVal"]
+        if "intVal" in data:
+            args["int_val"] = data["intVal"]        
+
         return cls(**args)
 
 
@@ -51,13 +54,19 @@ class Struct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "all_fields": NestedStruct.from_json(data["allFields"]),
-            "partial_fields": NestedStruct.from_json(data["partialFields"]),
-            "empty_fields": NestedStruct.from_json(data["emptyFields"]),
-            "complex_field": DefaultsStructComplexField.from_json(data["complexField"]),
-            "partial_complex_field": DefaultsStructPartialComplexField.from_json(data["partialComplexField"]),
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "allFields" in data:
+            args["all_fields"] = NestedStruct.from_json(data["allFields"])
+        if "partialFields" in data:
+            args["partial_fields"] = NestedStruct.from_json(data["partialFields"])
+        if "emptyFields" in data:
+            args["empty_fields"] = NestedStruct.from_json(data["emptyFields"])
+        if "complexField" in data:
+            args["complex_field"] = DefaultsStructComplexField.from_json(data["complexField"])
+        if "partialComplexField" in data:
+            args["partial_complex_field"] = DefaultsStructPartialComplexField.from_json(data["partialComplexField"])        
+
         return cls(**args)
 
 
@@ -75,9 +84,11 @@ class DefaultsStructComplexFieldNested:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "nested_val": data["nestedVal"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "nestedVal" in data:
+            args["nested_val"] = data["nestedVal"]        
+
         return cls(**args)
 
 
@@ -101,11 +112,15 @@ class DefaultsStructComplexField:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "uid": data["uid"],
-            "nested": DefaultsStructComplexFieldNested.from_json(data["nested"]),
-            "array": data["array"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "uid" in data:
+            args["uid"] = data["uid"]
+        if "nested" in data:
+            args["nested"] = DefaultsStructComplexFieldNested.from_json(data["nested"])
+        if "array" in data:
+            args["array"] = data["array"]        
+
         return cls(**args)
 
 
@@ -126,10 +141,13 @@ class DefaultsStructPartialComplexField:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "uid": data["uid"],
-            "int_val": data["intVal"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "uid" in data:
+            args["uid"] = data["uid"]
+        if "intVal" in data:
+            args["int_val"] = data["intVal"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -18,7 +18,7 @@ class NestedStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "string_val": data["stringVal"],
             "int_val": data["intVal"],
         }
@@ -51,7 +51,7 @@ class Struct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "all_fields": NestedStruct.from_json(data["allFields"]),
             "partial_fields": NestedStruct.from_json(data["partialFields"]),
             "empty_fields": NestedStruct.from_json(data["emptyFields"]),
@@ -75,7 +75,7 @@ class DefaultsStructComplexFieldNested:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "nested_val": data["nestedVal"],
         }
         return cls(**args)
@@ -101,7 +101,7 @@ class DefaultsStructComplexField:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "uid": data["uid"],
             "nested": DefaultsStructComplexFieldNested.from_json(data["nested"]),
             "array": data["array"],
@@ -126,7 +126,7 @@ class DefaultsStructPartialComplexField:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "uid": data["uid"],
             "int_val": data["intVal"],
         }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -41,11 +41,11 @@ class Struct:
 
     def to_json(self) -> dict[str, object]:
         payload: dict[str, object] = {
-            "allFields": None if self.all_fields is None else self.all_fields.to_json(),
-            "partialFields": None if self.partial_fields is None else self.partial_fields.to_json(),
-            "emptyFields": None if self.empty_fields is None else self.empty_fields.to_json(),
-            "complexField": None if self.complex_field is None else self.complex_field.to_json(),
-            "partialComplexField": None if self.partial_complex_field is None else self.partial_complex_field.to_json(),
+            "allFields": self.all_fields,
+            "partialFields": self.partial_fields,
+            "emptyFields": self.empty_fields,
+            "complexField": self.complex_field,
+            "partialComplexField": self.partial_complex_field,
         }
         return payload
 
@@ -94,7 +94,7 @@ class DefaultsStructComplexField:
     def to_json(self) -> dict[str, object]:
         payload: dict[str, object] = {
             "uid": self.uid,
-            "nested": None if self.nested is None else self.nested.to_json(),
+            "nested": self.nested,
             "array": self.array,
         }
         return payload

--- a/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
+++ b/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
@@ -22,7 +22,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
+++ b/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
@@ -22,9 +22,11 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
+++ b/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
@@ -15,9 +15,11 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
+++ b/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
@@ -15,7 +15,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
+++ b/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
@@ -16,9 +16,11 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
+++ b/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
@@ -16,7 +16,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -43,7 +43,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_ref": SomeOtherStruct.from_json(data["FieldRef"]),
             "field_disjunction_of_scalars": data["FieldDisjunctionOfScalars"],
             "field_mixed_disjunction": data["FieldMixedDisjunction"],
@@ -74,7 +74,7 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)
@@ -94,7 +94,7 @@ class StructComplexFieldsSomeStructFieldAnonymousStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -29,14 +29,14 @@ class SomeStruct:
 
     def to_json(self) -> dict[str, object]:
         payload: dict[str, object] = {
-            "FieldRef": None if self.field_ref is None else self.field_ref.to_json(),
+            "FieldRef": self.field_ref,
             "FieldDisjunctionOfScalars": self.field_disjunction_of_scalars,
             "FieldMixedDisjunction": self.field_mixed_disjunction,
             "FieldDisjunctionWithNull": self.field_disjunction_with_null,
             "Operator": self.operator,
             "FieldArrayOfStrings": self.field_array_of_strings,
             "FieldMapOfStringToString": self.field_map_of_string_to_string,
-            "FieldAnonymousStruct": None if self.field_anonymous_struct is None else self.field_anonymous_struct.to_json(),
+            "FieldAnonymousStruct": self.field_anonymous_struct,
             "fieldRefToConstant": self.field_ref_to_constant,
         }
         return payload

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -43,17 +43,27 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_ref": SomeOtherStruct.from_json(data["FieldRef"]),
-            "field_disjunction_of_scalars": data["FieldDisjunctionOfScalars"],
-            "field_mixed_disjunction": data["FieldMixedDisjunction"],
-            "field_disjunction_with_null": data["FieldDisjunctionWithNull"],
-            "operator": data["Operator"],
-            "field_array_of_strings": data["FieldArrayOfStrings"],
-            "field_map_of_string_to_string": data["FieldMapOfStringToString"],
-            "field_anonymous_struct": StructComplexFieldsSomeStructFieldAnonymousStruct.from_json(data["FieldAnonymousStruct"]),
-            "field_ref_to_constant": data["fieldRefToConstant"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldRef" in data:
+            args["field_ref"] = SomeOtherStruct.from_json(data["FieldRef"])
+        if "FieldDisjunctionOfScalars" in data:
+            args["field_disjunction_of_scalars"] = data["FieldDisjunctionOfScalars"]
+        if "FieldMixedDisjunction" in data:
+            args["field_mixed_disjunction"] = data["FieldMixedDisjunction"]
+        if "FieldDisjunctionWithNull" in data:
+            args["field_disjunction_with_null"] = data["FieldDisjunctionWithNull"]
+        if "Operator" in data:
+            args["operator"] = data["Operator"]
+        if "FieldArrayOfStrings" in data:
+            args["field_array_of_strings"] = data["FieldArrayOfStrings"]
+        if "FieldMapOfStringToString" in data:
+            args["field_map_of_string_to_string"] = data["FieldMapOfStringToString"]
+        if "FieldAnonymousStruct" in data:
+            args["field_anonymous_struct"] = StructComplexFieldsSomeStructFieldAnonymousStruct.from_json(data["FieldAnonymousStruct"])
+        if "fieldRefToConstant" in data:
+            args["field_ref_to_constant"] = data["fieldRefToConstant"]        
+
         return cls(**args)
 
 
@@ -74,9 +84,11 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 
@@ -94,9 +106,11 @@ class StructComplexFieldsSomeStructFieldAnonymousStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -27,10 +27,15 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_bool": data["fieldBool"],
-            "field_string": data["fieldString"],
-            "field_float32": data["FieldFloat32"],
-            "field_int32": data["FieldInt32"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "fieldBool" in data:
+            args["field_bool"] = data["fieldBool"]
+        if "fieldString" in data:
+            args["field_string"] = data["fieldString"]
+        if "FieldFloat32" in data:
+            args["field_float32"] = data["FieldFloat32"]
+        if "FieldInt32" in data:
+            args["field_int32"] = data["FieldInt32"]        
+
         return cls(**args)

--- a/testdata/jennies/rawtypes/struct_with_defaults/PythonRawTypes/models/defaults.py
+++ b/testdata/jennies/rawtypes/struct_with_defaults/PythonRawTypes/models/defaults.py
@@ -27,7 +27,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_bool": data["fieldBool"],
             "field_string": data["fieldString"],
             "field_float32": data["FieldFloat32"],

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
@@ -32,7 +32,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
         }
         
         if "FieldRef" in data:
@@ -63,7 +63,7 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)
@@ -83,7 +83,7 @@ class StructOptionalFieldsSomeStructFieldAnonymousStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
         }
         return cls(**args)

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
@@ -32,8 +32,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-        }
+        args: dict[str, typing.Any] = {}
         
         if "FieldRef" in data:
             args["field_ref"] = SomeOtherStruct.from_json(data["FieldRef"])
@@ -63,9 +62,11 @@ class SomeOtherStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 
@@ -83,9 +84,11 @@ class StructOptionalFieldsSomeStructFieldAnonymousStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]        
+
         return cls(**args)
 
 

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PythonRawTypes/models/struct_optional_fields.py
@@ -19,7 +19,7 @@ class SomeStruct:
         payload: dict[str, object] = {
         }
         if self.field_ref is not None:
-            payload["FieldRef"] = self.field_ref.to_json()
+            payload["FieldRef"] = self.field_ref
         if self.field_string is not None:
             payload["FieldString"] = self.field_string
         if self.operator is not None:
@@ -27,7 +27,7 @@ class SomeStruct:
         if self.field_array_of_strings is not None:
             payload["FieldArrayOfStrings"] = self.field_array_of_strings
         if self.field_anonymous_struct is not None:
-            payload["FieldAnonymousStruct"] = self.field_anonymous_struct.to_json()
+            payload["FieldAnonymousStruct"] = self.field_anonymous_struct
         return payload
 
     @classmethod

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/PythonRawTypes/models/basic.py
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/PythonRawTypes/models/basic.py
@@ -66,20 +66,35 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args: dict[str, typing.Any] = {
-            "field_any": data["FieldAny"],
-            "field_bool": data["FieldBool"],
-            "field_bytes": data["FieldBytes"],
-            "field_string": data["FieldString"],
-            "field_float32": data["FieldFloat32"],
-            "field_float64": data["FieldFloat64"],
-            "field_uint8": data["FieldUint8"],
-            "field_uint16": data["FieldUint16"],
-            "field_uint32": data["FieldUint32"],
-            "field_uint64": data["FieldUint64"],
-            "field_int8": data["FieldInt8"],
-            "field_int16": data["FieldInt16"],
-            "field_int32": data["FieldInt32"],
-            "field_int64": data["FieldInt64"],
-        }
+        args: dict[str, typing.Any] = {}
+        
+        if "FieldAny" in data:
+            args["field_any"] = data["FieldAny"]
+        if "FieldBool" in data:
+            args["field_bool"] = data["FieldBool"]
+        if "FieldBytes" in data:
+            args["field_bytes"] = data["FieldBytes"]
+        if "FieldString" in data:
+            args["field_string"] = data["FieldString"]
+        if "FieldFloat32" in data:
+            args["field_float32"] = data["FieldFloat32"]
+        if "FieldFloat64" in data:
+            args["field_float64"] = data["FieldFloat64"]
+        if "FieldUint8" in data:
+            args["field_uint8"] = data["FieldUint8"]
+        if "FieldUint16" in data:
+            args["field_uint16"] = data["FieldUint16"]
+        if "FieldUint32" in data:
+            args["field_uint32"] = data["FieldUint32"]
+        if "FieldUint64" in data:
+            args["field_uint64"] = data["FieldUint64"]
+        if "FieldInt8" in data:
+            args["field_int8"] = data["FieldInt8"]
+        if "FieldInt16" in data:
+            args["field_int16"] = data["FieldInt16"]
+        if "FieldInt32" in data:
+            args["field_int32"] = data["FieldInt32"]
+        if "FieldInt64" in data:
+            args["field_int64"] = data["FieldInt64"]        
+
         return cls(**args)

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/PythonRawTypes/models/basic.py
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/PythonRawTypes/models/basic.py
@@ -66,7 +66,7 @@ class SomeStruct:
 
     @classmethod
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
-        args = {
+        args: dict[str, typing.Any] = {
             "field_any": data["FieldAny"],
             "field_bool": data["FieldBool"],
             "field_bytes": data["FieldBytes"],


### PR DESCRIPTION
This PR adds support for unmarshalling json into types in Python.

The approach followed to make sure "composable slots" are unmarshalled properly (panels + dataqueries) is similar to what we did for Go.