### PR TITLE
CI: Print out the diff when generating the foundation SDK

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -43,7 +43,7 @@ jobs:
           echo -e "</summary>\n" >> preview.md
           echo '```patch' >> preview.md
           
-          git diff next+cog-v0.0.x..HEAD ':(exclude,glob)*/README.md' >> preview.md
+          git diff next+cog-v0.0.x..HEAD ':(exclude,glob)*/README.md' | tee -a preview.md
           
           echo '```' >> preview.md
           echo -e "\n" >> preview.md


### PR DESCRIPTION
For https://github.com/grafana/cog/pull/315, I removed the comment for dependabot PRs so we don't see the diff anymore

With this change, we'll see it in CI logs at least