### PR TITLE
Python/packaging

### DIFF
--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -9,14 +9,22 @@ import (
 
 const LanguageRef = "python"
 
+type Config struct {
+	PathPrefix string
+}
+
 type Language struct {
+	config Config
 }
 
 func New() *Language {
-	return &Language{}
+	return &Language{
+		config: Config{},
+	}
 }
 
-func (language *Language) RegisterCliFlags(_ *cobra.Command) {
+func (language *Language) RegisterCliFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&language.config.PathPrefix, "python-path-prefix", "", "Python path prefix.")
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
@@ -31,6 +39,10 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 		common.If[common.Context](globalConfig.Builders, &Builder{}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+
+	if language.config.PathPrefix != "" {
+		jenny.AddPostprocessors(common.PathPrefixer(language.config.PathPrefix))
+	}
 
 	return jenny
 }

--- a/package_templates/python/LICENSE.md
+++ b/package_templates/python/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+   Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+   stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+   that You distribute, all copyright, patent, trademark, and
+   attribution notices from the Source form of the Work,
+   excluding those notices that do not pertain to any part of
+   the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+   distribution, then any Derivative Works that You distribute must
+   include a readable copy of the attribution notices contained
+   within such NOTICE file, excluding those notices that do not
+   pertain to any part of the Derivative Works, in at least one
+   of the following places: within a NOTICE text file distributed
+   as part of the Derivative Works; within the Source form or
+   documentation, if provided along with the Derivative Works; or,
+   within a display generated by the Derivative Works, if and
+   wherever such third-party notices normally appear. The contents
+   of the NOTICE file are for informational purposes only and
+   do not modify the License. You may add Your own attribution
+   notices within Derivative Works that You distribute, alongside
+   or as an addendum to the NOTICE text from the Work, provided
+   that such additional attribution notices cannot be construed
+   as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -1,0 +1,43 @@
+# Grafana Foundation SDK – TypeScript
+
+A set of tools, types and *builder libraries* for building and manipulating Grafana objects in Python.
+
+> ℹ️ This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
+> Other supported versions of Grafana can be found at [this repository's root](https://github.com/grafana/grafana-foundation-sdk/).
+
+## Maturity
+
+> _The code in this repository should be considered experimental. Documentation is only
+available alongside the code. It comes with no support, but we are keen to receive
+feedback on the product and suggestions on how to improve it, though we cannot commit
+to resolution of any particular issue. No SLAs are available. It is not meant to be used
+in production environments, and the risks are unknown/high._
+
+Grafana Labs defines experimental features as follows:
+
+> Projects and features in the Experimental stage are supported only by the Engineering
+teams; on-call support is not available. Documentation is either limited or not provided
+outside of code comments. No SLA is provided.
+>
+> Experimental projects or features are primarily intended for open source engineers who
+want to participate in ensuring systems stability, and to gain consensus and approval
+for open source governance projects.
+>
+> Projects and features in the Experimental phase are not meant to be used in production
+environments, and the risks are unknown/high.
+
+## Installing
+
+```shell
+python3 -m pip install grafana_foundation_sdk
+```
+
+## Example usage
+
+```python
+TODO
+```
+
+## License
+
+[Apache 2.0 License](./LICENSE)

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -29,7 +29,7 @@ environments, and the risks are unknown/high.
 ## Installing
 
 ```shell
-python3 -m pip install grafana_foundation_sdk
+python3 -m pip install grafana_foundation_sdk=={{ .Extra.GrafanaVersion|registryToSemver }}+cog{{ .Extra.CogVersion }}.{{ .Extra.BuildTimestamp }}
 ```
 
 ## Example usage

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -35,7 +35,44 @@ python3 -m pip install 'grafana_foundation_sdk=={{ .Extra.BuildTimestamp }}!{{ .
 ## Example usage
 
 ```python
-TODO
+from grafana_foundation_sdk.builders.dashboard import Dashboard, Row
+from grafana_foundation_sdk.builders.prometheus import Dataquery as PrometheusQuery
+from grafana_foundation_sdk.builders.timeseries import Panel as Timeseries
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.models.common import TimeZoneBrowser
+
+def build_dashboard() -> Dashboard:
+    builder = (
+        Dashboard("[TEST] Node Exporter / Raspberry")
+        .uid("test-dashboard-raspberry")
+        .tags(["generated", "raspberrypi-node-integration"])
+
+        .refresh("1m")
+        .time("now-30m", "now")
+        .timezone(TimeZoneBrowser)
+
+        .with_row(Row("Overview"))
+        .with_panel(
+            Timeseries()
+            .title("Network Received")
+            .unit("bps")
+            .min_val(0)
+            .with_target(
+                PrometheusQuery()
+                .expr('rate(node_network_receive_bytes_total{job="integrations/raspberrypi-node", device!="lo"}[$__rate_interval]) * 8')
+                .legend_format({{ `"{{ device }}"` }})
+            )
+        )
+    )
+
+    return builder
+
+
+if __name__ == '__main__':
+    dashboard = build_dashboard().build()
+    encoder = JSONEncoder(sort_keys=True, indent=2)
+
+    print(encoder.encode(dashboard))
 ```
 
 ## License

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -29,7 +29,7 @@ environments, and the risks are unknown/high.
 ## Installing
 
 ```shell
-python3 -m pip install grafana_foundation_sdk=={{ .Extra.GrafanaVersion|registryToSemver }}+cog{{ .Extra.CogVersion }}.{{ .Extra.BuildTimestamp }}
+python3 -m pip install 'grafana_foundation_sdk=={{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}'
 ```
 
 ## Example usage

--- a/package_templates/python/pyproject.toml
+++ b/package_templates/python/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "traces",
     "metrics"
 ]
-version = "{{ .Extra.GrafanaVersion|registryToSemver }}+cog{{ .Extra.CogVersion }}.{{ .Extra.BuildTimestamp }}"
+version = "{{ .Extra.BuildTimestamp }}!{{ .Extra.GrafanaVersion|registryToSemver }}"
 dependencies = []
 requires-python = ">=3.11"
 classifiers = [

--- a/package_templates/python/pyproject.toml
+++ b/package_templates/python/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "grafana_foundation_sdk"
+description = "A set of tools, types and libraries for building and manipulating Grafana objects."
+keywords = [
+    "observability",
+    "sdk",
+    "grafana",
+    "logs",
+    "traces",
+    "metrics"
+]
+version = "0.0.1"
+dependencies = []
+requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Monitoring",
+]
+readme = "README.md"
+license = { file = "LICENSE.md" }
+authors = [
+    { name = "Grafana Labs" },
+]
+
+[project.urls]
+Homepage = "https://github.com/grafana/grafana-foundation-sdk"
+Repository = "https://github.com/grafana/grafana-foundation-sdk.git"
+Issues = "https://github.com/grafana/grafana-foundation-sdk/issues"

--- a/package_templates/python/pyproject.toml
+++ b/package_templates/python/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
     "traces",
     "metrics"
 ]
-version = "0.0.1"
+version = "{{ .Extra.GrafanaVersion|registryToSemver }}+cog{{ .Extra.CogVersion }}.{{ .Extra.BuildTimestamp }}"
 dependencies = []
 requires-python = ">=3.11"
 classifiers = [

--- a/package_templates/python/pyproject.toml
+++ b/package_templates/python/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 readme = "README.md"
-license = { file = "LICENSE.md" }
 authors = [
     { name = "Grafana Labs" },
 ]

--- a/repository_templates/python/.github/workflows/python-release.yaml
+++ b/repository_templates/python/.github/workflows/python-release.yaml
@@ -6,7 +6,7 @@ on:
       - 'python/grafana_foundation_sdk/**'
 
 env:
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.12'
 
 jobs:
   release:

--- a/repository_templates/python/.github/workflows/python-release.yaml
+++ b/repository_templates/python/.github/workflows/python-release.yaml
@@ -1,0 +1,48 @@
+name: Python Release
+on:
+  pull_request_target:
+    types: [ closed ]
+    paths:
+      - 'python/grafana_foundation_sdk/**'
+
+env:
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && github.base_ref == '{{ .Extra.ReleaseBranch }}'
+
+    name: Build and release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write  # mandatory for trusted publishing
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/grafana_foundation_sdk
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./python
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python {{ `${{ env.PYTHON_VERSION }}` }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: {{ `${{ env.PYTHON_VERSION }}` }}
+
+      - name: Install pypa/build
+        run: python3 -m pip install build --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -76,6 +76,9 @@ function run_codegen() {
     --go-package-root github.com/grafana/grafana-foundation-sdk/go \
     --language go \
     --language typescript
+
+    #--python-path-prefix grafana_foundation_sdk \
+    #--language python \
 }
 
 function gh_run() (


### PR DESCRIPTION
This PR kickstarts package generation for Python.

Running `python3 -m build` in the `python` folder of grafana-foundation-sdk produces a package that I could install and use in a venv.

How to build the package the package:

* `cd grafana-foundation-sdk/python`
* `python3 -m pip install --upgrade build`
* `python3 -m build`
* `ls -lh ./dist`

Note: having never built a python package before, I don't really know what I'm doing and just followed https://packaging.python.org/en/latest/tutorials/packaging-projects/ :sweat_smile: 

ToDo:

* [x] add quick example in the package's README
* [x] use the correct version in the package's definition + README