### PR TITLE
Attempt at fixing dependabot PRs

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Find preview comment
         uses: peter-evans/find-comment@v3
         id: preview-comment-find
-        if: "!contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
+        if: "!contains(github.actor, 'dependabot') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@v4
-        if: "!contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
+        if: "!contains(github.actor, 'dependabot') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
         with:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Find preview comment
         uses: peter-evans/find-comment@v3
         id: preview-comment-find
-        if: github.actor != 'dependabot[bot]' && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: not contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.actor != 'dependabot[bot]' && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: not contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -10,7 +10,6 @@ jobs:
   sdk_diff:
     name: Generate diff
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +52,7 @@ jobs:
       - name: Find preview comment
         uses: peter-evans/find-comment@v3
         id: preview-comment-find
+        if: github.actor != 'dependabot[bot]' && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -60,6 +60,7 @@ jobs:
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@v4
+        if: github.actor != 'dependabot[bot]' && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Find preview comment
         uses: peter-evans/find-comment@v3
         id: preview-comment-find
-        if: !contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: "!contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@v4
-        if: !contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: "!contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
         with:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Find preview comment
         uses: peter-evans/find-comment@v3
         id: preview-comment-find
-        if: not contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: !contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@v4
-        if: not contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
+        if: !contains(github.actor, 'dependabot[bot]') && github.repository == 'grafana/cog' # only run on main repo, and not on dependabot PRs
         with:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
PRs like this: https://github.com/grafana/cog/pull/310 fail because of missing permissions. We want the workflow to run but just not post the comments