### PR TITLE
Fix PrefixEnumValues compiler pass to handle empty string members

### DIFF
--- a/internal/ast/compiler/prefix_enum_values.go
+++ b/internal/ast/compiler/prefix_enum_values.go
@@ -65,6 +65,10 @@ func (pass *PrefixEnumValues) processEnum(parentName string, def ast.Type) ast.T
 }
 
 func (pass *PrefixEnumValues) enumMemberNameFromValue(member ast.EnumValue) string {
+	if member.Type.Scalar.ScalarKind == ast.KindString && member.Value.(string) == "" {
+		return "None"
+	}
+
 	if member.Type.Scalar.ScalarKind != ast.KindInt64 {
 		return tools.UpperCamelCase(member.Name)
 	}

--- a/internal/ast/compiler/prefix_enum_values_test.go
+++ b/internal/ast/compiler/prefix_enum_values_test.go
@@ -51,3 +51,24 @@ func TestPrefixEnumValuesWithNegativeIntegerName(t *testing.T) {
 	// Run the compiler pass
 	runPassOnObjects(t, &PrefixEnumValues{}, objects, expected)
 }
+
+func TestPrefixEnumValuesWithEmptyStringMember(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("pkg", "BarAlignment", ast.NewEnum([]ast.EnumValue{
+			{Name: "", Value: "", Type: ast.String()},
+			{Name: "foo", Value: "foo", Type: ast.String()},
+		})),
+	}
+
+	// Prepare expected output
+	expected := []ast.Object{
+		ast.NewObject("pkg", "BarAlignment", ast.NewEnum([]ast.EnumValue{
+			{Name: "BarAlignmentNone", Value: "", Type: ast.String()},
+			{Name: "BarAlignmentFoo", Value: "foo", Type: ast.String()},
+		}), "PrefixEnumValues"),
+	}
+
+	// Run the compiler pass
+	runPassOnObjects(t, &PrefixEnumValues{}, objects, expected)
+}


### PR DESCRIPTION
Allows us to generate correct enum member names for cases like:

```json
"enum": [
  "",
  "timeseries-wide",
  "timeseries-long",
  "timeseries-many",
  "timeseries-multi",
  "directory-listing",
  "table",
  "numeric-wide",
  "numeric-multi",
  "numeric-long",
  "log-lines"
],
```