### PR TITLE
Java: Builders

### DIFF
--- a/cmd/cli/loaders/config.go
+++ b/cmd/cli/loaders/config.go
@@ -172,7 +172,7 @@ func (config Config) OutputLanguages() (jennies.LanguageJennies, error) {
 		case output.Go != nil:
 			outputs[golang.LanguageRef] = golang.New(*output.Go)
 		case output.Java != nil:
-			outputs[java.LanguageRef] = java.New(*output.Java)
+			outputs[java.LanguageRef] = java.New()
 		case output.JSONSchema != nil:
 			outputs[jsonschema.LanguageRef] = jsonschema.New()
 		case output.OpenAPI != nil:

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -1,0 +1,177 @@
+package java
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/tools"
+)
+
+type Builders struct {
+	context       common.Context
+	typeFormatter *typeFormatter
+	builders      map[string]map[string]ast.Builder
+}
+
+func parseBuilders(context common.Context, formatter *typeFormatter) Builders {
+	b := make(map[string]map[string]ast.Builder)
+	for _, builder := range context.Builders {
+		if _, ok := b[builder.Package]; !ok {
+			b[builder.Package] = map[string]ast.Builder{}
+		}
+		b[builder.Package][builder.Name] = builder
+	}
+
+	return Builders{
+		context:       context,
+		builders:      b,
+		typeFormatter: formatter,
+	}
+}
+
+func (b Builders) genBuilder(pkg string, name string, fields []Field) (Builder, bool) {
+	builder, ok := b.getBuilder(pkg, name)
+	if !ok {
+		return Builder{}, false
+	}
+
+	object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
+	return Builder{
+		Builder: template.Builder{
+			ObjectName:  object.Name,
+			BuilderName: builder.Name,
+			Constructor: b.genConstructor(builder),
+			Options:     b.genOptions(builder.Options),
+			Properties:  builder.Properties,
+		},
+		Fields: fields,
+	}, true
+}
+
+func (b Builders) getBuilder(pkg string, name string) (ast.Builder, bool) {
+	builderMap, ok := b.builders[pkg]
+	if !ok {
+		return ast.Builder{}, false
+	}
+
+	builder, ok := builderMap[name]
+	return builder, ok
+}
+
+func (b Builders) genConstructor(builder ast.Builder) template.Constructor {
+	var argsList []ast.Argument
+	var assignmentList []template.Assignment
+	for _, opt := range builder.Options {
+		if !opt.IsConstructorArg {
+			continue
+		}
+
+		argsList = append(argsList, opt.Args[0])
+		assignmentList = append(assignmentList, b.genAssignments(opt.Assignments)...)
+	}
+
+	return template.Constructor{
+		Args:        argsList,
+		Assignments: assignmentList,
+	}
+}
+
+func (b Builders) genOptions(opts []ast.Option) []template.Option {
+	options := make([]template.Option, len(opts))
+	for i, option := range opts {
+		options[i] = template.Option{
+			Name:        tools.LowerCamelCase(option.Name),
+			Args:        b.genArgs(option.Args),
+			Assignments: b.genAssignments(option.Assignments),
+		}
+	}
+
+	return options
+}
+
+func (b Builders) genArgs(arguments []ast.Argument) []ast.Argument {
+	args := make([]ast.Argument, len(arguments))
+	for i, arg := range arguments {
+		args[i] = ast.Argument{
+			Name: tools.LowerCamelCase(arg.Name),
+			Type: arg.Type,
+		}
+	}
+
+	return args
+}
+
+func (b Builders) genAssignments(assignments []ast.Assignment) []template.Assignment {
+	assign := make([]template.Assignment, len(assignments))
+	for i, assignment := range assignments {
+		var constraints []template.Constraint
+		if assignment.Value.Argument != nil {
+			argName := escapeVarName(tools.LowerCamelCase(assignment.Value.Argument.Name))
+			constraints = b.genConstraints(argName, assignment.Constraints)
+		}
+
+		assign[i] = template.Assignment{
+			Path:           assignment.Path,
+			Method:         assignment.Method,
+			Constraints:    constraints,
+			Value:          assignment.Value,
+			InitSafeguards: b.getSafeGuards(assignment),
+		}
+	}
+
+	return assign
+}
+
+func (b Builders) genConstraints(name string, constraints []ast.TypeConstraint) []template.Constraint {
+	return tools.Map(constraints, func(t ast.TypeConstraint) template.Constraint {
+		return template.Constraint{
+			ArgName:   tools.LowerCamelCase(name),
+			Op:        t.Op,
+			Parameter: t.Args[0],
+		}
+	})
+}
+
+func (b Builders) getSafeGuards(assignment ast.Assignment) []string {
+	var initSafeGuards []string
+	for i, chunk := range assignment.Path {
+		if i == len(assignment.Path)-1 && assignment.Method != ast.AppendAssignment {
+			continue
+		}
+
+		canNullPointer := chunk.Type.IsAnyOf(ast.KindMap, ast.KindArray, ast.KindRef, ast.KindStruct) || chunk.Type.IsAny()
+
+		if !canNullPointer {
+			continue
+		}
+
+		subPath := assignment.Path[:i+1]
+		initSafeGuards = append(initSafeGuards, b.initSafeGuard(subPath))
+	}
+
+	return initSafeGuards
+}
+
+func (b Builders) initSafeGuard(path ast.Path) string {
+	parts := formatFieldPath(path)
+	valueType := path.Last().Type
+	if path.Last().TypeHint != nil {
+		valueType = *path.Last().TypeHint
+	}
+
+	emptyValue := b.typeFormatter.defaultValueFor(valueType)
+	if len(parts) == 1 {
+		return fmt.Sprintf(
+			`	if (this.%[1]s == null) {
+			this.%[1]s = %[2]s;
+		}`, tools.LowerCamelCase(parts[0]), emptyValue)
+	}
+
+	return fmt.Sprintf(
+		`	if (this.%[1]s == null) {
+			this.%[1]s = %[2]s;
+		}`, strings.Join(parts, "."), emptyValue)
+}

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -41,7 +41,7 @@ func (b Builders) genBuilder(pkg string, name string, fields []Field) (Builder, 
 	object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
 	return Builder{
 		Builder: template.Builder{
-			ObjectName:  object.Name,
+			ObjectName:  tools.UpperCamelCase(object.Name),
 			BuilderName: builder.Name,
 			Constructor: b.genConstructor(builder),
 			Options:     b.genOptions(builder.Options),

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -32,22 +32,19 @@ func parseBuilders(context common.Context, formatter *typeFormatter) Builders {
 	}
 }
 
-func (b Builders) genBuilder(pkg string, name string, fields []Field) (Builder, bool) {
+func (b Builders) genBuilder(pkg string, name string) (template.Builder, bool) {
 	builder, ok := b.getBuilder(pkg, name)
 	if !ok {
-		return Builder{}, false
+		return template.Builder{}, false
 	}
 
 	object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
-	return Builder{
-		Builder: template.Builder{
-			ObjectName:  tools.UpperCamelCase(object.Name),
-			BuilderName: builder.Name,
-			Constructor: b.genConstructor(builder),
-			Options:     b.genOptions(builder.Options),
-			Properties:  builder.Properties,
-		},
-		Fields: fields,
+	return template.Builder{
+		ObjectName:  tools.UpperCamelCase(object.Name),
+		BuilderName: builder.Name,
+		Constructor: b.genConstructor(builder),
+		Options:     b.genOptions(builder.Options),
+		Properties:  builder.Properties,
 	}, true
 }
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -37,6 +37,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
 		&compiler.AnonymousEnumToExplicitType{},
 		&compiler.AnonymousStructsToNamed{},
+		&compiler.NotRequiredFieldAsNullableType{},
 		&compiler.FlattenDisjunctions{},
 		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.DisjunctionInferMapping{},

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -9,15 +9,14 @@ import (
 const LanguageRef = "java"
 
 type Config struct {
-	GenGettersAndSetters bool `yaml:"getters_and_setters"`
 }
 
 type Language struct {
 	config Config
 }
 
-func New(config Config) *Language {
-	return &Language{config: config}
+func New() *Language {
+	return &Language{config: Config{}}
 }
 
 func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
@@ -27,7 +26,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 
 	jenny.AppendOneToMany(
 		Runtime{},
-		common.If[common.Context](globalConfig.Types, RawTypes{config: language.config}),
+		RawTypes{config: language.config},
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -26,7 +26,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 
 	jenny.AppendOneToMany(
 		Runtime{},
-		RawTypes{config: language.config},
+		RawTypes{},
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -38,6 +38,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.AnonymousEnumToExplicitType{},
 		&compiler.AnonymousStructsToNamed{},
 		&compiler.FlattenDisjunctions{},
+		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.DisjunctionInferMapping{},
 		&compiler.DisjunctionToType{},
 	}

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -155,29 +155,21 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 
 func (jenny RawTypes) formatInnerStruct(pkg string, name string, comments []string, variant string, def ast.StructType) ClassTemplate {
 	fields := make([]Field, 0)
-	nestedStructs := make([]ClassTemplate, 0)
-
 	for _, field := range def.Fields {
-		if field.Type.IsStruct() {
-			nestedStructs = append(nestedStructs, jenny.formatInnerStruct(pkg, field.Name, field.Comments, field.Type.ImplementedVariant(), field.Type.AsStruct()))
-		} else {
-			fields = append(fields, Field{
-				Name:     field.Name,
-				Type:     jenny.typeFormatter.formatFieldType(field.Type),
-				Comments: field.Comments,
-			})
-		}
+		fields = append(fields, Field{
+			Name:     field.Name,
+			Type:     jenny.typeFormatter.formatFieldType(field.Type),
+			Comments: field.Comments,
+		})
 	}
 
 	return ClassTemplate{
-		Package:              pkg,
-		Imports:              jenny.imports,
-		Name:                 tools.UpperCamelCase(name),
-		Fields:               fields,
-		InnerClasses:         nestedStructs,
-		GenGettersAndSetters: jenny.config.GenGettersAndSetters,
-		Comments:             comments,
-		Variant:              tools.UpperCamelCase(variant),
+		Package:  pkg,
+		Imports:  jenny.imports,
+		Name:     tools.UpperCamelCase(name),
+		Fields:   fields,
+		Comments: comments,
+		Variant:  tools.UpperCamelCase(variant),
 	}
 }
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -13,7 +13,6 @@ import (
 )
 
 type RawTypes struct {
-	config  Config
 	imports *common.DirectImportMap
 
 	typeFormatter *typeFormatter

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -158,7 +158,7 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 		})
 	}
 
-	builder, hasBuilder := jenny.builders.genBuilder(pkg, object.Name, fields)
+	builder, hasBuilder := jenny.builders.genBuilder(pkg, object.Name)
 
 	if err := templates.Funcs(template.FuncMap{
 		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
@@ -209,13 +209,12 @@ func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, er
 	reference := jenny.typeFormatter.formatReference(object.Type.AsRef())
 
 	if err := templates.ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
-		Package:              pkg,
-		Imports:              jenny.imports,
-		Name:                 object.Name,
-		Extends:              []string{reference},
-		ShouldHasConstructor: jenny.typeFormatter.typeHasBuilder(object.Type),
-		Comments:             object.Comments,
-		Variant:              tools.UpperCamelCase(object.Type.ImplementedVariant()),
+		Package:  pkg,
+		Imports:  jenny.imports,
+		Name:     object.Name,
+		Extends:  []string{reference},
+		Comments: object.Comments,
+		Variant:  tools.UpperCamelCase(object.Type.ImplementedVariant()),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -16,7 +16,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	jenny := RawTypes{}
-	compilerPasses := New(Config{}).CompilerPasses()
+	compilerPasses := New().CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test) {
 		req := require.New(tc)

--- a/internal/jennies/java/runtime.go
+++ b/internal/jennies/java/runtime.go
@@ -21,8 +21,14 @@ func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
 		return nil, err
 	}
 
+	builder, err := jenny.renderBuilderInterface()
+	if err != nil {
+		return nil, err
+	}
+
 	return codejen.Files{
 		*codejen.NewFile("cog/variants/Dataquery.java", variants, jenny),
+		*codejen.NewFile("cog/Builder.java", builder, jenny),
 	}, nil
 }
 
@@ -31,6 +37,15 @@ func (jenny Runtime) renderDataQueryVariant(variant string) ([]byte, error) {
 	if err := templates.ExecuteTemplate(&buf, "runtime/variants.tmpl", map[string]any{
 		"Variant": variant,
 	}); err != nil {
+		return nil, fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (jenny Runtime) renderBuilderInterface() ([]byte, error) {
+	buf := bytes.Buffer{}
+	if err := templates.ExecuteTemplate(&buf, "runtime/builder.tmpl", map[string]any{}); err != nil {
 		return nil, fmt.Errorf("failed executing template: %w", err)
 	}
 

--- a/internal/jennies/java/templates/runtime/builder.tmpl
+++ b/internal/jennies/java/templates/runtime/builder.tmpl
@@ -1,0 +1,5 @@
+package cog;
+
+public interface Builder<T> {
+    public T build();
+}

--- a/internal/jennies/java/templates/types/assigments.tmpl
+++ b/internal/jennies/java/templates/types/assigments.tmpl
@@ -1,0 +1,60 @@
+{{- define "assignment" }}
+    {{- template "constraints" .Assignment.Constraints }}
+    {{- range .Assignment.InitSafeguards }}
+    {{ . }}
+    {{- end }}
+
+    {{- template "assignment_setup" (dict "Assignment" .Assignment "Value" .Assignment.Value) }}
+
+    {{- $value := include "assignment_value" (dict "Assignment" .Assignment "Value" .Assignment.Value) -}}
+
+    {{- $preTmpl := print "pre_assignment_" .BuilderName "_" .OptionName }}
+    {{- includeIfExists $preTmpl (dict) -}}
+
+    {{- template "assignment_method" (dict "Method" .Assignment.Method "Path" .Assignment.Path "Value" $value) -}}
+
+    {{- $postTmpl := print "post_assignment_" .BuilderName "_" .OptionName }}
+    {{- includeIfExists $postTmpl (dict) -}}
+
+{{- end }}
+
+{{- define "assignment_setup" }}
+    {{- with .Value.Envelope }}
+        {{- range .Values }}
+        {{- template "assignment_setup" (dict "Assignment" $.Assignment "Value" .Value) }}
+        {{- end }}
+
+        {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
+    {{- end }}
+{{- end }}
+
+{{- define "assignment_value" }}
+    {{- if not (eq .Value.Constant nil) }}
+        {{- formatScalar .Value.Constant }}
+    {{- end }}
+    {{- with .Value.Argument }}
+        {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
+            {{- .Name | escapeVar | lowerCamelCase }}.build()
+        {{- else }}
+            {{- .Name | escapeVar | lowerCamelCase }}
+        {{- end }}
+    {{- end }}
+    {{- with .Value.Envelope }}
+        {{- .Type | formatType | lowerCamelCase }}
+    {{- end }}
+{{- end }}
+
+{{- define "value_envelope" }}
+    {{ $envelopeType := .Envelope.Type | formatType }}
+        {{- $envelopeType }} {{ $envelopeType | lowerCamelCase }} = new {{ $envelopeType }}();
+    {{- range .Envelope.Values }}
+        {{- $value := include "assignment_value" (dict "Assignment" $.Assignment "Value" .Value) }}
+        {{ $envelopeType | lowerCamelCase }}.{{ (index .Path 0).Identifier | lowerCamelCase }} = {{ $value }};
+    {{- end }}
+{{- end }}
+
+{{- define "assignment_method" }}
+    {{ $path := formatAssignmentPath .Path }}
+    {{- if eq .Method "direct" }}this.{{ $path }} = {{ .Value }};{{ end }}
+    {{- if eq .Method "append" }}this.{{ $path }}.add({{ .Value }});{{ end -}}
+{{- end }}

--- a/internal/jennies/java/templates/types/assigments.tmpl
+++ b/internal/jennies/java/templates/types/assigments.tmpl
@@ -55,6 +55,6 @@
 
 {{- define "assignment_method" }}
     {{ $path := formatAssignmentPath .Path }}
-    {{- if eq .Method "direct" }}this.{{ $path }} = {{ .Value }};{{ end }}
-    {{- if eq .Method "append" }}this.{{ $path }}.add({{ .Value }});{{ end -}}
+    {{- if eq .Method "direct" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
+    {{- if eq .Method "append" }}this.internal.{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -4,18 +4,24 @@
         public {{ .Type }} {{ .Name }};
         {{- end }}
         
+        {{- range .Properties }}
+        public {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
+        {{- end }}
+        
         public Builder({{- template "args" .Constructor.Args }}) {
-            {{- range .Constructor.Args }}
-            this.{{ .Name | escapeVar }} = {{ .Name | escapeVar }};
-            {{- end }}
+        {{- range .Constructor.Assignments }}
+            {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
+        {{- end }}
         }
         
-        {{- range .Options }}
-        public Builder set{{ .Name | camelcase }}({{- template "args" .Args }}) {
-            this.{{ .Name | escapeVar }} = {{ .Name | escapeVar }};
-            return this;
-        }
+    {{- range $opt := .Options }}
+    public Builder set{{ .Name | camelcase }}({{- template "args" .Args }}) {
+        {{- range .Assignments }}
+            {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" $opt.Name) }}
         {{- end }}
+        return this;
+    }
+    {{ end -}}
         
         public {{ .ObjectName }} build() {
             return new {{ .ObjectName }}(this);

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -1,14 +1,13 @@
 {{- define "builder" }}
     public static class Builder {
-        {{- range .Fields }}
-        public {{ .Type }} {{ .Name }};
-        {{- end }}
+        private {{ .ObjectName }} internal;
         
         {{- range .Properties }}
-        public {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
+        private {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
         {{- end }}
         
         public Builder({{- template "args" .Constructor.Args }}) {
+            this.internal = new {{ .ObjectName }}();
         {{- range .Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
         {{- end }}
@@ -24,7 +23,7 @@
     {{ end -}}
         
         public {{ .ObjectName }} build() {
-            return new {{ .ObjectName }}(this);
+            return this.internal;
         }
     }
 {{- end }}

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -1,0 +1,32 @@
+{{- define "builder" }}
+    public static class Builder {
+        {{- range .Fields }}
+        public {{ .Type }} {{ .Name }};
+        {{- end }}
+        
+        public Builder({{- template "args" .Constructor.Args }}) {
+            {{- range .Constructor.Args }}
+            this.{{ .Name | escapeVar }} = {{ .Name | escapeVar }};
+            {{- end }}
+        }
+        
+        {{- range .Options }}
+        public Builder set{{ .Name | camelcase }}({{- template "args" .Args }}) {
+            this.{{ .Name | escapeVar }} = {{ .Name | escapeVar }};
+            return this;
+        }
+        {{- end }}
+        
+        public {{ .ObjectName }} build() {
+            return new {{ .ObjectName }}(this);
+        }
+    }
+{{- end }}
+
+
+{{- define "args" }}
+    {{- range $i, $arg := . }}
+         {{- if gt $i 0 }}, {{- end }}
+         {{- $arg.Type | formatBuilderFieldType }} {{ $arg.Name | escapeVar }}
+    {{- end }}
+{{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -6,44 +6,20 @@ package {{ .Package }};
 // {{ . }}
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements cog.variants.{{ .Variant }}{{ end }} {
-    {{- template "types" dict "Fields" .Fields "GenGettersAndSetters" .GenGettersAndSetters }}
-
-    {{- range .InnerClasses }}
-    {{- template "inner_class" . }}
-    {{- end }}
+    {{- template "types" dict "Fields" .Fields }}
 }
-
-{{- define "inner_class" }}
-    {{- range .Comments }}
-    // {{ . }}
-    {{- end }}
-    class {{ .Name }} {
-        {{- template "types" dict "Fields" .Fields "GenGettersAndSetters" .GenGettersAndSetters }}
-
-        {{- range .InnerClasses }}
-        {{- template "inner_class" . }}
-        {{- end }}
-    }
-{{- end }}
-
 
 {{- define "types" }}
     {{- range .Fields }}
     {{- range .Comments }}
     // {{ . }}
     {{- end }}
-    {{ $.GenGettersAndSetters | ternary "private" "public" }} {{ .Type }} {{ .Name | escapeVar }};
+    private {{ .Type }} {{ .Name | escapeVar }};
     {{- end }}
-    {{ if .GenGettersAndSetters }}
-    {{- range .Fields }}
-    public void set{{ .Name | camelcase }}({{ .Type }} {{ .Name | escapeVar }}) {
-        this.{{ .Name | escapeVar }} = {{ .Name | escapeVar }};
-    }
-    {{ end }}
-    {{- range .Fields }}
+
+    {{ range .Fields -}}
     public {{ .Type }} get{{ .Name | camelcase }}() {
         return {{ .Name | escapeVar }};
     }
-    {{ end }}
-    {{- end }}
+    {{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -7,9 +7,15 @@ package {{ .Package }};
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements cog.variants.{{ .Variant }}{{ end }} {
     {{- template "types" dict "Fields" .Fields }}
+    
+    {{- if .ShouldHasConstructor }}
+    public {{ .Name }}(Builder builder) {
+        super(builder);
+    }
+    {{- end }}
 
-    {{ if .HasBuilder }}
-    protected {{ .Name }}(Builder builder) {
+    {{- if .HasBuilder }}
+    public {{ .Name }}(Builder builder) {
         {{- if .Extends }}
         super(builder);
         {{- else }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -7,12 +7,6 @@ package {{ .Package }};
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements cog.variants.{{ .Variant }}{{ end }} {
     {{- template "types" dict "Fields" .Fields }}
-    
-    {{- if .ShouldHasConstructor }}
-    public {{ .Name }}(Builder builder) {
-        super(builder);
-    }
-    {{- end }}
 
     {{- if .HasBuilder }}
     {{- if not .Extends }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -7,6 +7,21 @@ package {{ .Package }};
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements cog.variants.{{ .Variant }}{{ end }} {
     {{- template "types" dict "Fields" .Fields }}
+
+    {{ if .HasBuilder }}
+    protected {{ .Name }}(Builder builder) {
+        {{- if .Extends }}
+        super(builder);
+        {{- else }}
+        {{- range .Fields }}
+        this.{{ .Name | escapeVar }} = builder.{{ .Name | escapeVar }};
+        {{- end }}
+        {{- end }}
+    }
+    {{- if not .Extends }}
+    {{ template "builder" .Builder }}
+    {{- end }}
+    {{- end }}
 }
 
 {{- define "types" }}
@@ -14,12 +29,6 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- range .Comments }}
     // {{ . }}
     {{- end }}
-    private {{ .Type }} {{ .Name | escapeVar }};
+    public {{ .Type }} {{ .Name | escapeVar }};
     {{- end }}
-
-    {{ range .Fields -}}
-    public {{ .Type }} get{{ .Name | camelcase }}() {
-        return {{ .Name | escapeVar }};
-    }
-    {{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -15,15 +15,6 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- end }}
 
     {{- if .HasBuilder }}
-    public {{ .Name }}(Builder builder) {
-        {{- if .Extends }}
-        super(builder);
-        {{- else }}
-        {{- range .Fields }}
-        this.{{ .Name | escapeVar }} = builder.{{ .Name | escapeVar }};
-        {{- end }}
-        {{- end }}
-    }
     {{- if not .Extends }}
     {{ template "builder" .Builder }}
     {{- end }}

--- a/internal/jennies/java/templates/types/constraints.tmpl
+++ b/internal/jennies/java/templates/types/constraints.tmpl
@@ -1,0 +1,17 @@
+{{- define "constraints" }}
+{{- range . }}
+    {{- $leftOperand := .ArgName }}
+    {{- $operator := .Op }}
+    {{- if eq .Op "minLength" }}
+        {{- $leftOperand = print "" .ArgName ".length()" }}
+        {{- $operator = ">=" }}
+    {{- end }}
+    {{- if eq .Op "maxLength" }}
+        {{- $leftOperand = print "" .ArgName ".length()" }}
+        {{- $operator = "<=" }}
+    {{- end }}
+        if ({{ $leftOperand }} {{ $operator }} {{ .Parameter }} == false) {
+            return this;
+        }
+{{- end }}
+{{- end }}

--- a/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
+++ b/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
@@ -1,0 +1,23 @@
+{{- define "pre_assignment_Dashboard_withPanel" }}
+
+    if (panelResource.gridPos == null) {
+        panelOrRowPanel.panel.gridPos = new GridPos();
+    }
+	// Position the panel on the grid
+	panelOrRowPanel.panel.gridPos.x = this.currentX;
+	panelOrRowPanel.panel.gridPos.y = this.currentY;
+{{- end }}
+
+{{- define "post_assignment_Dashboard_withPanel" }}
+
+	// Prepare the coordinates for the next panel
+	this.currentX += panelOrRowPanel.panel.gridPos.w;
+	this.lastPanelHeight = java.lang.Math.max(this.lastPanelHeight, panelOrRowPanel.panel.gridPos.h);
+
+	// Check for grid width overflow?
+	if (this.currentX >= 24) {
+		this.currentX = 0;
+		this.currentY += this.lastPanelHeight;
+		this.lastPanelHeight = 0;
+	}
+{{- end }}

--- a/internal/jennies/java/templates/veneers/assigment_Dashboard_WithRow.tmpl
+++ b/internal/jennies/java/templates/veneers/assigment_Dashboard_WithRow.tmpl
@@ -1,0 +1,18 @@
+{{- define "pre_assignment_Dashboard_withRow" }}
+
+    // Position the row on the grid
+    GridPos gridPos = new GridPos();
+    gridPos.x = 0; // beginning of the line
+    gridPos.y = this.currentY;
+    gridPos.h = 1;
+    gridPos.w = 24; // full width
+    panelOrRowPanel.rowPanel.gridPos = gridPos;
+{{- end }}
+
+{{- define "post_assignment_Dashboard_withRow" }}
+
+    // Reset the state for the next row
+	this.currentX = 0;
+	this.currentY += panelOrRowPanel.rowPanel.gridPos.h;
+	this.lastPanelHeight = 0;
+{{- end }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -13,7 +13,7 @@ import (
 //nolint:gochecknoglobals
 var templates *template.Template
 
-//go:embed templates/runtime/*.tmpl templates/types/*.tmpl
+//go:embed templates/runtime/*.tmpl templates/types/*.tmpl templates/veneers/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -31,12 +31,21 @@ func init() {
 
 func functions() template.FuncMap {
 	return template.FuncMap{
+		"escapeVar":            escapeVarName,
+		"formatCastValue":      formatCastValue,
+		"formatScalar":         formatScalar,
+		"formatAssignmentPath": formatAssignmentPath,
 		"lastItem": func(index int, values []EnumValue) bool {
 			return len(values)-1 == index
 		},
-		"escapeVar": escapeVarName,
 		"formatBuilderFieldType": func(_ ast.Type) string {
 			panic("formatBuilderFieldType() needs to be overridden by a jenny")
+		},
+		"formatType": func(_ ast.Type) string {
+			panic("formatType() needs to be overridden by a jenny")
+		},
+		"typeHasBuilder": func(_ ast.Type) bool {
+			panic("typeHasBuilder() needs to be overridden by a jenny")
 		},
 	}
 }
@@ -55,11 +64,12 @@ type EnumValue struct {
 }
 
 type ClassTemplate struct {
-	Package  string
-	Imports  fmt.Stringer
-	Name     string
-	Extends  []string
-	Comments []string
+	Package              string
+	Imports              fmt.Stringer
+	Name                 string
+	Extends              []string
+	ShouldHasConstructor bool
+	Comments             []string
 
 	Fields     []Field
 	Builder    Builder

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -64,23 +64,17 @@ type EnumValue struct {
 }
 
 type ClassTemplate struct {
-	Package              string
-	Imports              fmt.Stringer
-	Name                 string
-	Extends              []string
-	ShouldHasConstructor bool
-	Comments             []string
+	Package  string
+	Imports  fmt.Stringer
+	Name     string
+	Extends  []string
+	Comments []string
 
 	Fields     []Field
-	Builder    Builder
+	Builder    cogtemplate.Builder
 	HasBuilder bool
 
 	Variant string
-}
-
-type Builder struct {
-	cogtemplate.Builder
-	Fields []Field
 }
 
 type Field struct {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -57,11 +57,9 @@ type ClassTemplate struct {
 	Extends  []string
 	Comments []string
 
-	Fields       []Field
-	InnerClasses []ClassTemplate
+	Fields []Field
 
-	GenGettersAndSetters bool
-	Variant              string
+	Variant string
 }
 
 type Field struct {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/grafana/cog/internal/ast"
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
 )
 
@@ -34,6 +35,9 @@ func functions() template.FuncMap {
 			return len(values)-1 == index
 		},
 		"escapeVar": escapeVarName,
+		"formatBuilderFieldType": func(_ ast.Type) string {
+			panic("formatBuilderFieldType() needs to be overridden by a jenny")
+		},
 	}
 }
 
@@ -57,9 +61,16 @@ type ClassTemplate struct {
 	Extends  []string
 	Comments []string
 
-	Fields []Field
+	Fields     []Field
+	Builder    Builder
+	HasBuilder bool
 
 	Variant string
+}
+
+type Builder struct {
+	cogtemplate.Builder
+	Fields []Field
 }
 
 type Field struct {

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -1,0 +1,13 @@
+package java
+
+import (
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
+)
+
+func formatFieldPath(fieldPath ast.Path) []string {
+	parts := tools.Map(fieldPath, func(fieldPath ast.PathItem) string {
+		return tools.UpperCamelCase(fieldPath.Identifier)
+	})
+	return parts
+}

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -1,13 +1,75 @@
 package java
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 )
 
 func formatFieldPath(fieldPath ast.Path) []string {
 	parts := tools.Map(fieldPath, func(fieldPath ast.PathItem) string {
-		return tools.UpperCamelCase(fieldPath.Identifier)
+		return tools.LowerCamelCase(fieldPath.Identifier)
 	})
 	return parts
+}
+
+type CastPath struct {
+	Class string
+	Value string
+	Path  string
+}
+
+func formatCastValue(fieldPath ast.Path) CastPath {
+	refPkg := ""
+	refType := ""
+	for _, path := range fieldPath {
+		if path.TypeHint != nil && path.TypeHint.Kind == ast.KindRef {
+			refPkg = path.TypeHint.AsRef().ReferredPkg
+			refType = path.TypeHint.AsRef().ReferredType
+		}
+	}
+
+	if refType == "" {
+		return CastPath{}
+	}
+
+	castedPath := fieldPath[0].Identifier
+	for _, p := range fieldPath[1 : len(fieldPath)-1] {
+		castedPath = fmt.Sprintf("%s.%s", castedPath, tools.LowerCamelCase(p.Identifier))
+	}
+
+	return CastPath{
+		Class: fmt.Sprintf("%s.%s", refPkg, refType),
+		Value: refType,
+		Path:  castedPath,
+	}
+}
+
+func formatScalar(val any) any {
+	newVal := fmt.Sprintf("%#v", val)
+	if len(strings.Split(newVal, ".")) > 1 {
+		return val
+	}
+	return newVal
+}
+
+func formatAssignmentPath(fieldPath ast.Path) string {
+	path := tools.LowerCamelCase(fieldPath[0].Identifier)
+
+	if len(fieldPath[1:]) == 1 && fieldPath[0].TypeHint != nil && fieldPath[0].TypeHint.Kind == ast.KindRef {
+		return tools.LowerCamelCase(path)
+	}
+
+	for i, p := range fieldPath[1:] {
+		identifier := tools.LowerCamelCase(p.Identifier)
+		if i == 0 && p.TypeHint != nil && p.TypeHint.Kind == ast.KindRef {
+			return tools.LowerCamelCase(identifier)
+		}
+
+		path = fmt.Sprintf("%s.%s", path, identifier)
+	}
+
+	return path
 }

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -528,7 +528,7 @@ func (g *generator) declareString(v cue.Value, defVal any, hints ast.JenniesHint
 func (g *generator) extractDefault(v cue.Value) (any, error) {
 	defaultVal, ok := v.Default()
 	if !ok {
-		//nolint: nilnil
+		// nolint: nilnil
 		return nil, nil
 	}
 

--- a/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
+++ b/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
@@ -2,6 +2,5 @@ package arrays;
 
 
 public class SomeStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
@@ -5,5 +5,4 @@ import java.util.List;
 public class Dashboard {
     public String title;
     public List<Panel> panels;
-    
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
@@ -4,5 +4,4 @@ package dashboard;
 public class DataSourceRef {
     public String type;
     public String uid;
-    
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfig.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfig.java
@@ -4,5 +4,4 @@ package dashboard;
 public class FieldConfig {
     public String unit;
     public Object custom;
-    
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfigSource.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfigSource.java
@@ -3,5 +3,4 @@ package dashboard;
 
 public class FieldConfigSource {
     public FieldConfig defaults;
-    
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
@@ -10,5 +10,4 @@ public class Panel {
     public Object options;
     public List<Dataquery> targets;
     public FieldConfigSource fieldConfig;
-    
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
@@ -2,5 +2,4 @@ package disjunctions;
 
 
 public class BoolOrRef extends BoolOrSomeStruct {
-    
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrSomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrSomeStruct.java
@@ -2,7 +2,6 @@ package disjunctions;
 
 
 public class BoolOrSomeStruct {
-    public Boolean Bool;
-    public SomeStruct SomeStruct;
-    
+    public Boolean bool;
+    public SomeStruct someStruct;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
@@ -3,5 +3,4 @@ package disjunctions;
 
 // Refresh rate or disabled.
 public class RefreshRate extends StringOrBool {
-    
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
@@ -2,5 +2,4 @@ package disjunctions;
 
 
 public class SeveralRefs extends SomeStructOrSomeOtherStructOrYetAnotherStruct {
-    
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
@@ -2,7 +2,6 @@ package disjunctions;
 
 
 public class SomeOtherStruct {
-    public String Type;
-    public Byte Foo;
-    
+    public String type;
+    public Byte foo;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
@@ -2,7 +2,6 @@ package disjunctions;
 
 
 public class SomeStruct {
-    public String Type;
-    public Object FieldAny;
-    
+    public String type;
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStructOrSomeOtherStructOrYetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStructOrSomeOtherStructOrYetAnotherStruct.java
@@ -2,8 +2,7 @@ package disjunctions;
 
 
 public class SomeStructOrSomeOtherStructOrYetAnotherStruct {
-    public SomeStruct SomeStruct;
-    public SomeOtherStruct SomeOtherStruct;
-    public YetAnotherStruct YetAnotherStruct;
-    
+    public SomeStruct someStruct;
+    public SomeOtherStruct someOtherStruct;
+    public YetAnotherStruct yetAnotherStruct;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrBool.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrBool.java
@@ -2,7 +2,6 @@ package disjunctions;
 
 
 public class StringOrBool {
-    public String String;
-    public Boolean Bool;
-    
+    public String string;
+    public Boolean bool;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
@@ -1,5 +1,0 @@
-package disjunctions;
-
-
-public class StringOrNull extends StringOrNull {
-}

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrNull.java
@@ -2,5 +2,4 @@ package disjunctions;
 
 
 public class StringOrNull extends StringOrNull {
-    
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
@@ -2,7 +2,6 @@ package disjunctions;
 
 
 public class YetAnotherStruct {
-    public String Type;
-    public Byte Bar;
-    
+    public String type;
+    public Byte bar;
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
@@ -6,5 +6,4 @@ public class DefaultsStructComplexField {
     public String uid;
     public DefaultsStructComplexFieldNested nested;
     public List<String> array;
-    
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
@@ -3,5 +3,4 @@ package defaults;
 
 public class DefaultsStructComplexFieldNested {
     public String nestedVal;
-    
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
@@ -4,5 +4,4 @@ package defaults;
 public class DefaultsStructPartialComplexField {
     public String uid;
     public Long intVal;
-    
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
@@ -4,5 +4,4 @@ package defaults;
 public class NestedStruct {
     public String stringVal;
     public Long intVal;
-    
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
@@ -7,5 +7,4 @@ public class Struct {
     public NestedStruct emptyFields;
     public DefaultsStructComplexField complexField;
     public DefaultsStructPartialComplexField partialComplexField;
-    
 }

--- a/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/Intersections.java
+++ b/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/Intersections.java
@@ -5,5 +5,4 @@ import externalPkg.AnotherStruct;
 public class Intersections extends SomeStruct, AnotherStruct {
     public String fieldString;
     public Integer fieldInteger;
-    
 }

--- a/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
+++ b/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
@@ -3,5 +3,4 @@ package intersections;
 
 public class SomeStruct {
     public Boolean fieldBool;
-    
 }

--- a/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
+++ b/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
@@ -2,6 +2,5 @@ package maps;
 
 
 public class SomeStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/RefreshRate.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/RefreshRate.java
@@ -3,5 +3,4 @@ package with-dashes;
 
 // Refresh rate or disabled.
 public class RefreshRate extends StringOrBool {
-    
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/SomeStruct.java
@@ -2,6 +2,5 @@ package with-dashes;
 
 
 public class SomeStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/StringOrBool.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/with-dashes/StringOrBool.java
@@ -2,7 +2,6 @@ package with-dashes;
 
 
 public class StringOrBool {
-    public String String;
-    public Boolean Bool;
-    
+    public String string;
+    public Boolean bool;
 }

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
@@ -2,5 +2,4 @@ package refs;
 
 
 public class RefToSomeStruct extends SomeStruct {
-    
 }

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStructFromOtherPackage.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStructFromOtherPackage.java
@@ -3,5 +3,4 @@ package refs;
 import otherpkg.SomeDistantStruct;
 
 public class RefToSomeStructFromOtherPackage extends SomeDistantStruct {
-    
 }

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/SomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/SomeStruct.java
@@ -2,6 +2,5 @@ package refs;
 
 
 public class SomeStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
@@ -2,6 +2,5 @@ package struct_complex_fields;
 
 
 public class SomeOtherStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -4,14 +4,13 @@ import java.util.List;
 
 // This struct does things.
 public class SomeStruct {
-    public SomeOtherStruct FieldRef;
-    public StringOrBool FieldDisjunctionOfScalars;
-    public StringOrSomeOtherStruct FieldMixedDisjunction;
-    public StringOrNull FieldDisjunctionWithNull;
-    public SomeStructOperator Operator;
-    public List<String> FieldArrayOfStrings;
-    public Map<String, String> FieldMapOfStringToString;
-    public StructComplexFieldsSomeStructFieldAnonymousStruct FieldAnonymousStruct;
+    public SomeOtherStruct fieldRef;
+    public StringOrBool fieldDisjunctionOfScalars;
+    public StringOrSomeOtherStruct fieldMixedDisjunction;
+    public StringOrNull fieldDisjunctionWithNull;
+    public SomeStructOperator operator;
+    public List<String> fieldArrayOfStrings;
+    public Map<String, String> fieldMapOfStringToString;
+    public StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
     public String fieldRefToConstant;
-    
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -7,7 +7,7 @@ public class SomeStruct {
     public SomeOtherStruct fieldRef;
     public StringOrBool fieldDisjunctionOfScalars;
     public StringOrSomeOtherStruct fieldMixedDisjunction;
-    public StringOrNull fieldDisjunctionWithNull;
+    public String fieldDisjunctionWithNull;
     public SomeStructOperator operator;
     public List<String> fieldArrayOfStrings;
     public Map<String, String> fieldMapOfStringToString;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrBool.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrBool.java
@@ -2,7 +2,6 @@ package struct_complex_fields;
 
 
 public class StringOrBool {
-    public String String;
-    public Boolean Bool;
-    
+    public String string;
+    public Boolean bool;
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrNull.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrNull.java
@@ -1,6 +1,0 @@
-package struct_complex_fields;
-
-
-public class StringOrNull {
-    public String string;
-}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrNull.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrNull.java
@@ -2,6 +2,5 @@ package struct_complex_fields;
 
 
 public class StringOrNull {
-    public String String;
-    
+    public String string;
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
@@ -2,7 +2,6 @@ package struct_complex_fields;
 
 
 public class StringOrSomeOtherStruct {
-    public String String;
-    public SomeOtherStruct SomeOtherStruct;
-    
+    public String string;
+    public SomeOtherStruct someOtherStruct;
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
@@ -2,6 +2,5 @@ package struct_complex_fields;
 
 
 public class StructComplexFieldsSomeStructFieldAnonymousStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
@@ -4,8 +4,7 @@ package defaults;
 public class SomeStruct {
     public Boolean fieldBool;
     public String fieldString;
-    public String FieldStringWithConstantValue;
-    public Float FieldFloat32;
-    public Integer FieldInt32;
-    
+    public String fieldStringWithConstantValue;
+    public Float fieldFloat32;
+    public Integer fieldInt32;
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
@@ -2,6 +2,5 @@ package struct_optional_fields;
 
 
 public class SomeOtherStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
@@ -3,10 +3,9 @@ package struct_optional_fields;
 import java.util.List;
 
 public class SomeStruct {
-    public SomeOtherStruct FieldRef;
-    public String FieldString;
-    public SomeStructOperator Operator;
-    public List<String> FieldArrayOfStrings;
-    public StructOptionalFieldsSomeStructFieldAnonymousStruct FieldAnonymousStruct;
-    
+    public SomeOtherStruct fieldRef;
+    public String fieldString;
+    public SomeStructOperator operator;
+    public List<String> fieldArrayOfStrings;
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
@@ -2,6 +2,5 @@ package struct_optional_fields;
 
 
 public class StructOptionalFieldsSomeStructFieldAnonymousStruct {
-    public Object FieldAny;
-    
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
@@ -8,20 +8,19 @@ package basic;
 public class SomeStruct {
     // Anything can go in there.
     // Really, anything.
-    public Object FieldAny;
-    public Boolean FieldBool;
-    public Byte FieldBytes;
-    public String FieldString;
-    public String FieldStringWithConstantValue;
-    public Float FieldFloat32;
-    public Double FieldFloat64;
-    public Byte FieldUint8;
-    public Short FieldUint16;
-    public Integer FieldUint32;
-    public Long FieldUint64;
-    public Byte FieldInt8;
-    public Short FieldInt16;
-    public Integer FieldInt32;
-    public Long FieldInt64;
-    
+    public Object fieldAny;
+    public Boolean fieldBool;
+    public Byte fieldBytes;
+    public String fieldString;
+    public String fieldStringWithConstantValue;
+    public Float fieldFloat32;
+    public Double fieldFloat64;
+    public Byte fieldUint8;
+    public Short fieldUint16;
+    public Integer fieldUint32;
+    public Long fieldUint64;
+    public Byte fieldInt8;
+    public Short fieldInt16;
+    public Integer fieldInt32;
+    public Long fieldInt64;
 }

--- a/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
+++ b/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
@@ -4,5 +4,4 @@ package variant_dataquery;
 public class Query implements cog.variants.Dataquery {
     public String expr;
     public Boolean instant;
-    
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
@@ -2,6 +2,5 @@ package variant_panelcfg_full;
 
 
 public class FieldConfig {
-    public String timeseries_field_config_option;
-    
+    public String timeseriesFieldConfigOption;
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
@@ -2,6 +2,5 @@ package variant_panelcfg_full;
 
 
 public class Options {
-    public String timeseries_option;
-    
+    public String timeseriesOption;
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
@@ -3,5 +3,4 @@ package variant_panelcfg_only_options;
 
 public class Options {
     public String content;
-    
 }


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cog/issues/360

Similar to this: https://github.com/grafana/cog/pull/229 but adding the builders inside the Java model as an inner class.

There is an example of the most common way to do it: [link](https://www.digitalocean.com/community/tutorials/builder-design-pattern-in-java#builder-design-pattern-in-java).

Some notes:
* Everything is public to simplify it. "Java way" uses setters and getters for this, but make it complex to do the generation.
  * It's something that we could add in the future if its a problem or/and someone complains about this.
  * GettersAndSetters flag was deleted because of this.
* It doesn't manage errors, extensions, marshalling/unmarshalling  yet.
* Panel builders aren't implemented yet. Their builders aren't inside the model since models only adds Options and/or FieldConfig.