### PR TITLE
Update json marshalling of dataquery types

### DIFF
--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -315,21 +315,25 @@ dataqueryTypeHint = *resource.%[1]s.Type
 	if field.Type.IsArray() {
 		return fmt.Sprintf(`
 	%[3]s
-	%[2]s, err := cog.UnmarshalDataqueryArray(fields["%[2]s"], dataqueryTypeHint)
-	if err != nil {
-		return err
+	if fields["%[2]s"] != nil {
+		%[2]s, err := cog.UnmarshalDataqueryArray(fields["%[2]s"], dataqueryTypeHint)
+		if err != nil {
+			return err
+		}
+		resource.%[1]s = %[2]s
 	}
-	resource.%[1]s = %[2]s
 `, tools.UpperCamelCase(field.Name), field.Name, hintValue)
 	}
 
 	return fmt.Sprintf(`
 	%[3]s
-	%[2]s, err := cog.UnmarshalDataquery(fields["%[2]s"], dataqueryTypeHint)
-	if err != nil {
-		return err
+	if fields["%[2]s"] != nil {
+		%[2]s, err := cog.UnmarshalDataquery(fields["%[2]s"], dataqueryTypeHint)
+		if err != nil {
+			return err
+		}
+		resource.%[1]s = %[2]s
 	}
-	resource.%[1]s = %[2]s
 `, tools.UpperCamelCase(field.Name), field.Name, hintValue)
 }
 

--- a/testdata/jennies/rawtypes/dashboard/GoJSONMarshalling/dashboard/types_json_marshalling_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoJSONMarshalling/dashboard/types_json_marshalling_gen.go
@@ -77,11 +77,13 @@ if resource.Datasource != nil && resource.Datasource.Type != nil {
 dataqueryTypeHint = *resource.Datasource.Type
 }
 
-	targets, err := cog.UnmarshalDataqueryArray(fields["targets"], dataqueryTypeHint)
-	if err != nil {
-		return err
+	if fields["targets"] != nil {
+		targets, err := cog.UnmarshalDataqueryArray(fields["targets"], dataqueryTypeHint)
+		if err != nil {
+			return err
+		}
+		resource.Targets = targets
 	}
-	resource.Targets = targets
 
 	return nil
 }


### PR DESCRIPTION
Possible fix for https://github.com/grafana/cog/issues/328, this change adds a presence check for the field before delegating to the `UnmarshalDataquery(Array)` function. An example of this applied to the kind-registry can be found [here](https://github.com/andybradshaw/grafana-foundation-sdk/blob/a49c19b26112212583151d32828235f633ed148e/go/dashboard/types_json_marshalling_gen.go#L195-L201):

```golang
if fields["targets"] != nil {
	targets, err := cog.UnmarshalDataqueryArray(fields["targets"], dataqueryTypeHint)
	if err != nil {
		return err
	}
	resource.Targets = targets
}
```