### PR TITLE
Use "RenameNumericEnumValues" compiler pass for python

### DIFF
--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -54,5 +54,6 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.DisjunctionInferMapping{},
 		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.AnonymousStructsToNamed{},
+		&compiler.RenameNumericEnumValues{},
 	}
 }


### PR DESCRIPTION
Needed for schemas that don't provide names for enum members.