### PR TITLE
Cleanup imports management in Python

### DIFF
--- a/internal/jennies/common/importmap.go
+++ b/internal/jennies/common/importmap.go
@@ -12,6 +12,7 @@ type ImportMapConfig[M any] struct {
 	Formatter           func(importMap M) string
 	AliasSanitizer      func(string) string
 	ImportPathSanitizer func(string) string
+	CurrentPkg          string
 }
 
 type ImportMapOption[M any] func(importMap *ImportMapConfig[M])
@@ -19,6 +20,12 @@ type ImportMapOption[M any] func(importMap *ImportMapConfig[M])
 func WithAliasSanitizer[M any](sanitizer func(string) string) ImportMapOption[M] {
 	return func(importMap *ImportMapConfig[M]) {
 		importMap.AliasSanitizer = sanitizer
+	}
+}
+
+func WithCurrentPkg[M any](currentPkg string) ImportMapOption[M] {
+	return func(importMap *ImportMapConfig[M]) {
+		importMap.CurrentPkg = currentPkg
 	}
 }
 

--- a/internal/jennies/python/runtime.go
+++ b/internal/jennies/python/runtime.go
@@ -60,7 +60,7 @@ func (jenny Runtime) variantPlugins(context common.Context) (string, error) {
 			continue
 		}
 
-		importAlias := imports.AddModule(schema.Package, "..models", schema.Package)
+		importAlias := imports.FromImport("..models", schema.Package)
 
 		if schema.Metadata.Variant == ast.SchemaVariantPanel {
 			panelSchemas = append(panelSchemas, importAlias)

--- a/testdata/jennies/builders/array_append/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/array_append/PythonBuilder/builders/sandbox.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import sandbox
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    

--- a/testdata/jennies/builders/basic_struct/PythonBuilder/builders/basic_struct.py
+++ b/testdata/jennies/builders/basic_struct/PythonBuilder/builders/basic_struct.py
@@ -1,6 +1,6 @@
-import typing
-from ..cog import builder as cogbuilder
 from ..models import basic_struct
+from ..cog import builder as cogbuilder
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[basic_struct.SomeStruct]):    

--- a/testdata/jennies/builders/basic_struct_defaults/PythonBuilder/builders/basic_struct_defaults.py
+++ b/testdata/jennies/builders/basic_struct_defaults/PythonBuilder/builders/basic_struct_defaults.py
@@ -1,6 +1,6 @@
-import typing
-from ..cog import builder as cogbuilder
 from ..models import basic_struct_defaults
+from ..cog import builder as cogbuilder
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[basic_struct_defaults.SomeStruct]):    

--- a/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
+++ b/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
@@ -1,6 +1,6 @@
-import typing
-from ..cog import builder as cogbuilder
 from ..models import builder_delegation
+from ..cog import builder as cogbuilder
+import typing
 
 
 class DashboardLink(cogbuilder.Builder[builder_delegation.DashboardLink]):    

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
@@ -1,6 +1,6 @@
-import typing
-from ..cog import builder as cogbuilder
 from ..models import builder_delegation_in_disjunction
+from ..cog import builder as cogbuilder
+import typing
 
 
 class DashboardLink(cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink]):    

--- a/testdata/jennies/builders/composable_slot/PythonBuilder/builders/composable_slot.py
+++ b/testdata/jennies/builders/composable_slot/PythonBuilder/builders/composable_slot.py
@@ -1,7 +1,7 @@
-import typing
 from ..cog import builder as cogbuilder
-from ..models import composable_slot
 from ..cog import variants as cogvariants
+from ..models import composable_slot
+import typing
 
 
 class LokiBuilder(cogbuilder.Builder[composable_slot.Dashboard]):    

--- a/testdata/jennies/builders/constant_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/constant_assignment/PythonBuilder/builders/sandbox.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import sandbox
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    

--- a/testdata/jennies/builders/constraints/PythonBuilder/builders/constraints.py
+++ b/testdata/jennies/builders/constraints/PythonBuilder/builders/constraints.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import constraints
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[constraints.SomeStruct]):    

--- a/testdata/jennies/builders/constructor_argument/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/constructor_argument/PythonBuilder/builders/sandbox.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import sandbox
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    

--- a/testdata/jennies/builders/constructor_initializations/PythonBuilder/builders/constructor_initializations.py
+++ b/testdata/jennies/builders/constructor_initializations/PythonBuilder/builders/constructor_initializations.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import constructor_initializations
+import typing
 
 
 class SomePanel(cogbuilder.Builder[constructor_initializations.SomePanel]):    

--- a/testdata/jennies/builders/dataquery_variant_builder/PythonBuilder/builders/dataquery_variant_builder.py
+++ b/testdata/jennies/builders/dataquery_variant_builder/PythonBuilder/builders/dataquery_variant_builder.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import dataquery_variant_builder
+import typing
 
 
 class LokiBuilder(cogbuilder.Builder[dataquery_variant_builder.Loki]):    

--- a/testdata/jennies/builders/envelope_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/envelope_assignment/PythonBuilder/builders/sandbox.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import sandbox
+import typing
 
 
 class Dashboard(cogbuilder.Builder[sandbox.Dashboard]):    

--- a/testdata/jennies/builders/foreign_builder/PythonBuilder/builders/builder_pkg.py
+++ b/testdata/jennies/builders/foreign_builder/PythonBuilder/builders/builder_pkg.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import some_pkg
+import typing
 
 
 class SomeNiceBuilder(cogbuilder.Builder[some_pkg.SomeStruct]):    

--- a/testdata/jennies/builders/initialization_safeguards/PythonBuilder/builders/initialization_safeguards.py
+++ b/testdata/jennies/builders/initialization_safeguards/PythonBuilder/builders/initialization_safeguards.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import initialization_safeguards
+import typing
 
 
 class SomePanel(cogbuilder.Builder[initialization_safeguards.SomePanel]):    

--- a/testdata/jennies/builders/known_any/PythonBuilder/builders/known_any.py
+++ b/testdata/jennies/builders/known_any/PythonBuilder/builders/known_any.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import known_any
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[known_any.SomeStruct]):    

--- a/testdata/jennies/builders/nullable_map_assignment/PythonBuilder/builders/nullable_map_assignment.py
+++ b/testdata/jennies/builders/nullable_map_assignment/PythonBuilder/builders/nullable_map_assignment.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import nullable_map_assignment
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[nullable_map_assignment.SomeStruct]):    

--- a/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
+++ b/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
@@ -1,5 +1,5 @@
-import typing
 from ..cog import builder as cogbuilder
+import typing
 from ..models import with-dashes
 
 

--- a/testdata/jennies/builders/properties/PythonBuilder/builders/properties.py
+++ b/testdata/jennies/builders/properties/PythonBuilder/builders/properties.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import properties
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[properties.SomeStruct]):    

--- a/testdata/jennies/builders/references/PythonBuilder/builders/some_pkg.py
+++ b/testdata/jennies/builders/references/PythonBuilder/builders/some_pkg.py
@@ -1,7 +1,7 @@
-import typing
 from ..cog import builder as cogbuilder
-from ..models import some_pkg
 from ..models import other_pkg
+from ..models import some_pkg
+import typing
 
 
 class Person(cogbuilder.Builder[some_pkg.Person]):    

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/PythonBuilder/builders/sandbox.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import sandbox
+import typing
 
 
 class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    

--- a/testdata/jennies/builders/struct_with_defaults/PythonBuilder/builders/struct_with_defaults.py
+++ b/testdata/jennies/builders/struct_with_defaults/PythonBuilder/builders/struct_with_defaults.py
@@ -1,6 +1,6 @@
-import typing
 from ..cog import builder as cogbuilder
 from ..models import struct_with_defaults
+import typing
 
 
 class NestedStruct(cogbuilder.Builder[struct_with_defaults.NestedStruct]):    

--- a/testdata/jennies/rawtypes/dashboard/PythonRawTypes/models/dashboard.py
+++ b/testdata/jennies/rawtypes/dashboard/PythonRawTypes/models/dashboard.py
@@ -1,6 +1,6 @@
-import typing
-from ..cog import variants as cogvariants
 from ..cog import runtime as cogruntime
+from ..cog import variants as cogvariants
+import typing
 
 
 class Dashboard:

--- a/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
+++ b/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
@@ -1,5 +1,5 @@
-import typing
 from ..models import otherpkg
+import typing
 
 
 class SomeStruct:

--- a/testdata/jennies/rawtypes/variant_dataquery/PythonRawTypes/models/variant_dataquery.py
+++ b/testdata/jennies/rawtypes/variant_dataquery/PythonRawTypes/models/variant_dataquery.py
@@ -1,6 +1,6 @@
+from ..cog import runtime as cogruntime
 from ..cog import variants as cogvariants
 import typing
-from ..cog import runtime as cogruntime
 
 
 class Query(cogvariants.Dataquery):

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/PythonRawTypes/models/variant_panelcfg_full.py
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/PythonRawTypes/models/variant_panelcfg_full.py
@@ -1,5 +1,5 @@
-import typing
 from ..cog import runtime as cogruntime
+import typing
 
 
 class Options:

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/PythonRawTypes/models/variant_panelcfg_only_options.py
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/PythonRawTypes/models/variant_panelcfg_only_options.py
@@ -1,5 +1,5 @@
-import typing
 from ..cog import runtime as cogruntime
+import typing
 
 
 class Options:


### PR DESCRIPTION
Mostly some renamings, to make the imports management more understandable.

Imports are also now sorted, to ensure a reproducible output