### PR TITLE
Disable examples validation in OpenAPI parser

### DIFF
--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -41,7 +41,7 @@ func GenerateAST(filePath string, cfg Config) (*ast.Schema, error) {
 		return nil, err
 	}
 
-	if err := oapi.Validate(context.Background()); err != nil {
+	if err := oapi.Validate(context.Background(), openapi3.DisableExamplesValidation()); err != nil {
 		return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
 	}
 


### PR DESCRIPTION
Cog can't parse [Grafana's OpenAPI spec](https://github.com/grafana/grafana/blob/main/public/openapi3.json) due to invalid examples.

Since these examples aren't used for codegen purposes, this PR updates our parser to no longer validate them.