### PR TITLE
Upgrade `kin-openapi` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	cuelang.org/go v0.8.1
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/getkin/kin-openapi v0.123.0
+	github.com/getkin/kin-openapi v0.124.0
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d
 	github.com/huandu/xstrings v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/emicklei/proto v1.13.0 h1:YtC/om6EdkJ0me1JPw4h2g10k+ELITjYFb7tpzm8i8k
 github.com/emicklei/proto v1.13.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/getkin/kin-openapi v0.123.0 h1:zIik0mRwFNLyvtXK274Q6ut+dPh6nlxBp0x7mNrPhs8=
-github.com/getkin/kin-openapi v0.123.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
+github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-openapi/jsonpointer v0.20.2 h1:mQc3nmndL8ZBzStEo3JYF8wzmeWffDH4VbXz58sAx6Q=
 github.com/go-openapi/jsonpointer v0.20.2/go.mod h1:bHen+N0u1KEO3YlmqOjTT9Adn1RfD91Ar825/PuiRVs=
 github.com/go-openapi/swag v0.22.8 h1:/9RjDSQ0vbFR+NyjGMkFTsA1IA0fmhKSThmfGZjicbw=

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -107,7 +107,8 @@ func (g *generator) walkDefinitions(schema *openapi3.Schema) (ast.Type, error) {
 		return g.walkEnum(schema)
 	}
 
-	switch schema.Type {
+	schemaType := getSchemaType(schema)
+	switch schemaType {
 	case openapi3.TypeString:
 		return g.walkString(schema)
 	case openapi3.TypeBoolean:
@@ -249,11 +250,12 @@ func (g *generator) walkEnum(schema *openapi3.Schema) (ast.Type, error) {
 	// Nullable enums? https://swagger.io/docs/specification/data-models/enums/
 	enums := make([]ast.EnumValue, 0, len(schema.Enum))
 	format := "%#v"
-	if schema.Type == openapi3.TypeString {
+	schemaType := getSchemaType(schema)
+	if schemaType == openapi3.TypeString {
 		format = "%s"
 	}
 
-	enumType, err := getEnumType(schema.Type)
+	enumType, err := getEnumType(schemaType)
 	if err != nil {
 		return ast.Type{}, err
 	}

--- a/internal/openapi/utils.go
+++ b/internal/openapi/utils.go
@@ -37,6 +37,7 @@ func getEnumType(t string) (ast.Type, error) {
 }
 
 func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
+	schemaType := getSchemaType(schema)
 	constraints := make([]ast.TypeConstraint, 0)
 
 	if schema.MinLength > 0 {
@@ -55,7 +56,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 	if schema.MultipleOf != nil {
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   ast.MultipleOfOp,
-			Args: getArgs(schema.MultipleOf, schema.Type),
+			Args: getArgs(schema.MultipleOf, schemaType),
 		})
 	}
 
@@ -66,7 +67,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 		}
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   op,
-			Args: getArgs(schema.Min, schema.Type),
+			Args: getArgs(schema.Min, schemaType),
 		})
 	}
 
@@ -77,7 +78,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 		}
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   op,
-			Args: getArgs(schema.Max, schema.Type),
+			Args: getArgs(schema.Max, schemaType),
 		})
 	}
 
@@ -94,4 +95,11 @@ func getArgs(v *float64, t string) []any {
 
 func isRef(ref string) bool {
 	return ref != "" && strings.ContainsAny(ref, "#")
+}
+
+func getSchemaType(schema *openapi3.Schema) string {
+	if schema.Type != nil && len(*schema.Type) == 1 {
+		return (*schema.Type)[0] // Handle multiple types?
+	}
+	return ""
 }


### PR DESCRIPTION
Supersedes https://github.com/grafana/cog/pull/309 
The type is now an array, so we should handle that