### PR TITLE
Support disabling OpenAPI spec validation

### DIFF
--- a/cmd/cli/loaders/openapi.go
+++ b/cmd/cli/loaders/openapi.go
@@ -21,6 +21,9 @@ type OpenAPIInput struct {
 	// from the input file name.
 	Package string `yaml:"package"`
 
+	// NoValidate disables validation of the OpenAPI spec.
+	NoValidate bool `yaml:"no_validate"`
+
 	// AllowedObjects is a list of object names that will be allowed when
 	// parsing the input schema.
 	// Note: if AllowedObjects is empty, no filter is applied.
@@ -68,6 +71,7 @@ func (input OpenAPIInput) LoadSchemas(ctx context.Context) (ast.Schemas, error) 
 	schema, err := openapi.GenerateAST(ctx, oapiSchema, openapi.Config{
 		Package:        input.packageName(),
 		SchemaMetadata: ast.SchemaMeta{}, // TODO: extract these from somewhere
+		Validate:       !input.NoValidate,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -27,6 +27,7 @@ const (
 type Config struct {
 	Package        string
 	SchemaMetadata ast.SchemaMeta
+	Validate       bool
 }
 
 type generator struct {
@@ -34,8 +35,10 @@ type generator struct {
 }
 
 func GenerateAST(ctx context.Context, oapi *openapi3.T, cfg Config) (*ast.Schema, error) {
-	if err := oapi.Validate(ctx, openapi3.DisableExamplesValidation()); err != nil {
-		return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
+	if cfg.Validate {
+		if err := oapi.Validate(ctx, openapi3.DisableExamplesValidation()); err != nil {
+			return nil, fmt.Errorf("[%s] %w", cfg.Package, err)
+		}
 	}
 
 	g := &generator{


### PR DESCRIPTION
Can be useful to ignore validation issues that wouldn't impact codegen.

Example:

```
Error: [alerting] invalid paths: operation GET /reports/render/pdf/{dashboardID} must define exactly all path parameters (missing: [DashboardID])
```