### PR TITLE
Fix empty value generation for go types with builders

### DIFF
--- a/internal/ast/compiler/anonymous_structs_to_named.go
+++ b/internal/ast/compiler/anonymous_structs_to_named.go
@@ -115,12 +115,15 @@ func (pass *AnonymousStructsToNamed) processDisjunction(pkg string, parentName s
 }
 
 func (pass *AnonymousStructsToNamed) processStruct(pkg string, parentName string, def ast.Type) ast.Type {
+	objectDef := def.DeepCopy()
+	objectDef.Nullable = false
+
 	for i, field := range def.AsStruct().Fields {
 		name := parentName + tools.UpperCamelCase(field.Name)
-		def.Struct.Fields[i].Type = pass.processType(pkg, name, field.Type)
+		objectDef.Struct.Fields[i].Type = pass.processType(pkg, name, field.Type)
 	}
 
-	newObject := ast.NewObject(pkg, parentName, def)
+	newObject := ast.NewObject(pkg, parentName, objectDef)
 	newObject.AddToPassesTrail("AnonymousStructsToNamed")
 
 	pass.newObjects = append(pass.newObjects, newObject)

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -273,7 +273,7 @@ func (jenny *Builder) generateAssignment(assignment ast.Assignment) template.Ass
 func (jenny *Builder) emptyValueForType(typeDef ast.Type) string {
 	switch typeDef.Kind {
 	case ast.KindRef, ast.KindStruct, ast.KindArray, ast.KindMap:
-		return jenny.typeFormatter.formatType(typeDef) + "{}"
+		return jenny.typeFormatter.doFormatType(typeDef, false) + "{}"
 	case ast.KindEnum:
 		return formatScalar(typeDef.AsEnum().Values[0].Value)
 	case ast.KindScalar:

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -92,7 +92,7 @@
 {{- end }}
 
 {{- define "value_envelope" }}
-    {{- .Envelope.Type | formatType }}{
+    {{- .Envelope.Type | formatTypeNoBuilder }}{
         {{- range .Envelope.Values }}
         {{- $value := include "assignment_value" (dict "Assignment" $.Assignment "Value" .Value) }}
         {{- $value = maybeAsPointer (.Path.Last.Type) $value }}


### PR DESCRIPTION
I noticed that our go jenny generates incorrect code for the empty value of a struct that has a builder:

```go
builder.internal.Time = cog.Builder[DashboardDashboardTime]{}
```

Instead of:

```go
builder.internal.Time = &DashboardDashboardTime{}
```

This bug doesn't appear in the foundation-sdk since it required enabling the `AnonymousStructsToNamed` compiler pass (which isn't enabled for Go at the moment), but it was easy to fix so here we are.