### PR TITLE
Fix parsing of oneOf/allOf/anyOf typed as objects in jsonschema

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -112,29 +112,29 @@ func (g *generator) walkDefinition(schema *schemaparser.Schema) (ast.Type, error
 	var def ast.Type
 	var err error
 
+	if schema.Ref != nil {
+		return g.walkRef(schema)
+	}
+
+	if schema.OneOf != nil {
+		return g.walkOneOf(schema)
+	}
+
+	if schema.AnyOf != nil {
+		return g.walkAnyOf(schema)
+	}
+
+	if schema.AllOf != nil {
+		return g.walkAllOf(schema)
+	}
+
+	if schema.Enum != nil {
+		return g.walkEnum(schema)
+	}
+
 	if len(schema.Types) == 0 {
-		if schema.Ref != nil {
-			return g.walkRef(schema)
-		}
-
-		if schema.OneOf != nil {
-			return g.walkOneOf(schema)
-		}
-
-		if schema.AnyOf != nil {
-			return g.walkAnyOf(schema)
-		}
-
-		if schema.AllOf != nil {
-			return g.walkAllOf(schema)
-		}
-
 		if schema.Properties != nil || schema.PatternProperties != nil || schema.AdditionalProperties != nil {
 			return g.walkObject(schema)
-		}
-
-		if schema.Enum != nil {
-			return g.walkEnum(schema)
 		}
 
 		if len(schema.Constant) != 0 {

--- a/testdata/jsonschema/allof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/allof_object/GenerateAST/ir.json
@@ -1,7 +1,7 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "EntryPoint": "AllOf",
+  "EntryPoint": "Entry",
   "Objects": {
     "AllOf": {
       "Name": "AllOf",
@@ -54,6 +54,98 @@
       "SelfRef": {
         "ReferredPkg": "grafanatest",
         "ReferredType": "AllOf"
+      }
+    },
+    "AllOfObject": {
+      "Name": "AllOfObject",
+      "Type": {
+        "Kind": "intersection",
+        "Nullable": false,
+        "Intersection": {
+          "Branches": [
+            {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "bar",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "int64"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "foo",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "AllOfObject"
+      }
+    },
+    "Entry": {
+      "Name": "Entry",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "allOf",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "AllOf"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "allOfObj",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "AllOfObject"
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "Entry"
       }
     }
   }

--- a/testdata/jsonschema/allof_object/schema.json
+++ b/testdata/jsonschema/allof_object/schema.json
@@ -1,8 +1,44 @@
 {
-  "$ref": "#/definitions/AllOf",
+  "$ref": "#/definitions/Entry",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "allOf": {
+          "$ref": "#/definitions/AllOf"
+        },
+        "allOfObj": {
+          "$ref": "#/definitions/AllOfObject"
+        }
+      }
+    },
     "AllOf": {
+      "allOf": [
+        {
+          "properties": {
+            "bar": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "bar"
+          ]
+        },
+        {
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "foo"
+          ]
+        }
+      ]
+    },
+    "AllOfObject": {
+      "type": "object",
       "allOf": [
         {
           "properties": {

--- a/testdata/jsonschema/oneof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_object/GenerateAST/ir.json
@@ -1,8 +1,47 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
-  "EntryPoint": "OneOf",
+  "EntryPoint": "Entry",
   "Objects": {
+    "Entry": {
+      "Name": "Entry",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "oneOf",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "OneOf"
+                }
+              },
+              "Required": false
+            },
+            {
+              "Name": "oneOfObj",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "OneOfObject"
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "Entry"
+      }
+    },
     "OneOf": {
       "Name": "OneOf",
       "Type": {
@@ -30,6 +69,59 @@
       "SelfRef": {
         "ReferredPkg": "grafanatest",
         "ReferredType": "OneOf"
+      }
+    },
+    "OneOfObject": {
+      "Name": "OneOfObject",
+      "Type": {
+        "Kind": "disjunction",
+        "Nullable": false,
+        "Disjunction": {
+          "Branches": [
+            {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "bar",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "int64"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            },
+            {
+              "Kind": "struct",
+              "Nullable": false,
+              "Struct": {
+                "Fields": [
+                  {
+                    "Name": "foo",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "Required": true
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "OneOfObject"
       }
     }
   }

--- a/testdata/jsonschema/oneof_object/schema.json
+++ b/testdata/jsonschema/oneof_object/schema.json
@@ -1,7 +1,18 @@
 {
-  "$ref": "#/definitions/OneOf",
+  "$ref": "#/definitions/Entry",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "oneOf": {
+          "$ref": "#/definitions/OneOf"
+        },
+        "oneOfObj": {
+          "$ref": "#/definitions/OneOfObject"
+        }
+      }
+    },
     "OneOf": {
       "oneOf": [
         {
@@ -9,6 +20,31 @@
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "OneOfObject": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "bar": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "bar"
+          ]
+        },
+        {
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "foo"
+          ]
         }
       ]
     }


### PR DESCRIPTION
The jsonschema parser wasn't able to correctly parse oneOf/anyOf/allOf definitions that had a `"type": "object"` attribute (it would incorrectly parse them as an object with no properties).