### PR TITLE
Omit Default() option on panels

### DIFF
--- a/config/veneers/dashboard.veneers.common.yaml
+++ b/config/veneers/dashboard.veneers.common.yaml
@@ -65,6 +65,7 @@ builders:
   - compose_dashboard_panel:
       panel_builder_name: dashboard.Panel
       exclude_panel_options: &UnwantedPanelOptions [
+        "defaults",      # merged with another builder
         "fieldConfig",   # merged with another builder
         "options",       # comes from a panel plugin
         "custom",        # comes from a panel plugin


### PR DESCRIPTION
See: https://github.com/grafana/grafana-foundation-sdk/blob/1f9bfb889f6f5cd8fc97a32d1905f5c5bb4cfb5e/go/canvas/panel_builder_gen.go#L342-L349

This option isn't needed since values defined in `FieldConfig` are already exposed as options within the panel builder: https://github.com/grafana/cog/blob/9ebd1797544db850ef0c24e6cbb18a332140b200/config/veneers/dashboard.veneers.common.yaml#L47-L62