### PR TITLE
Proper generation of type aliases in python

### DIFF
--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -58,7 +58,8 @@ func (formatter *typeFormatter) formatObject(def ast.Object) (string, error) {
 	case ast.KindStruct:
 		return formatter.formatStruct(def), nil
 	default:
-		buffer.WriteString(fmt.Sprintf("%s = %s", defName, formatter.formatType(def.Type)))
+		typingPkg := formatter.importPkg("typing", "typing")
+		buffer.WriteString(fmt.Sprintf("%s: %s.TypeAlias = %s", defName, typingPkg, formatter.formatType(def.Type)))
 	}
 
 	return buffer.String(), nil

--- a/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
+++ b/testdata/jennies/rawtypes/arrays/PythonRawTypes/models/arrays.py
@@ -2,7 +2,7 @@ import typing
 
 
 # List of tags, maybe?
-ArrayOfStrings = list[str]
+ArrayOfStrings: typing.TypeAlias = list[str]
 
 
 class SomeStruct:
@@ -27,10 +27,10 @@ class SomeStruct:
         return cls(**args)
 
 
-ArrayOfRefs = list['SomeStruct']
+ArrayOfRefs: typing.TypeAlias = list['SomeStruct']
 
 
-ArrayOfArrayOfNumbers = list[list[int]]
+ArrayOfArrayOfNumbers: typing.TypeAlias = list[list[int]]
 
 
 

--- a/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
+++ b/testdata/jennies/rawtypes/disjunctions/PythonRawTypes/models/disjunctions.py
@@ -2,10 +2,10 @@ import typing
 
 
 # Refresh rate or disabled.
-RefreshRate = typing.Union[str, bool]
+RefreshRate: typing.TypeAlias = typing.Union[str, bool]
 
 
-StringOrNull = typing.Optional[str]
+StringOrNull: typing.TypeAlias = typing.Optional[str]
 
 
 class SomeStruct:
@@ -33,7 +33,7 @@ class SomeStruct:
         return cls(**args)
 
 
-BoolOrRef = typing.Union[bool, 'SomeStruct']
+BoolOrRef: typing.TypeAlias = typing.Union[bool, 'SomeStruct']
 
 
 class SomeOtherStruct:
@@ -86,7 +86,7 @@ class YetAnotherStruct:
         return cls(**args)
 
 
-SeveralRefs = typing.Union['SomeStruct', 'SomeOtherStruct', 'YetAnotherStruct']
+SeveralRefs: typing.TypeAlias = typing.Union['SomeStruct', 'SomeOtherStruct', 'YetAnotherStruct']
 
 
 

--- a/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
+++ b/testdata/jennies/rawtypes/maps/PythonRawTypes/models/maps.py
@@ -2,10 +2,10 @@ import typing
 
 
 # String to... something.
-MapOfStringToAny = dict[str, object]
+MapOfStringToAny: typing.TypeAlias = dict[str, object]
 
 
-MapOfStringToString = dict[str, str]
+MapOfStringToString: typing.TypeAlias = dict[str, str]
 
 
 class SomeStruct:
@@ -30,10 +30,10 @@ class SomeStruct:
         return cls(**args)
 
 
-MapOfStringToRef = dict[str, 'SomeStruct']
+MapOfStringToRef: typing.TypeAlias = dict[str, 'SomeStruct']
 
 
-MapOfStringToMapOfStringToBool = dict[str, dict[str, bool]]
+MapOfStringToMapOfStringToBool: typing.TypeAlias = dict[str, dict[str, bool]]
 
 
 

--- a/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
+++ b/testdata/jennies/rawtypes/package-with-dashes/PythonRawTypes/models/with-dashes.py
@@ -24,7 +24,7 @@ class SomeStruct:
 
 
 # Refresh rate or disabled.
-RefreshRate = typing.Union[str, bool]
+RefreshRate: typing.TypeAlias = typing.Union[str, bool]
 
 
 

--- a/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
+++ b/testdata/jennies/rawtypes/refs/PythonRawTypes/models/refs.py
@@ -24,10 +24,10 @@ class SomeStruct:
         return cls(**args)
 
 
-RefToSomeStruct = 'SomeStruct'
+RefToSomeStruct: typing.TypeAlias = 'SomeStruct'
 
 
-RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct
+RefToSomeStructFromOtherPackage: typing.TypeAlias = otherpkg.SomeDistantStruct
 
 
 

--- a/testdata/jennies/rawtypes/scalars/PythonRawTypes/models/scalars.py
+++ b/testdata/jennies/rawtypes/scalars/PythonRawTypes/models/scalars.py
@@ -4,46 +4,46 @@ import typing
 ConstTypeString: typing.Literal["foo"] = "foo"
 
 
-ScalarTypeAny = object
+ScalarTypeAny: typing.TypeAlias = object
 
 
-ScalarTypeBool = bool
+ScalarTypeBool: typing.TypeAlias = bool
 
 
-ScalarTypeBytes = bytes
+ScalarTypeBytes: typing.TypeAlias = bytes
 
 
-ScalarTypeString = str
+ScalarTypeString: typing.TypeAlias = str
 
 
-ScalarTypeFloat32 = float
+ScalarTypeFloat32: typing.TypeAlias = float
 
 
-ScalarTypeFloat64 = float
+ScalarTypeFloat64: typing.TypeAlias = float
 
 
-ScalarTypeUint8 = int
+ScalarTypeUint8: typing.TypeAlias = int
 
 
-ScalarTypeUint16 = int
+ScalarTypeUint16: typing.TypeAlias = int
 
 
-ScalarTypeUint32 = int
+ScalarTypeUint32: typing.TypeAlias = int
 
 
-ScalarTypeUint64 = int
+ScalarTypeUint64: typing.TypeAlias = int
 
 
-ScalarTypeInt8 = int
+ScalarTypeInt8: typing.TypeAlias = int
 
 
-ScalarTypeInt16 = int
+ScalarTypeInt16: typing.TypeAlias = int
 
 
-ScalarTypeInt32 = int
+ScalarTypeInt32: typing.TypeAlias = int
 
 
-ScalarTypeInt64 = int
+ScalarTypeInt64: typing.TypeAlias = int
 
 
 


### PR DESCRIPTION
Make type alias explicitly declared in Python.

This fixes some linting errors returned by mypy when generating alerting-related code