### PR TITLE
Enable Python package publishing in grafana-foundation-sdk release pipeline

### DIFF
--- a/repository_templates/python/.github/workflows/python-release.yaml
+++ b/repository_templates/python/.github/workflows/python-release.yaml
@@ -42,8 +42,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
 
-# not yet setup
-#      - name: Publish distribution 📦 to PyPI
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          packages-dir: python/dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/


### PR DESCRIPTION
`grafana-foundation-sdk` has been setup using [PyPI's trusted publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), so we can now uncomment this :)