### PR TITLE
Bump santhosh-tekuri/jsonschema to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d
 	github.com/huandu/xstrings v1.4.0
-	github.com/santhosh-tekuri/jsonschema v1.2.4
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 	github.com/yalue/merged_fs v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/protocolbuffers/txtpbfmt v0.0.0-20231025115547-084445ff1adf/go.mod h1
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKPXCfD2aieJis=
-github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/jennies/common"
-	schemaparser "github.com/santhosh-tekuri/jsonschema"
+	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
-	schemaparser "github.com/santhosh-tekuri/jsonschema"
+	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 var errUndescriptiveSchema = fmt.Errorf("the schema does not appear to be describing anything")
@@ -273,7 +273,7 @@ func (g *generator) walkAllOf(schema *schemaparser.Schema) (ast.Type, error) {
 }
 
 func (g *generator) definitionNameFromRef(schema *schemaparser.Schema) string {
-	parts := strings.Split(schema.Ref.Ptr, "/")
+	parts := strings.Split(schema.Ref.Location, "/")
 
 	return parts[len(parts)-1] // Very naive
 }
@@ -346,28 +346,28 @@ func (g *generator) walkNumber(schema *schemaparser.Schema) (ast.Type, error) {
 	}
 
 	if schema.Minimum != nil {
-		value, _ := schema.Minimum.Int64()
+		value, _ := schema.Minimum.Float64()
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.GreaterThanEqualOp,
 			Args: []any{value},
 		})
 	}
 	if schema.ExclusiveMinimum != nil {
-		value, _ := schema.ExclusiveMinimum.Int64()
+		value, _ := schema.ExclusiveMinimum.Float64()
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.GreaterThanOp,
 			Args: []any{value},
 		})
 	}
 	if schema.Maximum != nil {
-		value, _ := schema.Maximum.Int64()
+		value, _ := schema.Maximum.Float64()
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.LessThanEqualOp,
 			Args: []any{value},
 		})
 	}
 	if schema.ExclusiveMaximum != nil {
-		value, _ := schema.ExclusiveMaximum.Int64()
+		value, _ := schema.ExclusiveMaximum.Float64()
 		def.Scalar.Constraints = append(def.Scalar.Constraints, ast.TypeConstraint{
 			Op:   ast.LessThanOp,
 			Args: []any{value},

--- a/internal/jsonschema/utils.go
+++ b/internal/jsonschema/utils.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	schemaparser "github.com/santhosh-tekuri/jsonschema"
+	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 func schemaComments(schema *schemaparser.Schema) []string {


### PR DESCRIPTION
We currently depend on santhosh-tekuri/jsonschema v1.2.4, while v5.3.1 is out :scream: 