### PR TITLE
Model builder constructors in the IR

### DIFF
--- a/config/veneers/dashboard.variables.veneers.common.yaml
+++ b/config/veneers/dashboard.variables.veneers.common.yaml
@@ -6,6 +6,9 @@ builders:
   #################
   # VariableModel #
   #################
+  - promote_options_to_constructor:
+      by_object: VariableModel
+      options: [name]
 
   - duplicate:
       by_name: VariableModel
@@ -74,11 +77,6 @@ builders:
   - omit: { by_name: VariableModel }
 
 options:
-  #################
-  # VariableModel #
-  #################
-  - promote_to_constructor: { by_name: VariableModel.name }
-
   #################
   # QueryVariable #
   #################

--- a/config/veneers/dashboard.veneers.common.yaml
+++ b/config/veneers/dashboard.veneers.common.yaml
@@ -84,13 +84,25 @@ builders:
   # No need for builders for structs generated from a disjunction
   - omit: { generated_from_disjunction: true }
 
+  ################
+  # Constructors #
+  ################
+  - promote_options_to_constructor:
+      by_object: Dashboard
+      options: [title]
+
+  - promote_options_to_constructor:
+      by_object: RowPanel
+      options: [title]
+
+  - promote_options_to_constructor:
+      by_object: DashboardLink
+      options: [title]
+
 options:
   ##############
   # Dashboards #
   ##############
-
-  # Make the dashboard constructor more friendly
-  - promote_to_constructor: { by_name: Dashboard.title }
 
   # `Tooltip` looks better than `GraphTooltip`
   - rename:
@@ -214,12 +226,3 @@ options:
 
   - omit: { by_name: RowPanel.gridPos }
 
-  # Make the constructor more friendly
-  - promote_to_constructor: { by_name: RowPanel.title }
-
-  #################
-  # DashboardLink #
-  #################
-
-  # Make the constructor more friendly
-  - promote_to_constructor: { by_name: DashboardLink.title }

--- a/config/veneers/folder.veneers.common.yaml
+++ b/config/veneers/folder.veneers.common.yaml
@@ -2,7 +2,12 @@ language: all
 
 package: folder
 
-builders: ~
+builders:
+  ################
+  # Constructors #
+  ################
+  - promote_options_to_constructor:
+      by_name: Folder
+      options: [name]
 
-options:
-  - promote_to_constructor: { by_name: Folder.title }
+options: ~

--- a/config/veneers/team.veneers.common.yaml
+++ b/config/veneers/team.veneers.common.yaml
@@ -2,8 +2,12 @@ language: all
 
 package: team
 
-builders: ~
+builders:
+  ################
+  # Constructors #
+  ################
+  - promote_options_to_constructor:
+      by_name: Team
+      options: [name]
 
-options:
-  # Make the constructor more friendly
-  - promote_to_constructor: { by_name: Team.name }
+options: ~

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -164,25 +164,9 @@ func (jenny *Builder) formatDefaultTypedArgs(context common.Context, opt ast.Opt
 }
 
 func (jenny *Builder) generateConstructor(builder ast.Builder) template.Constructor {
-	var argsList []ast.Argument
-	var assignmentList []template.Assignment
-	for _, opt := range builder.Options {
-		if !opt.IsConstructorArg {
-			continue
-		}
-
-		// FIXME: this is assuming that there's only one argument for that option
-		argsList = append(argsList, opt.Args[0])
-		assignmentList = append(assignmentList, jenny.generateAssignment(opt.Assignments[0]))
-	}
-
-	for _, init := range builder.Initializations {
-		assignmentList = append(assignmentList, jenny.generateAssignment(init))
-	}
-
 	return template.Constructor{
-		Args:        argsList,
-		Assignments: assignmentList,
+		Args:        builder.Constructor.Args,
+		Assignments: tools.Map(builder.Constructor.Assignments, jenny.generateAssignment),
 	}
 }
 

--- a/internal/jennies/python/builder.go
+++ b/internal/jennies/python/builder.go
@@ -118,25 +118,11 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 }
 
 func (jenny *Builder) generateConstructor(context common.Context, builder ast.Builder) template.Constructor {
-	var argsList []ast.Argument
-	var assignments []template.Assignment
-	for _, opt := range builder.Options {
-		if !opt.IsConstructorArg {
-			continue
-		}
-
-		// FIXME: this is assuming that there's only one argument for that option
-		argsList = append(argsList, opt.Args[0])
-		assignments = append(assignments, jenny.generateAssignment(context, opt.Assignments[0]))
-	}
-
-	for _, init := range builder.Initializations {
-		assignments = append(assignments, jenny.generateAssignment(context, init))
-	}
-
 	return template.Constructor{
-		Args:        argsList,
-		Assignments: assignments,
+		Args: builder.Constructor.Args,
+		Assignments: tools.Map(builder.Constructor.Assignments, func(assignment ast.Assignment) template.Assignment {
+			return jenny.generateAssignment(context, assignment)
+		}),
 	}
 }
 

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -101,25 +101,9 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 }
 
 func (jenny *Builder) generateConstructor(builder ast.Builder) template.Constructor {
-	var argsList []ast.Argument
-	var assignments []template.Assignment
-	for _, opt := range builder.Options {
-		if !opt.IsConstructorArg {
-			continue
-		}
-
-		// FIXME: this is assuming that there's only one argument for that option
-		argsList = append(argsList, opt.Args[0])
-		assignments = append(assignments, jenny.generateAssignment(opt.Assignments[0]))
-	}
-
-	for _, init := range builder.Initializations {
-		assignments = append(assignments, jenny.generateAssignment(init))
-	}
-
 	return template.Constructor{
-		Args:        argsList,
-		Assignments: assignments,
+		Args:        builder.Constructor.Args,
+		Assignments: tools.Map(builder.Constructor.Assignments, jenny.generateAssignment),
 	}
 }
 

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -101,18 +101,6 @@ func VeneerTrailAsCommentsAction() RewriteAction {
 	}
 }
 
-// PromoteToConstructorAction flag the arguments of the given option as "constructor arguments".
-// This flag indicates builder jennies that the arguments and assignments described by this option
-// should be exposed by the builder's constructor.
-func PromoteToConstructorAction() RewriteAction {
-	return func(_ ast.Builder, option ast.Option) []ast.Option {
-		option.IsConstructorArg = true
-		option.AddToVeneerTrail("PromoteToConstructor")
-
-		return []ast.Option{option}
-	}
-}
-
 // StructFieldsAsArgumentsAction uses the fields of the first argument's struct (assuming it is one) and turns them
 // into arguments.
 //

--- a/internal/veneers/option/actions_test.go
+++ b/internal/veneers/option/actions_test.go
@@ -27,16 +27,6 @@ func TestOmitAction(t *testing.T) {
 	req.Empty(modifiedOpts)
 }
 
-func TestPromoteToConstructorAction(t *testing.T) {
-	req := require.New(t)
-
-	option := ast.Option{Name: "Name", IsConstructorArg: false}
-	modifiedOpts := PromoteToConstructorAction()(ast.Builder{}, option)
-
-	req.Len(modifiedOpts, 1)
-	req.True(modifiedOpts[0].IsConstructorArg)
-}
-
 func TestUnfoldBooleanAction(t *testing.T) {
 	req := require.New(t)
 

--- a/internal/veneers/option/rules.go
+++ b/internal/veneers/option/rules.go
@@ -40,13 +40,6 @@ func UnfoldBoolean(selector Selector, unfoldOpts BooleanUnfold) RewriteRule {
 	}
 }
 
-func PromoteToConstructor(selector Selector) RewriteRule {
-	return RewriteRule{
-		Selector: selector,
-		Action:   PromoteToConstructorAction(),
-	}
-}
-
 func StructFieldsAsArguments(selector Selector, explicitFields ...string) RewriteRule {
 	return RewriteRule{
 		Selector: selector,

--- a/internal/yaml/option.go
+++ b/internal/yaml/option.go
@@ -13,7 +13,6 @@ import (
 
 type OptionRule struct {
 	Omit                    *OptionSelector          `yaml:"omit"`
-	PromoteToConstructor    *OptionSelector          `yaml:"promote_to_constructor"`
 	Rename                  *RenameOption            `yaml:"rename"`
 	UnfoldBoolean           *UnfoldBoolean           `yaml:"unfold_boolean"`
 	StructFieldsAsArguments *StructFieldsAsArguments `yaml:"struct_fields_as_arguments"`
@@ -31,15 +30,6 @@ func (rule OptionRule) AsRewriteRule(pkg string) (option.RewriteRule, error) {
 		}
 
 		return option.Omit(selector), nil
-	}
-
-	if rule.PromoteToConstructor != nil {
-		selector, err := rule.PromoteToConstructor.AsSelector(pkg)
-		if err != nil {
-			return option.RewriteRule{}, err
-		}
-
-		return option.PromoteToConstructor(selector), nil
 	}
 
 	if rule.Rename != nil {

--- a/testdata/jennies/builders/constructor_argument/builders_context.json
+++ b/testdata/jennies/builders/constructor_argument/builders_context.json
@@ -95,6 +95,49 @@
       },
       "Package": "sandbox",
       "Name": "SomeStruct",
+      "Constructor": {
+        "Args": [
+          {
+            "Name": "title",
+            "Type": {
+              "Kind": "scalar",
+              "Nullable": false,
+              "Scalar": {
+                "ScalarKind": "string"
+              }
+            }
+          }
+        ],
+        "Assignments": [
+          {
+            "Path": [
+              {
+                "Identifier": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                }
+              }
+            ],
+            "Value": {
+              "Argument": {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                }
+              }
+            },
+            "Method": "direct"
+          }
+        ]
+      },
       "Options": [
         {
           "Name": "title",
@@ -138,8 +181,7 @@
               },
               "Method": "direct"
             }
-          ],
-          "IsConstructorArg": true
+          ]
         }
       ]
     }

--- a/testdata/jennies/builders/constructor_initializations/builders_context.json
+++ b/testdata/jennies/builders/constructor_initializations/builders_context.json
@@ -211,46 +211,48 @@
       },
       "Package": "constructor_initializations",
       "Name": "SomePanel",
-      "Initializations": [
-        {
-          "Path": [
-            {
-              "Identifier": "type",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string",
-                  "Value": "panel_type"
+      "Constructor": {
+        "Assignments": [
+          {
+            "Path": [
+              {
+                "Identifier": "type",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string",
+                    "Value": "panel_type"
+                  }
                 }
               }
-            }
-          ],
-          "Value": {
-            "Constant": "panel_type"
+            ],
+            "Value": {
+              "Constant": "panel_type"
+            },
+            "Method": "direct"
           },
-          "Method": "direct"
-        },
-        {
-          "Path": [
-            {
-              "Identifier": "cursor",
-              "Type": {
-                "Kind": "ref",
-                "Nullable": false,
-                "Ref": {
-                  "ReferredPkg": "constructor_initializations",
-                  "ReferredType": "CursorMode"
+          {
+            "Path": [
+              {
+                "Identifier": "cursor",
+                "Type": {
+                  "Kind": "ref",
+                  "Nullable": false,
+                  "Ref": {
+                    "ReferredPkg": "constructor_initializations",
+                    "ReferredType": "CursorMode"
+                  }
                 }
               }
-            }
-          ],
-          "Value": {
-            "Constant": "tooltip"
-          },
-          "Method": "direct"
-        }
-      ],
+            ],
+            "Value": {
+              "Constant": "tooltip"
+            },
+            "Method": "direct"
+          }
+        ]
+      },
       "Options": [
         {
           "Name": "title",


### PR DESCRIPTION
The code dealing with options being "promoted" as constructor arguments had to be duplicated in every jenny that generates builders.

To try and lessen a bit the amount of work we have to do when writing/maintaining jennies, this PR models builder constructors and their arguments in the IR.

The complexity is moved one step up the codegen chain, where it's implemented once and used transparently by all jennies.