### PR TITLE
Better identifier formatting in python

### DIFF
--- a/internal/jennies/python/tools.go
+++ b/internal/jennies/python/tools.go
@@ -50,6 +50,7 @@ func formatFieldPath(fieldPath ast.Path) string {
 }
 
 func formatIdentifier(name string) string {
+	name = strings.TrimLeft(name, "$_")
 	return tools.SnakeCase(escapeIdentifier(name))
 }
 


### PR DESCRIPTION
Some schemas describe objects with property names starting with `$` or `_`. In Python, we do not want these in the resulting code.