### PR TITLE
Parse "constant" regexes as actual constants in Jsonschema and OpenAPI

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -296,6 +296,17 @@ func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 		def.Scalar.Value = schema.Constant[0]
 	}
 
+	// to handle constant values defined as a string with a "static" regex:
+	// ```
+	// "someField": {
+	// 	  "type": "string",
+	// 	  "pattern": "^math$"
+	// }
+	// ```
+	if schema.Pattern != nil && tools.RegexMatchesConstantString(schema.Pattern.String()) {
+		def.Scalar.Value = tools.ConstantStringFromRegex(schema.Pattern.String())
+	}
+
 	if schema.MinLength != -1 {
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.MinLengthOp,

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -188,6 +188,10 @@ func (g *generator) walkString(schema *openapi3.Schema) (ast.Type, error) {
 		t = ast.String()
 	}
 
+	if schema.Pattern != "" && tools.RegexMatchesConstantString(schema.Pattern) {
+		t.Scalar.Value = tools.ConstantStringFromRegex(schema.Pattern)
+	}
+
 	t.Scalar.Constraints = getConstraints(schema)
 	t.Nullable = schema.Nullable
 	t.Default = schema.Default

--- a/internal/tools/regexp.go
+++ b/internal/tools/regexp.go
@@ -1,0 +1,23 @@
+package tools
+
+import (
+	"strings"
+)
+
+// naive way of checking if the input regex describes a constant string, or something else.
+// ex: `^math$` or `^reduce$` would return true, while `^foo[0-9]+$` wouldn't
+func RegexMatchesConstantString(regex string) bool {
+	if regex == "" {
+		return false
+	}
+
+	if regex[0] != '^' || regex[len(regex)-1] != '$' {
+		return false
+	}
+
+	return !strings.ContainsAny(regex, ".+*?()|[]{}")
+}
+
+func ConstantStringFromRegex(regex string) string {
+	return regex[1 : len(regex)-1]
+}

--- a/testdata/jsonschema/consts/GenerateAST/ir.json
+++ b/testdata/jsonschema/consts/GenerateAST/ir.json
@@ -35,6 +35,18 @@
               "Required": false
             },
             {
+              "Name": "const_disguised_as_regex",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Value": "surprise"
+                }
+              },
+              "Required": false
+            },
+            {
               "Name": "integer",
               "Type": {
                 "Kind": "scalar",

--- a/testdata/jsonschema/consts/schema.json
+++ b/testdata/jsonschema/consts/schema.json
@@ -27,6 +27,10 @@
         "boolean_with_type": {
           "type": "boolean",
           "const": true
+        },
+        "const_disguised_as_regex": {
+          "type": "string",
+          "pattern": "^surprise$"
         }
       }
     }

--- a/testdata/openapi/consts/GenerateAST/ir.json
+++ b/testdata/openapi/consts/GenerateAST/ir.json
@@ -1,0 +1,33 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": {
+    "Constants": {
+      "Name": "Constants",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "const_disguised_as_regex",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Value": "surprise"
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "Constants"
+      }
+    }
+  }
+}

--- a/testdata/openapi/consts/schema.json
+++ b/testdata/openapi/consts/schema.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "consts",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Constants": {
+        "type": "object",
+        "properties": {
+          "const_disguised_as_regex": {
+            "type": "string",
+            "pattern": "^surprise$"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some schemas choose to express constant values using a regex (see test cases). This PR introduces a bit of a hack to correctly identify these cases and parse them as actual constant scalar values in our IR.