### PR TITLE
Improve readmes

### DIFF
--- a/package_templates/go/README.md
+++ b/package_templates/go/README.md
@@ -20,45 +20,45 @@ go get github.com/grafana/grafana-foundation-sdk/go@{{ .Extra.ReleaseBranch }}
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+    "encoding/json"
+    "fmt"
 
-	"github.com/grafana/grafana-foundation-sdk/go/common"
-	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
-	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
-	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+    "github.com/grafana/grafana-foundation-sdk/go/common"
+    "github.com/grafana/grafana-foundation-sdk/go/dashboard"
+    "github.com/grafana/grafana-foundation-sdk/go/prometheus"
+    "github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
 func main() {
-	builder := dashboard.NewDashboardBuilder("Sample dashboard").
-		Uid("generated-from-go").
-		Tags([]string{"generated", "from", "go"}).
-		Refresh("1m").
-		Time("now-30m", "now").
-		Timezone(common.TimeZoneBrowser).
-		WithRow(dashboard.NewRowBuilder("Overview")).
-		WithPanel(
-			timeseries.NewPanelBuilder().
-				Title("Network Received").
-				Unit("bps").
-				Min(0).
-				WithTarget(
-					prometheus.NewDataqueryBuilder().
-						Expr(`rate(node_network_receive_bytes_total{job="integrations/raspberrypi-node", device!="lo"}[$__rate_interval]) * 8`).
-						LegendFormat({{ `"{{ device }}"` }}),
-				),
-		)
+    builder := dashboard.NewDashboardBuilder("Sample dashboard").
+        Uid("generated-from-go").
+        Tags([]string{"generated", "from", "go"}).
+        Refresh("1m").
+        Time("now-30m", "now").
+        Timezone(common.TimeZoneBrowser).
+        WithRow(dashboard.NewRowBuilder("Overview")).
+        WithPanel(
+            timeseries.NewPanelBuilder().
+                Title("Network Received").
+                Unit("bps").
+                Min(0).
+                WithTarget(
+                    prometheus.NewDataqueryBuilder().
+                        Expr(`rate(node_network_receive_bytes_total{job="integrations/raspberrypi-node", device!="lo"}[$__rate_interval]) * 8`).
+                        LegendFormat({{ `"{{ device }}"` }}),
+                ),
+        )
 
-	sampleDashboard, err := builder.Build()
-	if err != nil {
-		panic(err)
-	}
-	dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
-	if err != nil {
-		panic(err)
-	}
+    sampleDashboard, err := builder.Build()
+    if err != nil {
+        panic(err)
+    }
+    dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
+    if err != nil {
+        panic(err)
+    }
 
-	fmt.Println(string(dashboardJson))
+    fmt.Println(string(dashboardJson))
 }
 ```
 
@@ -68,29 +68,29 @@ func main() {
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
+    "encoding/json"
+    "fmt"
+    "os"
 
-	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
-	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+    "github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
+    "github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
 func main() {
-	// Required to correctly unmarshal panels and dataqueries
-	plugins.RegisterDefaultPlugins()
+    // Required to correctly unmarshal panels and dataqueries
+    plugins.RegisterDefaultPlugins()
 
-	dashboardJSON, err := os.ReadFile("dashboard.json")
-	if err != nil {
-		panic(err)
-	}
+    dashboardJSON, err := os.ReadFile("dashboard.json")
+    if err != nil {
+        panic(err)
+    }
 
-	sampleDashboard := &dashboard.Dashboard{}
-	if err := json.Unmarshal(dashboardJSON, sampleDashboard); err != nil {
-		panic(fmt.Sprintf("%s", err))
-	}
+    sampleDashboard := &dashboard.Dashboard{}
+    if err := json.Unmarshal(dashboardJSON, sampleDashboard); err != nil {
+        panic(fmt.Sprintf("%s", err))
+    }
 
-	fmt.Printf("%#v\n", sampleDashboard)
+    fmt.Printf("%#v\n", sampleDashboard)
 }
 ```
 
@@ -105,37 +105,37 @@ To do so, define a type and a builder for the custom query:
 package main
 
 import (
-	"encoding/json"
+    "encoding/json"
 
-	"github.com/grafana/grafana-foundation-sdk/go/cog"
-	cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+    "github.com/grafana/grafana-foundation-sdk/go/cog"
+    cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
 )
 
 type CustomQuery struct {
-	// RefId and Hide are expected on all queries
-	RefId        *string `json:"refId,omitempty"`
-	Hide         *bool   `json:"hide,omitempty"`
+    // RefId and Hide are expected on all queries
+    RefId        *string `json:"refId,omitempty"`
+    Hide         *bool   `json:"hide,omitempty"`
 
-	// Query is specific to the CustomQuery type
-	Query        string  `json:"query,omitempty"`
+    // Query is specific to the CustomQuery type
+    Query        string  `json:"query,omitempty"`
 }
 
 // Let cog know that CustomQuery is a Dataquery variant
 func (resource CustomQuery) ImplementsDataqueryVariant() {}
 
 func CustomQueryVariantConfig() cogvariants.DataqueryConfig {
-	return cogvariants.DataqueryConfig{
-		Identifier: "custom", // datasource plugin ID
-		DataqueryUnmarshaler: func(raw []byte) (cogvariants.Dataquery, error) {
-			dataquery := &CustomQuery{}
+    return cogvariants.DataqueryConfig{
+        Identifier: "custom", // datasource plugin ID
+        DataqueryUnmarshaler: func(raw []byte) (cogvariants.Dataquery, error) {
+            dataquery := &CustomQuery{}
 
-			if err := json.Unmarshal(raw, dataquery); err != nil {
-				return nil, err
-			}
+            if err := json.Unmarshal(raw, dataquery); err != nil {
+                return nil, err
+            }
 
-			return dataquery, nil
-		},
-	}
+            return dataquery, nil
+        },
+    }
 }
 
 // Compile-time check to ensure that CustomQueryBuilder indeed is
@@ -143,27 +143,27 @@ func CustomQueryVariantConfig() cogvariants.DataqueryConfig {
 var _ cog.Builder[cogvariants.Dataquery] = (*CustomQueryBuilder)(nil)
 
 type CustomQueryBuilder struct {
-	internal *CustomQuery
+    internal *CustomQuery
 }
 
 func NewCustomQueryBuilder(query string) *CustomQueryBuilder {
-	return &CustomQueryBuilder{
-		internal: &CustomQuery{Query: query},
-	}
+    return &CustomQueryBuilder{
+        internal: &CustomQuery{Query: query},
+    }
 }
 
 func (builder *CustomQueryBuilder) Build() (cogvariants.Dataquery, error) {
-	return *builder.internal, nil
+    return *builder.internal, nil
 }
 
 func (builder *CustomQueryBuilder) RefId(refId string) *CustomQueryBuilder {
-	builder.internal.RefId = &refId
-	return builder
+    builder.internal.RefId = &refId
+    return builder
 }
 
 func (builder *CustomQueryBuilder) Hide(hide bool) *CustomQueryBuilder {
-	builder.internal.Hide = &hide
-	return builder
+    builder.internal.Hide = &hide
+    return builder
 }
 ```
 
@@ -173,45 +173,45 @@ Register the type with cog, and use it as usual to build a dashboard:
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+    "encoding/json"
+    "fmt"
 
-	"github.com/grafana/grafana-foundation-sdk/go/cog"
-	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
-	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
-	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+    "github.com/grafana/grafana-foundation-sdk/go/cog"
+    "github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
+    "github.com/grafana/grafana-foundation-sdk/go/dashboard"
+    "github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
 func main() {
-	// Required to correctly unmarshal panels and dataqueries
-	plugins.RegisterDefaultPlugins()
+    // Required to correctly unmarshal panels and dataqueries
+    plugins.RegisterDefaultPlugins()
 
-	// This lets cog know about the newly created query type and how to unmarshal it.
-	cog.NewRuntime().RegisterDataqueryVariant(CustomQueryVariantConfig())
+    // This lets cog know about the newly created query type and how to unmarshal it.
+    cog.NewRuntime().RegisterDataqueryVariant(CustomQueryVariantConfig())
 
-	sampleDashboard, err := dashboard.NewDashboardBuilder("Custom query type").
-		Uid("test-custom-query-type").
-		Refresh("1m").
-		Time("now-30m", "now").
-		WithRow(dashboard.NewRowBuilder("Overview")).
-		WithPanel(
-			timeseries.NewPanelBuilder().
-				Title("Sample panel").
-				WithTarget(
-					NewCustomQueryBuilder("query here").LegendFormat("{{ cpu }}"),
-				),
-		).
-		Build()
-	if err != nil {
-		panic(err)
-	}
+    sampleDashboard, err := dashboard.NewDashboardBuilder("Custom query type").
+        Uid("test-custom-query-type").
+        Refresh("1m").
+        Time("now-30m", "now").
+        WithRow(dashboard.NewRowBuilder("Overview")).
+        WithPanel(
+            timeseries.NewPanelBuilder().
+                Title("Sample panel").
+                WithTarget(
+                    NewCustomQueryBuilder("query here"),
+                ),
+        ).
+        Build()
+    if err != nil {
+        panic(err)
+    }
 
-	dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
-	if err != nil {
-		panic(err)
-	}
+    dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
+    if err != nil {
+        panic(err)
+    }
 
-	fmt.Println(string(dashboardJson))
+    fmt.Println(string(dashboardJson))
 }
 ```
 
@@ -226,30 +226,30 @@ To do so, define a type and a builder for the custom panel's options:
 package main
 
 import (
-	"encoding/json"
+    "encoding/json"
 
-	"github.com/grafana/grafana-foundation-sdk/go/cog"
-	cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
-	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+    "github.com/grafana/grafana-foundation-sdk/go/cog"
+    cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+    "github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
 type CustomPanelOptions struct {
-	MakeBeautiful bool `json:"makeBeautiful"`
+    MakeBeautiful bool `json:"makeBeautiful"`
 }
 
 func CustomPanelVariantConfig() cogvariants.PanelcfgConfig {
-	return cogvariants.PanelcfgConfig{
-		Identifier: "custom-panel", // plugin ID
-		OptionsUnmarshaler: func(raw []byte) (any, error) {
-			options := CustomPanelOptions{}
+    return cogvariants.PanelcfgConfig{
+        Identifier: "custom-panel", // plugin ID
+        OptionsUnmarshaler: func(raw []byte) (any, error) {
+            options := CustomPanelOptions{}
 
-			if err := json.Unmarshal(raw, &options); err != nil {
-				return nil, err
-			}
+            if err := json.Unmarshal(raw, &options); err != nil {
+                return nil, err
+            }
 
-			return options, nil
-		},
-	}
+            return options, nil
+        },
+    }
 }
 
 // Compile-time check to ensure that CustomPanelBuilder indeed is
@@ -257,59 +257,59 @@ func CustomPanelVariantConfig() cogvariants.PanelcfgConfig {
 var _ cog.Builder[dashboard.Panel] = (*CustomPanelBuilder)(nil)
 
 type CustomPanelBuilder struct {
-	internal *dashboard.Panel
-	errors   map[string]cog.BuildErrors
+    internal *dashboard.Panel
+    errors   map[string]cog.BuildErrors
 }
 
 func NewCustomPanelBuilder() *CustomPanelBuilder {
-	return &CustomPanelBuilder{
-		internal: &dashboard.Panel{
-			Type: "custom-panel",
-		},
-		errors: make(map[string]cog.BuildErrors),
-	}
+    return &CustomPanelBuilder{
+        internal: &dashboard.Panel{
+            Type: "custom-panel",
+        },
+        errors: make(map[string]cog.BuildErrors),
+    }
 }
 
 func (builder *CustomPanelBuilder) Build() (dashboard.Panel, error) {
-	var errs cog.BuildErrors
+    var errs cog.BuildErrors
 
-	for _, err := range builder.errors {
-		errs = append(errs, cog.MakeBuildErrors("CustomPanel", err)...)
-	}
+    for _, err := range builder.errors {
+        errs = append(errs, cog.MakeBuildErrors("CustomPanel", err)...)
+    }
 
-	if len(errs) != 0 {
-		return dashboard.Panel{}, errs
-	}
+    if len(errs) != 0 {
+        return dashboard.Panel{}, errs
+    }
 
-	return *builder.internal, nil
+    return *builder.internal, nil
 }
 
 func (builder *CustomPanelBuilder) Title(title string) *CustomPanelBuilder {
-	builder.internal.Title = &title
+    builder.internal.Title = &title
 
-	return builder
+    return builder
 }
 
 func (builder *CustomPanelBuilder) WithTarget(targets cog.Builder[cogvariants.Dataquery]) *CustomPanelBuilder {
-	targetsResource, err := targets.Build()
-	if err != nil {
-		builder.errors["targets"] = err.(cog.BuildErrors)
-		return builder
-	}
-	builder.internal.Targets = append(builder.internal.Targets, targetsResource)
+    targetsResource, err := targets.Build()
+    if err != nil {
+        builder.errors["targets"] = err.(cog.BuildErrors)
+        return builder
+    }
+    builder.internal.Targets = append(builder.internal.Targets, targetsResource)
 
-	return builder
+    return builder
 }
 
 // [other panel options omitted for brevity]
 
 func (builder *CustomPanelBuilder) MakeBeautiful() *CustomPanelBuilder {
-	if builder.internal.Options == nil {
-		builder.internal.Options = &CustomPanelOptions{}
-	}
-	builder.internal.Options.(*CustomPanelOptions).MakeBeautiful = true
+    if builder.internal.Options == nil {
+        builder.internal.Options = &CustomPanelOptions{}
+    }
+    builder.internal.Options.(*CustomPanelOptions).MakeBeautiful = true
 
-	return builder
+    return builder
 }
 ```
 
@@ -319,42 +319,42 @@ Register the type with cog, and use it as usual to build a dashboard:
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+    "encoding/json"
+    "fmt"
 
-	"github.com/grafana/grafana-foundation-sdk/go/cog"
-	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
-	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+    "github.com/grafana/grafana-foundation-sdk/go/cog"
+    "github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
+    "github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
 func main() {
-	// Required to correctly unmarshal panels and dataqueries
-	plugins.RegisterDefaultPlugins()
+    // Required to correctly unmarshal panels and dataqueries
+    plugins.RegisterDefaultPlugins()
 
-	// This lets cog know about the newly created panel type and how to unmarshal it.
-	cog.NewRuntime().RegisterPanelcfgVariant(CustomPanelVariantConfig())
+    // This lets cog know about the newly created panel type and how to unmarshal it.
+    cog.NewRuntime().RegisterPanelcfgVariant(CustomPanelVariantConfig())
 
-	sampleDashboard, err := dashboard.NewDashboardBuilder("Custom panel type").
-		Uid("test-custom-panel").
-		Refresh("1m").
-		Time("now-30m", "now").
-		WithRow(dashboard.NewRowBuilder("Overview")).
-		WithPanel(
-			NewCustomPanelBuilder().
-				Title("Sample panel").
-				MakeBeautiful(),
-		).
-		Build()
-	if err != nil {
-		panic(err)
-	}
+    sampleDashboard, err := dashboard.NewDashboardBuilder("Custom panel type").
+        Uid("test-custom-panel").
+        Refresh("1m").
+        Time("now-30m", "now").
+        WithRow(dashboard.NewRowBuilder("Overview")).
+        WithPanel(
+            NewCustomPanelBuilder().
+                Title("Sample panel").
+                MakeBeautiful(),
+        ).
+        Build()
+    if err != nil {
+        panic(err)
+    }
 
-	dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
-	if err != nil {
-		panic(err)
-	}
+    dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
+    if err != nil {
+        panic(err)
+    }
 
-	fmt.Println(string(dashboardJson))
+    fmt.Println(string(dashboardJson))
 }
 ```
 

--- a/package_templates/go/README.md
+++ b/package_templates/go/README.md
@@ -215,6 +215,149 @@ func main() {
 }
 ```
 
+### Defining a custom panel type
+
+While the SDK ships with support for all core panels, it can be extended for
+private/third-party plugins.
+
+To do so, define a type and a builder for the custom panel's options:
+
+```go
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+type CustomPanelOptions struct {
+	MakeBeautiful bool `json:"makeBeautiful"`
+}
+
+func CustomPanelVariantConfig() cogvariants.PanelcfgConfig {
+	return cogvariants.PanelcfgConfig{
+		Identifier: "custom-panel", // plugin ID
+		OptionsUnmarshaler: func(raw []byte) (any, error) {
+			options := CustomPanelOptions{}
+
+			if err := json.Unmarshal(raw, &options); err != nil {
+				return nil, err
+			}
+
+			return options, nil
+		},
+	}
+}
+
+// Compile-time check to ensure that CustomPanelBuilder indeed is
+// a builder for a dashboard.Panel.
+var _ cog.Builder[dashboard.Panel] = (*CustomPanelBuilder)(nil)
+
+type CustomPanelBuilder struct {
+	internal *dashboard.Panel
+	errors   map[string]cog.BuildErrors
+}
+
+func NewCustomPanelBuilder() *CustomPanelBuilder {
+	return &CustomPanelBuilder{
+		internal: &dashboard.Panel{
+			Type: "custom-panel",
+		},
+		errors: make(map[string]cog.BuildErrors),
+	}
+}
+
+func (builder *CustomPanelBuilder) Build() (dashboard.Panel, error) {
+	var errs cog.BuildErrors
+
+	for _, err := range builder.errors {
+		errs = append(errs, cog.MakeBuildErrors("CustomPanel", err)...)
+	}
+
+	if len(errs) != 0 {
+		return dashboard.Panel{}, errs
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *CustomPanelBuilder) Title(title string) *CustomPanelBuilder {
+	builder.internal.Title = &title
+
+	return builder
+}
+
+func (builder *CustomPanelBuilder) WithTarget(targets cog.Builder[cogvariants.Dataquery]) *CustomPanelBuilder {
+	targetsResource, err := targets.Build()
+	if err != nil {
+		builder.errors["targets"] = err.(cog.BuildErrors)
+		return builder
+	}
+	builder.internal.Targets = append(builder.internal.Targets, targetsResource)
+
+	return builder
+}
+
+// [other panel options omitted for brevity]
+
+func (builder *CustomPanelBuilder) MakeBeautiful() *CustomPanelBuilder {
+	if builder.internal.Options == nil {
+		builder.internal.Options = &CustomPanelOptions{}
+	}
+	builder.internal.Options.(*CustomPanelOptions).MakeBeautiful = true
+
+	return builder
+}
+```
+
+Register the type with cog, and use it as usual to build a dashboard:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/grafana-foundation-sdk/go/cog"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/plugins"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+)
+
+func main() {
+	// Required to correctly unmarshal panels and dataqueries
+	plugins.RegisterDefaultPlugins()
+
+	// This lets cog know about the newly created panel type and how to unmarshal it.
+	cog.NewRuntime().RegisterPanelcfgVariant(CustomPanelVariantConfig())
+
+	sampleDashboard, err := dashboard.NewDashboardBuilder("Custom panel type").
+		Uid("test-custom-panel").
+		Refresh("1m").
+		Time("now-30m", "now").
+		WithRow(dashboard.NewRowBuilder("Overview")).
+		WithPanel(
+			NewCustomPanelBuilder().
+				Title("Sample panel").
+				MakeBeautiful(),
+		).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+
+	dashboardJson, err := json.MarshalIndent(sampleDashboard, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(dashboardJson))
+}
+```
+
 ## Maturity
 
 > [!WARNING]

--- a/package_templates/go/README.md
+++ b/package_templates/go/README.md
@@ -2,29 +2,9 @@
 
 A set of tools, types and *builder libraries* for building and manipulating Grafana objects in Go.
 
-> ℹ️ This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
+> [!NOTE]
+> This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
 > Other supported versions of Grafana can be found at [this repository's root](https://github.com/grafana/grafana-foundation-sdk/).
-
-## Maturity
-
-> _The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback on the product and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue. No SLAs are available. It is not meant to be used
-in production environments, and the risks are unknown/high._
-
-Grafana Labs defines experimental features as follows:
-
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
 
 ## Installing
 
@@ -79,6 +59,27 @@ func main() {
 	fmt.Println(string(dashboardJson))
 }
 ```
+
+## Maturity
+
+> [!WARNING]
+> The code in this repository should be considered experimental. Documentation is only
+available alongside the code. It comes with no support, but we are keen to receive
+feedback and suggestions on how to improve it, though we cannot commit
+to resolution of any particular issue.
+
+Grafana Labs defines experimental features as follows:
+
+> Projects and features in the Experimental stage are supported only by the Engineering
+teams; on-call support is not available. Documentation is either limited or not provided
+outside of code comments. No SLA is provided.
+>
+> Experimental projects or features are primarily intended for open source engineers who
+want to participate in ensuring systems stability, and to gain consensus and approval
+for open source governance projects.
+>
+> Projects and features in the Experimental phase are not meant to be used in production
+environments, and the risks are unknown/high.
 
 ## License
 

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -77,6 +77,125 @@ if __name__ == '__main__':
     print(decoded_dashboard)
 ```
 
+### Defining a custom query type
+
+While the SDK ships with support for all core datasources and their query types,
+it can be extended for private/third-party plugins.
+
+To do so, define a type and a builder for the custom query:
+
+```python
+# src/customquery.py
+from typing import Any, Optional, Self
+
+from grafana_foundation_sdk.cog import variants as cogvariants
+from grafana_foundation_sdk.cog import runtime as cogruntime
+from grafana_foundation_sdk.cog import builder
+
+
+class CustomQuery(cogvariants.Dataquery):
+    # ref_id and hide are expected on all queries
+    ref_id: Optional[str]
+    hide: Optional[bool]
+
+    # query is specific to the CustomQuery type
+    query: str
+
+    def __init__(self, query: str, ref_id: Optional[str] = None, hide: Optional[bool] = None):
+        self.query = query
+        self.ref_id = ref_id
+        self.hide = hide
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "query": self.query,
+        }
+        if self.ref_id is not None:
+            payload["refId"] = self.ref_id
+        if self.hide is not None:
+            payload["hide"] = self.hide
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        args: dict[str, Any] = {}
+
+        if "query" in data:
+            args["query"] = data["query"]
+        if "refId" in data:
+            args["ref_id"] = data["refId"]
+        if "hide" in data:
+            args["hide"] = data["hide"]
+
+        return cls(**args)
+
+
+def custom_query_variant_config() -> cogruntime.DataqueryConfig:
+    return cogruntime.DataqueryConfig(
+        # datasource plugin ID
+        identifier="custom-query",
+        from_json_hook=CustomQuery.from_json,
+    )
+
+
+class CustomQueryBuilder(builder.Builder[CustomQuery]):
+    __internal: CustomQuery
+
+    def __init__(self, query: str):
+        self.__internal = CustomQuery(query=query)
+
+    def build(self) -> CustomQuery:
+        return self.__internal
+
+    def ref_id(self, ref_id: str) -> Self:
+        self.__internal.ref_id = ref_id
+
+        return self
+
+    def hide(self, hide: bool) -> Self:
+        self.__internal.hide = hide
+
+        return self
+```
+
+Register the type with cog, and use it as usual to build a dashboard:
+
+```python
+from grafana_foundation_sdk.builders.dashboard import Dashboard, Row
+from grafana_foundation_sdk.builders.timeseries import Panel as Timeseries
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.cog.plugins import register_default_plugins
+from grafana_foundation_sdk.cog.runtime import register_dataquery_variant
+
+from src.customquery import custom_query_variant_config, CustomQueryBuilder
+
+
+if __name__ == '__main__':
+    # Required to correctly unmarshal panels and dataqueries
+    register_default_plugins()
+
+    # This lets cog know about the newly created query type and how to unmarshal it.
+    register_dataquery_variant(custom_query_variant_config())
+
+    dashboard = (
+        Dashboard("Custom query type")
+        .uid("test-custom-query")
+        .refresh("1m")
+        .time("now-30m", "now")
+
+        .with_row(Row("Overview"))
+        .with_panel(
+            Timeseries()
+            .title("Sample panel")
+            .with_target(
+                CustomQueryBuilder("query here")
+            )
+        )
+    ).build()
+
+    print(JSONEncoder(sort_keys=True, indent=2).encode(dashboard))
+```
+
 ## Maturity
 
 > [!WARNING]

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -196,6 +196,112 @@ if __name__ == '__main__':
     print(JSONEncoder(sort_keys=True, indent=2).encode(dashboard))
 ```
 
+### Defining a custom panel type
+
+While the SDK ships with support for all core panels, it can be extended for
+private/third-party plugins.
+
+To do so, define a type and a builder for the custom panel's options:
+
+```python
+# src/custompanel.py
+from typing import Any, Self
+
+from grafana_foundation_sdk.cog import builder
+from grafana_foundation_sdk.cog import runtime as cogruntime
+from grafana_foundation_sdk.models import dashboard
+
+
+class CustomPanelOptions:
+    make_beautiful: bool
+
+    def __init__(self, make_beautiful: bool = False):
+        self.make_beautiful = make_beautiful
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "makeBeautiful": self.make_beautiful,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> Self:
+        args: dict[str, Any] = {}
+
+        if "makeBeautiful" in data:
+            args["make_beautiful"] = data["makeBeautiful"]
+
+        return cls(**args)
+
+
+def custom_panel_variant_config() -> cogruntime.PanelCfgConfig:
+    return cogruntime.PanelCfgConfig(
+        # plugin ID
+        identifier="custom-panel",
+        options_from_json_hook=CustomPanelOptions.from_json,
+    )
+
+
+class CustomPanelBuilder(builder.Builder[dashboard.Panel]):
+    __internal: dashboard.Panel
+
+    def __init__(self):
+        self.__internal = dashboard.Panel()
+
+    def build(self) -> dashboard.Panel:
+        return self.__internal
+
+    def title(self, title: str) -> Self:
+        self.__internal.title = title
+        return self
+
+    # [other panel options omitted for brevity]
+
+    def make_beautiful(self) -> Self:
+        if self.__internal.options is None:
+            self.__internal.options = CustomPanelOptions()
+
+        assert isinstance(self.__internal.options, CustomPanelOptions)
+
+        self.__internal.options.make_beautiful = True
+
+        return self
+```
+
+Register the type with cog, and use it as usual to build a dashboard:
+
+```python
+from grafana_foundation_sdk.builders.dashboard import Dashboard, Row
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.cog.plugins import register_default_plugins
+from grafana_foundation_sdk.cog.runtime import register_panelcfg_variant
+
+from src.custompanel import custom_panel_variant_config, CustomPanelBuilder
+
+
+if __name__ == '__main__':
+    # Required to correctly unmarshal panels and dataqueries
+    register_default_plugins()
+
+    # This lets cog know about the newly created panel type and how to unmarshal it.
+    register_panelcfg_variant(custom_panel_variant_config())
+
+    dashboard = (
+        Dashboard("Custom panel type")
+        .uid("test-custom-panel")
+        .refresh("1m")
+        .time("now-30m", "now")
+
+        .with_row(Row("Overview"))
+        .with_panel(
+            CustomPanelBuilder()
+            .title("Sample panel")
+            .make_beautiful()
+        )
+    ).build()
+
+    print(JSONEncoder(sort_keys=True, indent=2).encode(dashboard))
+```
+
 ## Maturity
 
 > [!WARNING]

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -2,29 +2,9 @@
 
 A set of tools, types and *builder libraries* for building and manipulating Grafana objects in Python.
 
-> ℹ️ This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
+> [!NOTE]
+> This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
 > Other supported versions of Grafana can be found at [this repository's root](https://github.com/grafana/grafana-foundation-sdk/).
-
-## Maturity
-
-> _The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback on the product and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue. No SLAs are available. It is not meant to be used
-in production environments, and the risks are unknown/high._
-
-Grafana Labs defines experimental features as follows:
-
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
 
 ## Installing
 
@@ -74,6 +54,27 @@ if __name__ == '__main__':
 
     print(encoder.encode(dashboard))
 ```
+
+## Maturity
+
+> [!WARNING]
+> The code in this repository should be considered experimental. Documentation is only
+available alongside the code. It comes with no support, but we are keen to receive
+feedback and suggestions on how to improve it, though we cannot commit
+to resolution of any particular issue.
+
+Grafana Labs defines experimental features as follows:
+
+> Projects and features in the Experimental stage are supported only by the Engineering
+teams; on-call support is not available. Documentation is either limited or not provided
+outside of code comments. No SLA is provided.
+>
+> Experimental projects or features are primarily intended for open source engineers who
+want to participate in ensuring systems stability, and to gain consensus and approval
+for open source governance projects.
+>
+> Projects and features in the Experimental phase are not meant to be used in production
+environments, and the risks are unknown/high.
 
 ## License
 

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -14,6 +14,8 @@ python3 -m pip install 'grafana_foundation_sdk=={{ .Extra.BuildTimestamp }}!{{ .
 
 ## Example usage
 
+### Building a dashboard
+
 ```python
 from grafana_foundation_sdk.builders.dashboard import Dashboard, Row
 from grafana_foundation_sdk.builders.prometheus import Dataquery as PrometheusQuery
@@ -53,6 +55,26 @@ if __name__ == '__main__':
     encoder = JSONEncoder(sort_keys=True, indent=2)
 
     print(encoder.encode(dashboard))
+```
+
+### Unmarshaling a dashboard
+
+```python
+import json
+
+from grafana_foundation_sdk.cog.plugins import register_default_plugins
+from grafana_foundation_sdk.models.dashboard import Dashboard as DashboardModel
+
+
+if __name__ == '__main__':
+    # Required to correctly unmarshal panels and dataqueries
+    register_default_plugins()
+
+    decoded_dashboard = DashboardModel.from_json(
+        json.load(open("dashboard.json", "r"))
+    )
+
+    print(decoded_dashboard)
 ```
 
 ## Maturity

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -70,11 +70,9 @@ if __name__ == '__main__':
     # Required to correctly unmarshal panels and dataqueries
     register_default_plugins()
 
-    decoded_dashboard = DashboardModel.from_json(
-        json.load(open("dashboard.json", "r"))
-    )
-
-    print(decoded_dashboard)
+    with open("dashboard.json", "r") as f:
+        decoded_dashboard = DashboardModel.from_json(json.load(f))
+        print(decoded_dashboard)
 ```
 
 ### Defining a custom query type

--- a/package_templates/typescript/README.md
+++ b/package_templates/typescript/README.md
@@ -2,29 +2,9 @@
 
 A set of tools, types and *builder libraries* for building and manipulating Grafana objects in TypeScript.
 
-> ℹ️ This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
+> [!NOTE]
+> This branch contains **types and builders generated for Grafana {{ .Extra.GrafanaVersion }}.**
 > Other supported versions of Grafana can be found at [this repository's root](https://github.com/grafana/grafana-foundation-sdk/).
-
-## Maturity
-
-> _The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback on the product and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue. No SLAs are available. It is not meant to be used
-in production environments, and the risks are unknown/high._
-
-Grafana Labs defines experimental features as follows:
-
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
 
 ## Installing
 
@@ -63,6 +43,27 @@ const builder = new DashboardBuilder('[TEST] Node Exporter / Raspberry')
 
 console.log(JSON.stringify(builder.build(), null, 2));
 ```
+
+## Maturity
+
+> [!WARNING]
+> The code in this repository should be considered experimental. Documentation is only
+available alongside the code. It comes with no support, but we are keen to receive
+feedback and suggestions on how to improve it, though we cannot commit
+to resolution of any particular issue.
+
+Grafana Labs defines experimental features as follows:
+
+> Projects and features in the Experimental stage are supported only by the Engineering
+teams; on-call support is not available. Documentation is either limited or not provided
+outside of code comments. No SLA is provided.
+>
+> Experimental projects or features are primarily intended for open source engineers who
+want to participate in ensuring systems stability, and to gain consensus and approval
+for open source governance projects.
+>
+> Projects and features in the Experimental phase are not meant to be used in production
+environments, and the risks are unknown/high.
 
 ## License
 

--- a/package_templates/typescript/README.md
+++ b/package_templates/typescript/README.md
@@ -14,6 +14,8 @@ yarn add '@grafana/grafana-foundation-sdk@~{{ .Extra.GrafanaVersion|registryToSe
 
 ## Example usage
 
+### Building a dashboard
+
 ```typescript
 import { DashboardBuilder, RowBuilder } from '@grafana/grafana-foundation-sdk/dashboard';
 import { DataqueryBuilder } from '@grafana/grafana-foundation-sdk/prometheus';
@@ -40,6 +42,81 @@ const builder = new DashboardBuilder('[TEST] Node Exporter / Raspberry')
       )
   )
 ;
+
+console.log(JSON.stringify(builder.build(), null, 2));
+```
+
+### Defining a custom query type
+
+While the SDK ships with support for all core datasources and their query types,
+it can be extended for private/third-party plugins.
+
+To do so, define a type and a builder for the custom query:
+
+```typescript
+// customQuery.ts
+import { Builder, Dataquery } from '@grafana/grafana-foundation-sdk/cog';
+
+export interface CustomQuery {
+    // refId and hide are expected on all queries
+    refId?: string;
+    hide?: boolean;
+
+
+    // query is specific to the CustomQuery type
+    query: string;
+
+    // Let cog know that CustomQuery is a Dataquery variant
+    _implementsDataqueryVariant(): void;
+}
+
+export class CustomQueryBuilder implements Builder<Dataquery> {
+    private readonly internal: CustomQuery;
+
+    constructor(query: string) {
+        this.internal = {
+            query: query,
+            _implementsDataqueryVariant() {},
+        };
+    }
+
+    build(): CustomQuery {
+        return this.internal;
+    }
+
+    refId(refId: string): this {
+        this.internal.refId = refId;
+        return this;
+    }
+
+    hide(hide: boolean): this {
+        this.internal.hide = hide;
+        return this;
+    }
+}
+```
+
+The custom query type can now be used as usual to build a dashboard:
+
+```typescript
+import { DashboardBuilder, RowBuilder } from '@grafana/grafana-foundation-sdk/dashboard';
+import { PanelBuilder as TimeSeriesBuilder } from "@grafana/grafana-foundation-sdk/timeseries";
+import { CustomQueryBuilder } from "./customQuery";
+
+const builder = new DashboardBuilder('Custom query type')
+    .uid('test-custom-query-type')
+
+    .refresh('1m')
+    .time({ from: 'now-30m', to: 'now' })
+
+    .withRow(new RowBuilder('Overview'))
+    .withPanel(
+        new TimeSeriesBuilder()
+            .title('Sample panel')
+            .withTarget(
+                new CustomQueryBuilder("query here")
+            )
+    );
 
 console.log(JSON.stringify(builder.build(), null, 2));
 ```


### PR DESCRIPTION
This PR is a first pass at improving the READMEs in `grafana-foundation-sdk`.

The first commit is mostly cosmetic, while the last two add more information on the Go readme on how to deal with custom query/panel types.

I'll add the same type of examples in the Typescript and Python READMEs in other PRs.