### PR TITLE
Treat empty objects with extra properties as a map in OpenAPI

### DIFF
--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -134,6 +134,19 @@ func (g *generator) walkRef(schema *openapi3.SchemaRef) (ast.Type, error) {
 }
 
 func (g *generator) walkObject(schema *openapi3.Schema) (ast.Type, error) {
+	if len(schema.Properties) == 0 {
+		if schema.AdditionalProperties.Schema == nil {
+			return ast.Any(), nil
+		}
+
+		valueType, err := g.walkSchemaRef(schema.AdditionalProperties.Schema)
+		if err != nil {
+			return ast.Type{}, err
+		}
+
+		return ast.NewMap(ast.String(), valueType), nil
+	}
+
 	fields := make([]ast.StructField, 0, len(schema.Properties))
 	for name, schemaRef := range schema.Properties {
 		def, err := g.walkSchemaRef(schemaRef)

--- a/testdata/openapi/object_no_properties/GenerateAST/ir.json
+++ b/testdata/openapi/object_no_properties/GenerateAST/ir.json
@@ -1,0 +1,61 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": {
+    "ObjectAdditionalPropertiesWithSchema": {
+      "Name": "ObjectAdditionalPropertiesWithSchema",
+      "Type": {
+        "Kind": "map",
+        "Nullable": false,
+        "Map": {
+          "IndexType": {
+            "Kind": "scalar",
+            "Nullable": false,
+            "Scalar": {
+              "ScalarKind": "string"
+            }
+          },
+          "ValueType": {
+            "Kind": "scalar",
+            "Nullable": false,
+            "Scalar": {
+              "ScalarKind": "string"
+            }
+          }
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "ObjectAdditionalPropertiesWithSchema"
+      }
+    },
+    "ObjectNoAdditionalProperties": {
+      "Name": "ObjectNoAdditionalProperties",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "any"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "ObjectNoAdditionalProperties"
+      }
+    },
+    "ObjectNoProperties": {
+      "Name": "ObjectNoProperties",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "any"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "ObjectNoProperties"
+      }
+    }
+  }
+}

--- a/testdata/openapi/object_no_properties/schema.json
+++ b/testdata/openapi/object_no_properties/schema.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "object_no_properties",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ObjectNoProperties": {
+        "type": "object"
+      },
+      "ObjectNoAdditionalProperties": {
+        "additionalProperties": false
+      },
+      "ObjectAdditionalPropertiesWithSchema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
OpenAPI objects having no properties but accepting additional ones should be treated as a map.

This PR reproduces the behavior already implemented for similar cases in our jsonschema parser: https://github.com/grafana/cog/blob/51902c4dd96e4fcfd8587cae7354d9e3a7410a5e/internal/jsonschema/generator.go#L413-L426