### PR TITLE
Add a "RetypeObject" compiler pass

### DIFF
--- a/internal/ast/compiler/retype_object.go
+++ b/internal/ast/compiler/retype_object.go
@@ -1,0 +1,43 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*RetypeObject)(nil)
+
+type RetypeObject struct {
+	Object ObjectReference
+	As     ast.Type
+}
+
+func (pass *RetypeObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	for i, schema := range schemas {
+		schemas[i] = pass.processSchema(schema)
+	}
+
+	return schemas, nil
+}
+
+func (pass *RetypeObject) processSchema(schema *ast.Schema) *ast.Schema {
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		return pass.processObject(object)
+	})
+
+	return schema
+}
+
+func (pass *RetypeObject) processObject(object ast.Object) ast.Object {
+	if !pass.Object.Matches(object) {
+		return object
+	}
+
+	trailMessage := fmt.Sprintf("RetypeObject[%s → %s]", ast.TypeName(object.Type), ast.TypeName(pass.As))
+
+	object.Type = pass.As
+	object.AddToPassesTrail(trailMessage)
+
+	return object
+}

--- a/internal/ast/compiler/retype_object_test.go
+++ b/internal/ast/compiler/retype_object_test.go
@@ -1,0 +1,34 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestRetypeObject(t *testing.T) {
+	// Prepare test input
+	schema := &ast.Schema{
+		Package: "retype_object",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("retype_object", "SomeObject", ast.NewStruct(
+				ast.NewStructField("AString", ast.String()),
+			)),
+		),
+	}
+	expected := &ast.Schema{
+		Package: "retype_object",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("retype_object", "SomeObject", ast.Bool(), "RetypeObject[Struct → Bool]"),
+		),
+	}
+
+	pass := &RetypeObject{
+		Object: ObjectReference{Package: schema.Package, Object: "SomeObject"},
+		As:     ast.Bool(),
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, pass, schema, expected)
+}

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -17,6 +17,7 @@ type CompilerPass struct {
 	AddFields               *AddFields               `yaml:"add_fields"`
 	NameAnonymousStruct     *NameAnonymousStruct     `yaml:"name_anonymous_struct"`
 	RenameObject            *RenameObject            `yaml:"rename_object"`
+	RetypeObject            *RetypeObject            `yaml:"retype_object"`
 	RetypeField             *RetypeField             `yaml:"retype_field"`
 	SchemaSetIdentifier     *SchemaSetIdentifier     `yaml:"schema_set_identifier"`
 
@@ -52,6 +53,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 	}
 	if pass.NameAnonymousStruct != nil {
 		return pass.NameAnonymousStruct.AsCompilerPass()
+	}
+	if pass.RetypeObject != nil {
+		return pass.RetypeObject.AsCompilerPass()
 	}
 	if pass.RenameObject != nil {
 		return pass.RenameObject.AsCompilerPass()
@@ -201,6 +205,23 @@ func (pass NameAnonymousStruct) AsCompilerPass() (compiler.Pass, error) {
 	return &compiler.NameAnonymousStruct{
 		Field: fieldRef,
 		As:    pass.As,
+	}, nil
+}
+
+type RetypeObject struct {
+	Object string // Expected format: [package].[object]
+	As     ast.Type
+}
+
+func (pass RetypeObject) AsCompilerPass() (compiler.Pass, error) {
+	objectRef, err := compiler.ObjectReferenceFromString(pass.Object)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compiler.RetypeObject{
+		Object: objectRef,
+		As:     pass.As,
 	}, nil
 }
 


### PR DESCRIPTION
Sometimes, schemas lie to us and we need a way to fix that.