### PR TITLE
Release jsonschema and OpenAPI specs to foundation-sdk

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -78,8 +78,8 @@ function run_codegen() {
     --language typescript \
     --python-path-prefix grafana_foundation_sdk \
     --language python \
-    #--language jsonschema \
-    #--language openapi
+    --language jsonschema \
+    --language openapi
 }
 
 function gh_run() (


### PR DESCRIPTION
Will allow us to replace grok as input for grafonnet.