### PR TITLE
Skip foundation-sdk preview when is dependabot

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -10,6 +10,7 @@ jobs:
   sdk_diff:
     name: Generate diff
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It skips foundation-sdk preview for `dependabot` PR's since they fail because a lack of authorization. 