### PR TITLE
Add a veneer to ensure that adding panels to a dashboard or a row is similar

### DIFF
--- a/config/veneers/dashboard.veneers.common.yaml
+++ b/config/veneers/dashboard.veneers.common.yaml
@@ -142,6 +142,14 @@ options:
       by_name: Dashboard.rowPanel
       as: withRow
 
+  # Append a single `panel` value instead of a list of everything
+  - array_to_append:
+      by_name: RowPanel.panels
+  # Panels() to WithPanel()
+  - rename:
+      by_name: RowPanel.panels
+      as: withPanel
+
   # Templating([]VariableModel) instead of Templating(struct []struct{List []VariableModel})
   - struct_fields_as_arguments:
       by_name: Dashboard.templating


### PR DESCRIPTION
The API to add panels to a dashboard or a row was different. This PR sets a veneer to change that.