### PR TITLE
Manually fix incorrectly parsed type for `heatmap.Options.tooltip`

### DIFF
--- a/config/compiler/common_passes.yaml
+++ b/config/compiler/common_passes.yaml
@@ -122,6 +122,11 @@ passes:
         kind: ref
         ref: { referred_pkg: heatmap, referred_type: ExemplarConfig }
         default: { color: "rgba(255,0,255,0.7)" }
+  - retype_field:
+      field: heatmap.Options.tooltip
+      as:
+        kind: ref
+        ref: { referred_pkg: heatmap, referred_type: HeatmapTooltip }
 
   ##########
   # Others #


### PR DESCRIPTION
Similar to https://github.com/grafana/cog/pull/293

Relates to https://github.com/grafana/cog/issues/292