### PR TITLE
Replace a few kind checks by their utility 'IsX' function

### DIFF
--- a/internal/ast/compiler/anonymous_enum.go
+++ b/internal/ast/compiler/anonymous_enum.go
@@ -61,7 +61,7 @@ func (pass *AnonymousEnumToExplicitType) processSchema(schema *ast.Schema) (*ast
 }
 
 func (pass *AnonymousEnumToExplicitType) processObject(object ast.Object) ast.Object {
-	if object.Type.Kind == ast.KindEnum {
+	if object.Type.IsEnum() {
 		return object
 	}
 
@@ -71,15 +71,15 @@ func (pass *AnonymousEnumToExplicitType) processObject(object ast.Object) ast.Ob
 }
 
 func (pass *AnonymousEnumToExplicitType) processType(pkg string, currentObjectName string, suggestedEnumName string, def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(pkg, currentObjectName, suggestedEnumName, def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(pkg, currentObjectName, def)
 	}
 
-	if def.Kind == ast.KindEnum {
+	if def.IsEnum() {
 		return pass.processAnonymousEnum(pkg, suggestedEnumName, def.AsEnum())
 	}
 

--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -74,19 +74,19 @@ func (pass *AnonymousStructsToNamed) processObject(object ast.Object) ast.Object
 }
 
 func (pass *AnonymousStructsToNamed) processType(pkg string, parentName string, def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(pkg, parentName, def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(pkg, parentName, def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(pkg, parentName, def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(pkg, parentName, def)
 	}
 

--- a/internal/ast/compiler/cloudwatch.go
+++ b/internal/ast/compiler/cloudwatch.go
@@ -73,7 +73,7 @@ func (pass *Cloudwatch) processSchema(schema *ast.Schema) (*ast.Schema, error) {
 func (pass *Cloudwatch) processDataquery(objectName string, typeDef ast.Type) ast.Type {
 	typeDef.Hints[ast.HintSkipVariantPluginRegistration] = true
 
-	if typeDef.Kind != ast.KindStruct {
+	if !typeDef.IsStruct() {
 		return typeDef
 	}
 
@@ -121,7 +121,7 @@ func (pass *Cloudwatch) defineQueryDisjunction(schema *ast.Schema) ast.Object {
 }
 
 func (pass *Cloudwatch) processQueryEditorExpression(object ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindDisjunction {
+	if !object.Type.IsDisjunction() {
 		return object
 	}
 
@@ -141,7 +141,7 @@ func (pass *Cloudwatch) processQueryEditorExpression(object ast.Object) ast.Obje
 }
 
 func (pass *Cloudwatch) processQueryEditorArrayExpression(object ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 

--- a/internal/ast/compiler/dataquery_identification.go
+++ b/internal/ast/compiler/dataquery_identification.go
@@ -33,7 +33,7 @@ func (pass *DataqueryIdentification) processSchema(schema *ast.Schema, commonDat
 }
 
 func (pass *DataqueryIdentification) processObject(object ast.Object, commonDataquery ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 

--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -114,19 +114,19 @@ func (pass *DisjunctionToType) processObject(schema *ast.Schema, object ast.Obje
 }
 
 func (pass *DisjunctionToType) processType(schema *ast.Schema, def ast.Type) (ast.Type, error) {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(schema, def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(schema, def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(schema, def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(schema, def)
 	}
 
@@ -283,7 +283,7 @@ func (pass *DisjunctionToType) hasOnlySingleTypeScalars(schema *ast.Schema, disj
 		return false
 	}
 
-	if firstBranchType.Kind != ast.KindScalar {
+	if !firstBranchType.IsScalar() {
 		return false
 	}
 
@@ -294,7 +294,7 @@ func (pass *DisjunctionToType) hasOnlySingleTypeScalars(schema *ast.Schema, disj
 			return false
 		}
 
-		if resolvedType.Kind != ast.KindScalar {
+		if !resolvedType.IsScalar() {
 			return false
 		}
 

--- a/internal/ast/compiler/disjunctions_infer_mapping.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping.go
@@ -65,19 +65,19 @@ func (pass *DisjunctionInferMapping) processObject(schema *ast.Schema, object as
 }
 
 func (pass *DisjunctionInferMapping) processType(schema *ast.Schema, def ast.Type) (ast.Type, error) {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(schema, def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(schema, def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(schema, def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(schema, def)
 	}
 
@@ -191,15 +191,12 @@ func (pass *DisjunctionInferMapping) inferDiscriminatorField(schema *ast.Schema,
 		candidates[typeName] = make(map[string]any)
 
 		for _, field := range structType.Fields {
-			if field.Type.Kind != ast.KindScalar {
+			if !field.Type.IsConcreteScalar() {
 				continue
 			}
 
 			scalarField := field.Type.AsScalar()
-			if !scalarField.IsConcrete() {
-				continue
-			}
-			if field.Type.AsScalar().ScalarKind != ast.KindString {
+			if scalarField.ScalarKind != ast.KindString {
 				continue
 			}
 
@@ -256,7 +253,7 @@ func (pass *DisjunctionInferMapping) buildDiscriminatorMapping(schema *ast.Schem
 		}
 
 		// trust, but verify: we need the field to be an actual scalar with a concrete value?
-		if field.Type.Kind != ast.KindScalar {
+		if !field.Type.IsScalar() {
 			return nil, fmt.Errorf("discriminator field is not a scalar: %w", ErrCanNotInferDiscriminator)
 		}
 

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -55,19 +55,19 @@ func (pass *DisjunctionWithNullToOptional) processObject(object ast.Object) ast.
 }
 
 func (pass *DisjunctionWithNullToOptional) processType(def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(def)
 	}
 

--- a/internal/ast/compiler/flatten_disjunctions.go
+++ b/internal/ast/compiler/flatten_disjunctions.go
@@ -66,19 +66,19 @@ func (pass *FlattenDisjunctions) processObject(schema *ast.Schema, object ast.Ob
 }
 
 func (pass *FlattenDisjunctions) processType(schema *ast.Schema, def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(schema, def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(schema, def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(schema, def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(schema, def)
 	}
 
@@ -127,7 +127,7 @@ func (pass *FlattenDisjunctions) flattenDisjunction(schema *ast.Schema, disjunct
 	}
 
 	for _, branch := range disjunction.Branches {
-		if branch.Kind != ast.KindRef {
+		if !branch.IsRef() {
 			addBranch(branch)
 			continue
 		}
@@ -138,7 +138,7 @@ func (pass *FlattenDisjunctions) flattenDisjunction(schema *ast.Schema, disjunct
 			continue
 		}
 
-		if resolved.Kind != ast.KindDisjunction {
+		if !resolved.IsDisjunction() {
 			addBranch(branch)
 			continue
 		}

--- a/internal/ast/compiler/googlecloudmonitoring.go
+++ b/internal/ast/compiler/googlecloudmonitoring.go
@@ -52,7 +52,7 @@ func (pass *GoogleCloudMonitoring) processSchema(schema *ast.Schema) (*ast.Schem
 }
 
 func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 
@@ -65,7 +65,7 @@ func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object
 			continue
 		}
 
-		if field.Type.Kind != ast.KindDisjunction {
+		if !field.Type.IsDisjunction() {
 			fields = append(fields, field)
 			continue
 		}
@@ -85,7 +85,7 @@ func (pass *GoogleCloudMonitoring) processCloudMonitoringQuery(object ast.Object
 }
 
 func (pass *GoogleCloudMonitoring) processTimeSeriesList(object ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 

--- a/internal/ast/compiler/librarypanels.go
+++ b/internal/ast/compiler/librarypanels.go
@@ -57,7 +57,7 @@ func (pass *LibraryPanels) parseSchema(schema *ast.Schema, dashboardPanel ast.Ob
 }
 
 func (pass *LibraryPanels) processLibraryPanel(object ast.Object, dashboardPanel ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 

--- a/internal/ast/compiler/name_anonymous_struct.go
+++ b/internal/ast/compiler/name_anonymous_struct.go
@@ -56,7 +56,7 @@ func (pass *NameAnonymousStruct) processObject(object ast.Object) (ast.Object, a
 		}
 
 		// we expect the target field to be defined an inline struct
-		if field.Type.Kind != ast.KindStruct {
+		if !field.Type.IsStruct() {
 			continue
 		}
 

--- a/internal/ast/compiler/not_required_as_nullable.go
+++ b/internal/ast/compiler/not_required_as_nullable.go
@@ -28,7 +28,7 @@ func (pass *NotRequiredFieldAsNullableType) processSchema(schema *ast.Schema) *a
 }
 
 func (pass *NotRequiredFieldAsNullableType) processObject(object ast.Object) ast.Object {
-	if object.Type.Kind != ast.KindStruct {
+	if !object.Type.IsStruct() {
 		return object
 	}
 
@@ -38,19 +38,19 @@ func (pass *NotRequiredFieldAsNullableType) processObject(object ast.Object) ast
 }
 
 func (pass *NotRequiredFieldAsNullableType) processType(def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(def)
 	}
 

--- a/internal/ast/compiler/rename_object.go
+++ b/internal/ast/compiler/rename_object.go
@@ -48,27 +48,27 @@ func (pass *RenameObject) processSchema(schema *ast.Schema) *ast.Schema {
 }
 
 func (pass *RenameObject) processType(def ast.Type) ast.Type {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return pass.processArray(def)
 	}
 
-	if def.Kind == ast.KindMap {
+	if def.IsMap() {
 		return pass.processMap(def)
 	}
 
-	if def.Kind == ast.KindStruct {
+	if def.IsStruct() {
 		return pass.processStruct(def)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		return pass.processDisjunction(def)
 	}
 
-	if def.Kind == ast.KindIntersection {
+	if def.IsIntersection() {
 		return pass.processIntersection(def)
 	}
 
-	if def.Kind == ast.KindRef {
+	if def.IsRef() {
 		return pass.processRef(def)
 	}
 

--- a/internal/ast/schema.go
+++ b/internal/ast/schema.go
@@ -147,7 +147,7 @@ func (schema *Schema) LocateObject(name string) (Object, bool) {
 }
 
 func (schema *Schema) Resolve(typeDef Type) (Type, bool) {
-	if typeDef.Kind != KindRef {
+	if !typeDef.IsRef() {
 		return typeDef, true
 	}
 

--- a/internal/ast/tools.go
+++ b/internal/ast/tools.go
@@ -5,13 +5,13 @@ import (
 )
 
 func TypeName(typeDef Type) string {
-	if typeDef.Kind == KindRef {
+	if typeDef.IsRef() {
 		return tools.UpperCamelCase(typeDef.AsRef().ReferredType)
 	}
-	if typeDef.Kind == KindScalar {
+	if typeDef.IsScalar() {
 		return tools.UpperCamelCase(string(typeDef.AsScalar().ScalarKind))
 	}
-	if typeDef.Kind == KindArray {
+	if typeDef.IsArray() {
 		return "ArrayOf" + TypeName(typeDef.AsArray().ValueType)
 	}
 

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -170,6 +170,14 @@ func (t Type) IsDisjunction() bool {
 	return t.Kind == KindDisjunction
 }
 
+func (t Type) IsIntersection() bool {
+	return t.Kind == KindIntersection
+}
+
+func (t Type) IsComposableSlot() bool {
+	return t.Kind == KindComposableSlot
+}
+
 func (t Type) IsStructGeneratedFromDisjunction() bool {
 	if t.Kind != KindStruct {
 		return false

--- a/internal/jennies/common/context.go
+++ b/internal/jennies/common/context.go
@@ -15,11 +15,11 @@ func (context *Context) LocateObject(pkg string, name string) (ast.Object, bool)
 }
 
 func (context *Context) ResolveToBuilder(def ast.Type) bool {
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return context.ResolveToBuilder(def.AsArray().ValueType)
 	}
 
-	if def.Kind == ast.KindDisjunction {
+	if def.IsDisjunction() {
 		for _, branch := range def.AsDisjunction().Branches {
 			if context.ResolveToBuilder(branch) {
 				return true
@@ -29,7 +29,7 @@ func (context *Context) ResolveToBuilder(def ast.Type) bool {
 		return false
 	}
 
-	if def.Kind != ast.KindRef {
+	if !def.IsRef() {
 		return false
 	}
 
@@ -40,7 +40,7 @@ func (context *Context) ResolveToBuilder(def ast.Type) bool {
 }
 
 func (context *Context) IsDisjunctionOfBuilders(def ast.Type) bool {
-	if def.Kind != ast.KindDisjunction {
+	if !def.IsDisjunction() {
 		return false
 	}
 
@@ -54,15 +54,15 @@ func (context *Context) IsDisjunctionOfBuilders(def ast.Type) bool {
 }
 
 func (context *Context) ResolveToComposableSlot(def ast.Type) (ast.Type, bool) {
-	if def.Kind == ast.KindComposableSlot {
+	if def.IsComposableSlot() {
 		return def, true
 	}
 
-	if def.Kind == ast.KindArray {
+	if def.IsArray() {
 		return context.ResolveToComposableSlot(def.AsArray().ValueType)
 	}
 
-	if def.Kind == ast.KindRef {
+	if def.IsRef() {
 		referredObj, found := context.LocateObject(def.AsRef().ReferredPkg, def.AsRef().ReferredType)
 		if !found {
 			return ast.Type{}, false

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -52,7 +52,7 @@ func init() {
 				return variableName
 			},
 			"isNullableNonArray": func(typeDef ast.Type) bool {
-				return typeDef.Nullable && typeDef.Kind != ast.KindArray
+				return typeDef.Nullable && !typeDef.IsArray()
 			},
 		})
 

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -46,7 +46,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			return "any"
 		}
 
-		if def.Kind == ast.KindComposableSlot {
+		if def.IsComposableSlot() {
 			formatted := formatter.variantInterface(string(def.AsComposableSlot().Variant))
 
 			if !resolveBuilders {
@@ -58,15 +58,15 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			return fmt.Sprintf("%s.Builder[%s]", cogAlias, formatted)
 		}
 
-		if def.Kind == ast.KindArray {
+		if def.IsArray() {
 			return formatter.formatArray(def.AsArray(), resolveBuilders)
 		}
 
-		if def.Kind == ast.KindMap {
+		if def.IsMap() {
 			return formatter.formatMap(def.AsMap())
 		}
 
-		if def.Kind == ast.KindScalar {
+		if def.IsScalar() {
 			typeName := def.AsScalar().ScalarKind
 			if def.Nullable {
 				typeName = "*" + typeName
@@ -75,12 +75,12 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			return string(typeName)
 		}
 
-		if def.Kind == ast.KindRef {
+		if def.IsRef() {
 			return formatter.formatRef(def, resolveBuilders)
 		}
 
 		// anonymous struct or struct body
-		if def.Kind == ast.KindStruct {
+		if def.IsStruct() {
 			output := formatter.formatStructBody(def.AsStruct())
 			if def.Nullable {
 				output = "*" + output
@@ -89,7 +89,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			return output
 		}
 
-		if def.Kind == ast.KindIntersection {
+		if def.IsIntersection() {
 			return formatter.formatIntersection(def.AsIntersection())
 		}
 
@@ -221,7 +221,7 @@ func formatDefaultReferenceStructForBuilder(refPkg string, name string, isBuilde
 			buffer.WriteString(fmt.Sprintf(format, key, formatScalar([]any{})))
 		default:
 			val := formatScalar(x)
-			if !isBuilder && field.Type.Kind == ast.KindScalar && field.Type.Nullable {
+			if !isBuilder && field.Type.IsScalar() && field.Type.Nullable {
 				val = fmt.Sprintf("cog.ToPtr[%s](%v)", field.Type.AsScalar().ScalarKind, value)
 			}
 			buffer.WriteString(fmt.Sprintf(format, key, val))
@@ -256,7 +256,7 @@ func defineAnonymousFields(def ast.StructType) string {
 			structDefinition.WriteString(fmt.Sprintf("%s struct %v `json:\"%s\"`\n", key, structFields, tools.LowerCamelCase(key)))
 		case ast.KindArray:
 			array := f.Type.AsArray()
-			if array.ValueType.Kind == ast.KindScalar {
+			if array.ValueType.IsScalar() {
 				structDefinition.WriteString(fmt.Sprintf("%s []%v `json:\"%s\"`\n", key, array.ValueType.AsScalar().ScalarKind, tools.LowerCamelCase(key)))
 			}
 		// TODO: Map rest of array cases

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -158,7 +158,7 @@ func (jenny RawTypes) formatInnerStruct(pkg string, name string, comments []stri
 	nestedStructs := make([]ClassTemplate, 0)
 
 	for _, field := range def.Fields {
-		if field.Type.Kind == ast.KindStruct {
+		if field.Type.IsStruct() {
 			nestedStructs = append(nestedStructs, jenny.formatInnerStruct(pkg, field.Name, field.Comments, field.Type.ImplementedVariant(), field.Type.AsStruct()))
 		} else {
 			fields = append(fields, Field{

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -159,10 +159,7 @@ func (jenny *Builder) generateAssignment(assign ast.Assignment) template.Assignm
 		}
 
 		maybeUndefined := chunkType.Nullable ||
-			chunkType.Kind == ast.KindMap ||
-			chunkType.Kind == ast.KindArray ||
-			chunkType.Kind == ast.KindRef ||
-			chunkType.Kind == ast.KindStruct
+			chunkType.IsAnyOf(ast.KindMap, ast.KindArray, ast.KindRef, ast.KindStruct)
 
 		if !maybeUndefined {
 			continue

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -133,7 +133,7 @@ func (jenny RawTypes) formatObject(def ast.Object, packageMapper pkgMapper) ([]b
 		return nil, fmt.Errorf("unhandled object of type: %s", def.Type.Kind)
 	}
 	// generate a "default value factory" for every object, except for constants or composability slots
-	if (def.Type.Kind != ast.KindScalar && def.Type.Kind != ast.KindComposableSlot) || (def.Type.Kind == ast.KindScalar && !def.Type.AsScalar().IsConcrete()) {
+	if (!def.Type.IsScalar() && !def.Type.IsComposableSlot()) || (def.Type.IsScalar() && !def.Type.AsScalar().IsConcrete()) {
 		buffer.WriteString("\n")
 
 		buffer.WriteString(fmt.Sprintf("export const default%[1]s = (): %[2]s => (", tools.UpperCamelCase(objectName), objectName))
@@ -304,7 +304,7 @@ func (jenny RawTypes) defaultValuesForReference(typeDef ast.Type, packageMapper 
 	referredTypeName := tools.CleanupNames(referredType.Name)
 
 	// is the reference to a constant?
-	if referredType.Type.Kind == ast.KindScalar && referredType.Type.AsScalar().IsConcrete() {
+	if referredType.Type.IsConcreteScalar() {
 		if pkg != "" {
 			return raw(fmt.Sprintf("%s.%s", pkg, referredTypeName))
 		}
@@ -312,7 +312,7 @@ func (jenny RawTypes) defaultValuesForReference(typeDef ast.Type, packageMapper 
 		return raw(referredTypeName)
 	}
 
-	if referredType.Type.Kind == ast.KindEnum {
+	if referredType.Type.IsEnum() {
 		return raw(jenny.typeFormatter.formatEnumValue(referredType, typeDef.Default))
 	}
 
@@ -386,7 +386,7 @@ func defaultEmptyValuesForStructs(def ast.StructType) string {
 
 func hasStructDefaults(typeDef ast.Type, defaults any) bool {
 	_, ok := defaults.(map[string]interface{})
-	return ok && typeDef.Kind == ast.KindStruct
+	return ok && typeDef.IsStruct()
 }
 
 func escapeEnumMemberName(identifier string) string {

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -179,7 +179,7 @@ func (formatter *typeFormatter) formatScalarKind(kind ast.ScalarKind) string {
 func (formatter *typeFormatter) formatArray(def ast.ArrayType, resolveBuilders bool) string {
 	subTypeString := formatter.doFormatType(def.ValueType, resolveBuilders)
 
-	if def.ValueType.Kind == ast.KindDisjunction {
+	if def.ValueType.IsDisjunction() {
 		return fmt.Sprintf("(%s)[]", subTypeString)
 	}
 


### PR DESCRIPTION
Just a refactoring/cleanup: instead of directly comparing a type's kind with a constant, let's use the `IsX()` utility methods instead.

This PR doesn't change the generated code.