### PR TITLE
Add a FilterSchemas compiler pass

### DIFF
--- a/internal/ast/compiler/filter_schemas.go
+++ b/internal/ast/compiler/filter_schemas.go
@@ -1,0 +1,110 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
+	"github.com/grafana/cog/internal/tools"
+)
+
+var _ Pass = (*FilterSchemas)(nil)
+
+// FilterSchemas filters a schema to only include the allowed objects and their
+// dependencies.
+type FilterSchemas struct {
+	AllowedObjects []ObjectReference
+}
+
+func (pass *FilterSchemas) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	allowList := pass.buildAllowList(schemas, pass.AllowedObjects)
+
+	return tools.Map(schemas, func(schema *ast.Schema) *ast.Schema {
+		return pass.processSchema(schema, allowList)
+	}), nil
+}
+
+func (pass *FilterSchemas) processSchema(schema *ast.Schema, allowList *orderedmap.Map[string, struct{}]) *ast.Schema {
+	schema.Objects = schema.Objects.Filter(func(_ string, object ast.Object) bool {
+		return allowList.Has(object.SelfRef.String())
+	})
+
+	return schema
+}
+
+// buildAllowList returns the set of objects that should be included in the
+// processed schemas. This set is built by recursively exploring the
+// "entrypoint objects" and any object they might reference, each of these
+// references contributing to the allow list.
+func (pass *FilterSchemas) buildAllowList(schemas ast.Schemas, entrypoints []ObjectReference) *orderedmap.Map[string, struct{}] {
+	allowList := orderedmap.New[string, struct{}]()
+	rootObjects := orderedmap.New[string, ast.Object]()
+
+	for _, allowedObj := range entrypoints {
+		obj, found := schemas.LocateObject(allowedObj.Package, allowedObj.Object)
+		if !found {
+			continue
+		}
+
+		rootObjects.Set(obj.SelfRef.String(), obj)
+	}
+
+	var exploreType func(typeDef ast.Type)
+	exploreType = func(typeDef ast.Type) {
+		if typeDef.IsRef() {
+			ref := typeDef.Ref
+			referredObj, found := schemas.LocateObject(ref.ReferredPkg, ref.ReferredType)
+			if !found {
+				return
+			}
+
+			rootObjects.Set(ref.String(), referredObj)
+		}
+
+		if typeDef.IsStruct() {
+			for _, field := range typeDef.Struct.Fields {
+				exploreType(field.Type)
+			}
+		}
+
+		if typeDef.IsDisjunction() {
+			for _, branch := range typeDef.Disjunction.Branches {
+				exploreType(branch)
+			}
+		}
+
+		if typeDef.IsIntersection() {
+			for _, branch := range typeDef.Intersection.Branches {
+				exploreType(branch)
+			}
+		}
+
+		if typeDef.IsArray() {
+			exploreType(typeDef.Array.ValueType)
+		}
+
+		if typeDef.IsMap() {
+			exploreType(typeDef.Map.IndexType)
+			exploreType(typeDef.Map.ValueType)
+		}
+	}
+
+	for {
+		if rootObjects.Len() == 0 {
+			break
+		}
+
+		objects := rootObjects
+		rootObjects = orderedmap.New[string, ast.Object]()
+
+		objects.Iterate(func(key string, object ast.Object) {
+			if allowList.Has(object.SelfRef.String()) {
+				return
+			}
+
+			allowList.Set(key, struct{}{})
+
+			exploreType(object.Type)
+		})
+	}
+
+	return allowList
+}

--- a/internal/ast/compiler/filter_schemas_test.go
+++ b/internal/ast/compiler/filter_schemas_test.go
@@ -1,0 +1,114 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestFilterSchemas(t *testing.T) {
+	// Prepare test input
+	allowedObjects := []ObjectReference{
+		{Package: "team", Object: "BigTeam"},
+		{Package: "dashboard", Object: "Dashboard"},
+	}
+	schemas := ast.Schemas{
+		&ast.Schema{
+			Package: "team",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("team", "Team", ast.NewStruct(
+					ast.NewStructField("Name", ast.String()),
+				)),
+				ast.NewObject("team", "BigTeam", ast.NewStruct(
+					ast.NewStructField("BigName", ast.String()),
+				)),
+			),
+		},
+
+		&ast.Schema{
+			Package: "dashboard",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("dashboard", "Link", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Url", ast.String()),
+				)),
+				ast.NewObject("dashboard", "Variable", ast.NewStruct(
+					ast.NewStructField("Label", ast.String()),
+					ast.NewStructField("Foo", ast.String()),
+				)),
+				ast.NewObject("dashboard", "Panel", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Type", ast.String()),
+				)),
+				ast.NewObject("dashboard", "RowPanel", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Type", ast.String(ast.Value("row"))),
+					ast.NewStructField("panels", ast.NewArray(
+						ast.NewRef("dashboard", "Panel"),
+					)),
+					ast.NewStructField("links", ast.NewArray(
+						ast.NewRef("dashboard", "Link"),
+					)),
+				)),
+				ast.NewObject("dashboard", "GraphPanel", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Type", ast.String(ast.Value("graph"))),
+				)),
+				ast.NewObject("dashboard", "Dashboard", ast.NewStruct(
+					ast.NewStructField("title", ast.String()),
+					ast.NewStructField("panels", ast.NewArray(ast.NewDisjunction(ast.Types{
+						ast.NewRef("dashboard", "RowPanel"),
+						ast.NewRef("dashboard", "Panel"),
+					}))),
+				)),
+			),
+		},
+	}
+
+	// Prepare expected output
+	expected := ast.Schemas{
+		&ast.Schema{
+			Package: "team",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("team", "BigTeam", ast.NewStruct(
+					ast.NewStructField("BigName", ast.String()),
+				)),
+			),
+		},
+
+		&ast.Schema{
+			Package: "dashboard",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("dashboard", "Link", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Url", ast.String()),
+				)),
+				ast.NewObject("dashboard", "Panel", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Type", ast.String()),
+				)),
+				ast.NewObject("dashboard", "RowPanel", ast.NewStruct(
+					ast.NewStructField("Title", ast.String()),
+					ast.NewStructField("Type", ast.String(ast.Value("row"))),
+					ast.NewStructField("panels", ast.NewArray(
+						ast.NewRef("dashboard", "Panel"),
+					)),
+					ast.NewStructField("links", ast.NewArray(
+						ast.NewRef("dashboard", "Link"),
+					)),
+				)),
+				ast.NewObject("dashboard", "Dashboard", ast.NewStruct(
+					ast.NewStructField("title", ast.String()),
+					ast.NewStructField("panels", ast.NewArray(ast.NewDisjunction(ast.Types{
+						ast.NewRef("dashboard", "RowPanel"),
+						ast.NewRef("dashboard", "Panel"),
+					}))),
+				)),
+			),
+		},
+	}
+
+	// Run the compiler pass
+	runPassOnSchemas(t, &FilterSchemas{AllowedObjects: allowedObjects}, schemas, expected)
+}


### PR DESCRIPTION
In order to generate alerting-related code for the foundation-sdk, we would need to use [Grafana's OpenAPI spec](https://github.com/grafana/grafana/blob/main/public/openapi3.json) in addition to schemas from the [kind-registry](https://github.com/grafana/kind-registry/).

Not everything in that spec is relevant for alerting purposes though, so we'll need a way to easily target "entrypoint objects" for which we want to generate code.

This PR defines a compiler pass that will enable just that: given some objects, identify all their dependencies and filter out everything else.

Note: it's not used anywhere yet, that will come later :)