### PR TITLE
Escape identifiers in typescript

### DIFF
--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -25,8 +25,8 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
 
     .timepicker(
         new TimePickerBuilder()
-            .refresh_intervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"])
-            .time_options(["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]),
+            .refreshIntervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"])
+            .timeOptions(["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]),
     )
 
     .tooltip(DashboardCursorSync.Crosshair)

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -125,7 +125,7 @@ func (jenny *Builder) generateConstructor(builder ast.Builder) template.Construc
 
 func (jenny *Builder) generateOption(def ast.Option) template.Option {
 	return template.Option{
-		Name:        def.Name,
+		Name:        formatIdentifier(def.Name),
 		Comments:    def.Comments,
 		Args:        def.Args,
 		Assignments: tools.Map(def.Assignments, jenny.generateAssignment),
@@ -171,7 +171,7 @@ func (jenny *Builder) generateAssignment(assign ast.Assignment) template.Assignm
 
 	var constraints []template.Constraint
 	if assign.Value.Argument != nil {
-		argName := tools.LowerCamelCase(assign.Value.Argument.Name)
+		argName := formatIdentifier(assign.Value.Argument.Name)
 		constraints = jenny.constraints(argName, assign.Constraints)
 	}
 

--- a/internal/jennies/typescript/templates/args.tmpl
+++ b/internal/jennies/typescript/templates/args.tmpl
@@ -1,6 +1,6 @@
 {{- define "args" }}
     {{- range $i, $arg := . }}
         {{- if gt $i 0 }}, {{- end }}
-        {{- $arg.Name }}: {{ $arg.Type | formatType }}
+        {{- $arg.Name|formatIdentifier }}: {{ $arg.Type | formatType }}
     {{- end }}
 {{- end }}

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -47,7 +47,7 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
     {{- with .Value.Argument }}
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
         {{- $builtResultSuffix := ternary "Resources" "Resource" .Type.IsArray }}
-        const {{ .Name }}{{ $builtResultSuffix }} = {{ template "unfold_builders" (dict "InputType" .Type "InputVar" .Name "Depth" 1) }};
+        const {{ .Name|formatIdentifier }}{{ $builtResultSuffix }} = {{ template "unfold_builders" (dict "InputType" .Type "InputVar" (.Name|formatIdentifier) "Depth" 1) }};
         {{- end }}
     {{- end }}
 {{- end }}
@@ -70,9 +70,9 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
     {{- end }}
     {{- with .Value.Argument }}
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
-        {{- .Name }}{{- .Type.IsArray | ternary "Resources" "Resource" }}
+        {{- .Name|formatIdentifier }}{{- .Type.IsArray | ternary "Resources" "Resource" }}
         {{- else }}
-        {{- .Name }}
+        {{- .Name|formatIdentifier }}
         {{- end }}
     {{- end }}
     {{- with .Value.Envelope }}

--- a/internal/jennies/typescript/tmpl.go
+++ b/internal/jennies/typescript/tmpl.go
@@ -28,6 +28,7 @@ func init() {
 			"formatType": func(_ ast.Type) string {
 				panic("formatType() needs to be overridden by a jenny")
 			},
+			"formatIdentifier": formatIdentifier,
 			"typeIsDisjunctionOfBuilders": func(_ ast.Type) string {
 				panic("typeIsDisjunctionOfBuilders() needs to be overridden by a jenny")
 			},

--- a/internal/jennies/typescript/tools.go
+++ b/internal/jennies/typescript/tools.go
@@ -1,0 +1,31 @@
+package typescript
+
+import (
+	"github.com/grafana/cog/internal/tools"
+)
+
+func formatIdentifier(name string) string {
+	return tools.LowerCamelCase(escapeIdentifier(name))
+}
+
+func escapeIdentifier(name string) string {
+	if isReservedTypescriptKeyword(name) {
+		return name + "Val"
+	}
+
+	return name
+}
+
+func isReservedTypescriptKeyword(input string) bool {
+	// see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words
+	switch input {
+	case "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
+		"do", "else", "export", "extends", "false", "finally", "for", "function", "if", "import",
+		"in", "instanceof", "new", "null", "return", "super", "switch", "this", "throw", "true",
+		"try", "typeof", "var", "void", "while", "with", "let", "static", "yield", "await":
+		return true
+
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Some schemas describe objects with property names that are reserved keywords in typescript. Let's escape them.