### PR TITLE
Better representation of constraints in the builder IR

### DIFF
--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -239,16 +239,10 @@ func (jenny *Builder) generateAssignment(assignment ast.Assignment) template.Ass
 		}
 	}
 
-	var constraints []template.Constraint
-	if assignment.Value.Argument != nil {
-		argName := escapeVarName(tools.LowerCamelCase(assignment.Value.Argument.Name))
-		constraints = jenny.constraints(argName, assignment.Constraints)
-	}
-
 	return template.Assignment{
 		Path:           assignment.Path,
 		InitSafeguards: initSafeGuards,
-		Constraints:    constraints,
+		Constraints:    assignment.Constraints,
 		Method:         assignment.Method,
 		Value:          assignment.Value,
 	}
@@ -268,16 +262,6 @@ func (jenny *Builder) emptyValueForType(typeDef ast.Type) string {
 	}
 }
 
-func (jenny *Builder) constraints(argumentName string, constraints []ast.TypeConstraint) []template.Constraint {
-	return tools.Map(constraints, func(constraint ast.TypeConstraint) template.Constraint {
-		return template.Constraint{
-			ArgName:   argumentName,
-			Op:        constraint.Op,
-			Parameter: constraint.Args[0],
-		}
-	})
-}
-
 // importType declares an import statement for the type definition of
 // the given object and returns a fully qualified type name for it.
 func (jenny *Builder) importType(typeRef ast.RefType) string {
@@ -288,42 +272,4 @@ func (jenny *Builder) importType(typeRef ast.RefType) string {
 	}
 
 	return fmt.Sprintf("%s.%s", pkg, typeName)
-}
-
-func escapeVarName(varName string) string {
-	if isReservedGoKeyword(varName) {
-		return varName + "Arg"
-	}
-
-	return varName
-}
-
-func isReservedGoKeyword(input string) bool {
-	// see: https://go.dev/ref/spec#Keywords
-	return input == "break" ||
-		input == "case" ||
-		input == "chan" ||
-		input == "continue" ||
-		input == "const" ||
-		input == "default" ||
-		input == "defer" ||
-		input == "else" ||
-		input == "error" ||
-		input == "fallthrough" ||
-		input == "for" ||
-		input == "func" ||
-		input == "go" ||
-		input == "goto" ||
-		input == "if" ||
-		input == "import" ||
-		input == "interface" ||
-		input == "map" ||
-		input == "package" ||
-		input == "range" ||
-		input == "return" ||
-		input == "select" ||
-		input == "struct" ||
-		input == "switch" ||
-		input == "type" ||
-		input == "var"
 }

--- a/internal/jennies/golang/templates/builders/constraints.tmpl
+++ b/internal/jennies/golang/templates/builders/constraints.tmpl
@@ -1,17 +1,18 @@
 {{- define "constraints" }}
 {{- range . }}
-    {{- $leftOperand := .ArgName }}
+    {{- $argName := .Argument.Name|formatArgName }}
+    {{- $leftOperand := $argName }}
     {{- $operator := .Op }}
     {{- if eq .Op "minLength" }}
-        {{- $leftOperand = print "len([]rune(" .ArgName "))" }}
+        {{- $leftOperand = print "len([]rune(" $leftOperand "))" }}
         {{- $operator = ">=" }}
     {{- end }}
     {{- if eq .Op "maxLength" }}
-        {{- $leftOperand = print "len([]rune(" .ArgName "))" }}
+        {{- $leftOperand = print "len([]rune(" $leftOperand "))" }}
         {{- $operator = "<=" }}
     {{- end }}
     if !({{ $leftOperand }} {{ $operator }} {{ .Parameter }}) {
-        builder.errors["{{ .ArgName }}"] = cog.MakeBuildErrors("{{ .ArgName }}", errors.New("{{ $leftOperand }} must be {{ $operator }} {{ .Parameter }}"))
+        builder.errors["{{ $argName }}"] = cog.MakeBuildErrors("{{ $argName }}", errors.New("{{ $leftOperand }} must be {{ $operator }} {{ .Parameter }}"))
         return builder
     }
 {{- end }}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/grafana/cog/internal/ast"
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
-	"github.com/grafana/cog/internal/tools"
 )
 
 //nolint:gochecknoglobals
@@ -41,9 +40,7 @@ func init() {
 		Funcs(map[string]any{
 			"formatPackageName": formatPackageName,
 			"formatScalar":      formatScalar,
-			"formatArgName": func(name string) string {
-				return escapeVarName(tools.LowerCamelCase(name))
-			},
+			"formatArgName":     formatArgName,
 			"maybeAsPointer": func(intoType ast.Type, variableName string) string {
 				if intoType.Nullable && !(intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot()) {
 					return "&" + variableName

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -1,0 +1,56 @@
+package golang
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/grafana/cog/internal/tools"
+)
+
+func formatPackageName(pkg string) string {
+	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
+
+	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
+}
+
+func formatArgName(name string) string {
+	return escapeVarName(tools.LowerCamelCase(name))
+}
+
+func escapeVarName(varName string) string {
+	if isReservedGoKeyword(varName) {
+		return varName + "Arg"
+	}
+
+	return varName
+}
+
+func isReservedGoKeyword(input string) bool {
+	// see: https://go.dev/ref/spec#Keywords
+	return input == "break" ||
+		input == "case" ||
+		input == "chan" ||
+		input == "continue" ||
+		input == "const" ||
+		input == "default" ||
+		input == "defer" ||
+		input == "else" ||
+		input == "error" ||
+		input == "fallthrough" ||
+		input == "for" ||
+		input == "func" ||
+		input == "go" ||
+		input == "goto" ||
+		input == "if" ||
+		input == "import" ||
+		input == "interface" ||
+		input == "map" ||
+		input == "package" ||
+		input == "range" ||
+		input == "return" ||
+		input == "select" ||
+		input == "struct" ||
+		input == "switch" ||
+		input == "type" ||
+		input == "var"
+}

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
@@ -345,10 +344,4 @@ func (formatter *typeFormatter) formatIntersection(def ast.IntersectionType) str
 	buffer.WriteString("}")
 
 	return buffer.String()
-}
-
-func formatPackageName(pkg string) string {
-	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
-
-	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
 }

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -91,29 +91,13 @@ func (b Builders) genArgs(arguments []ast.Argument) []ast.Argument {
 }
 
 func (b Builders) genAssignment(assignment ast.Assignment) template.Assignment {
-	var constraints []template.Constraint
-	if assignment.Value.Argument != nil {
-		argName := escapeVarName(tools.LowerCamelCase(assignment.Value.Argument.Name))
-		constraints = b.genConstraints(argName, assignment.Constraints)
-	}
-
 	return template.Assignment{
 		Path:           assignment.Path,
 		Method:         assignment.Method,
-		Constraints:    constraints,
+		Constraints:    assignment.Constraints,
 		Value:          assignment.Value,
 		InitSafeguards: b.getSafeGuards(assignment),
 	}
-}
-
-func (b Builders) genConstraints(name string, constraints []ast.TypeConstraint) []template.Constraint {
-	return tools.Map(constraints, func(t ast.TypeConstraint) template.Constraint {
-		return template.Constraint{
-			ArgName:   tools.LowerCamelCase(name),
-			Op:        t.Op,
-			Parameter: t.Args[0],
-		}
-	})
 }
 
 func (b Builders) getSafeGuards(assignment ast.Assignment) []string {

--- a/internal/jennies/java/templates/types/constraints.tmpl
+++ b/internal/jennies/java/templates/types/constraints.tmpl
@@ -1,16 +1,16 @@
 {{- define "constraints" }}
 {{- range . }}
-    {{- $leftOperand := .ArgName }}
+    {{- $leftOperand := .Argument.Name }}
     {{- $operator := .Op }}
     {{- if eq .Op "minLength" }}
-        {{- $leftOperand = print "" .ArgName ".length()" }}
+        {{- $leftOperand = print $leftOperand ".length()" }}
         {{- $operator = ">=" }}
     {{- end }}
     {{- if eq .Op "maxLength" }}
-        {{- $leftOperand = print "" .ArgName ".length()" }}
+        {{- $leftOperand = print $leftOperand ".length()" }}
         {{- $operator = "<=" }}
     {{- end }}
-        if ({{ $leftOperand }} {{ $operator }} {{ .Parameter }} == false) {
+        if ({{ $leftOperand }} {{ $operator }} {{ .Parameter }}) {
             return this;
         }
 {{- end }}

--- a/internal/jennies/python/builder.go
+++ b/internal/jennies/python/builder.go
@@ -189,26 +189,11 @@ func (jenny *Builder) generateAssignment(context common.Context, assignment ast.
 		initSafeGuards = append(initSafeGuards, jenny.generatePathInitializationSafeGuard(context, subPath))
 	}
 
-	var constraints []template.Constraint
-	if assignment.Value.Argument != nil {
-		constraints = jenny.constraints(assignment.Value.Argument.Name, assignment.Constraints)
-	}
-
 	return template.Assignment{
 		Path:           assignment.Path,
 		InitSafeguards: initSafeGuards,
-		Constraints:    constraints,
+		Constraints:    assignment.Constraints,
 		Method:         assignment.Method,
 		Value:          assignment.Value,
 	}
-}
-
-func (jenny *Builder) constraints(argumentName string, constraints []ast.TypeConstraint) []template.Constraint {
-	return tools.Map(constraints, func(constraint ast.TypeConstraint) template.Constraint {
-		return template.Constraint{
-			ArgName:   argumentName,
-			Op:        constraint.Op,
-			Parameter: constraint.Args[0],
-		}
-	})
 }

--- a/internal/jennies/python/templates/builders/constraints.tmpl
+++ b/internal/jennies/python/templates/builders/constraints.tmpl
@@ -1,6 +1,6 @@
 {{- define "constraints" }}
 {{- range . }}
-{{- $leftOperand := .ArgName|formatIdentifier }}
+{{- $leftOperand := .Argument.Name|formatIdentifier }}
 {{- $operator := .Op }}
 {{- if eq .Op "minLength" }}
     {{- $leftOperand = print "len(" $leftOperand ")" }}

--- a/internal/jennies/template/models.go
+++ b/internal/jennies/template/models.go
@@ -35,15 +35,9 @@ type Option struct {
 type Assignment struct {
 	Path           ast.Path
 	InitSafeguards []string
-	Constraints    []Constraint
+	Constraints    []ast.AssignmentConstraint
 	Method         ast.AssignmentMethod
 	Value          ast.AssignmentValue
-}
-
-type Constraint struct {
-	ArgName   string
-	Op        ast.Op
-	Parameter any
 }
 
 type OptionCall struct {

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -153,29 +153,13 @@ func (jenny *Builder) generateAssignment(assign ast.Assignment) template.Assignm
 		initSafeGuards = append(initSafeGuards, jenny.generatePathInitializationSafeGuard(subPath))
 	}
 
-	var constraints []template.Constraint
-	if assign.Value.Argument != nil {
-		argName := formatIdentifier(assign.Value.Argument.Name)
-		constraints = jenny.constraints(argName, assign.Constraints)
-	}
-
 	return template.Assignment{
 		Path:           assign.Path,
 		InitSafeguards: initSafeGuards,
-		Constraints:    constraints,
+		Constraints:    assign.Constraints,
 		Method:         assign.Method,
 		Value:          assign.Value,
 	}
-}
-
-func (jenny *Builder) constraints(argumentName string, constraints []ast.TypeConstraint) []template.Constraint {
-	return tools.Map(constraints, func(constraint ast.TypeConstraint) template.Constraint {
-		return template.Constraint{
-			ArgName:   argumentName,
-			Op:        constraint.Op,
-			Parameter: constraint.Args[0],
-		}
-	})
 }
 
 // importType declares an import statement for the type definition of

--- a/internal/jennies/typescript/templates/constraints.tmpl
+++ b/internal/jennies/typescript/templates/constraints.tmpl
@@ -1,14 +1,14 @@
 {{- define "constraints" }}
     {{- range $c := . }}
-        {{- $leftOperand := .ArgName }}
+        {{- $leftOperand := .Argument.Name|formatIdentifier }}
         {{- $operator := .Op }}
 
         {{- if eq .Op "minLength" }}
-            {{- $leftOperand = print .ArgName ".length" }}
+            {{- $leftOperand = print $leftOperand ".length" }}
             {{- $operator = ">=" }}
         {{- end }}
         {{- if eq .Op "maxLength" }}
-            {{- $leftOperand = print .ArgName ".length" }}
+            {{- $leftOperand = print $leftOperand ".length" }}
             {{- $operator = "<=" }}
         {{- end }}
         if (!({{ $leftOperand }} {{ $operator }} {{ .Parameter }})) {

--- a/internal/tools/arrays.go
+++ b/internal/tools/arrays.go
@@ -25,6 +25,10 @@ func StringInListEqualFold(needle string, haystack []string) bool {
 }
 
 func Map[T any, O any](input []T, mapper func(T) O) []O {
+	if input == nil {
+		return nil
+	}
+
 	output := make([]O, len(input))
 
 	for i := range input {
@@ -35,6 +39,10 @@ func Map[T any, O any](input []T, mapper func(T) O) []O {
 }
 
 func Filter[T any](input []T, predicate func(T) bool) []T {
+	if input == nil {
+		return nil
+	}
+
 	output := make([]T, 0, len(input))
 
 	for i := range input {

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -192,7 +192,7 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 					newAssignment = ast.ArgumentAssignment(
 						assignmentPathPrefix.Append(ast.PathFromStructField(field)),
 						newArg,
-						ast.Constraints(constraints),
+						ast.WithTypeConstraints(constraints),
 						ast.Method(oldAssignments[0].Method),
 					)
 				}

--- a/testdata/jennies/builders/constraints/builders_context.json
+++ b/testdata/jennies/builders/constraints/builders_context.json
@@ -194,6 +194,7 @@
       },
       "Package": "constraints",
       "Name": "SomeStruct",
+      "Constructor": {},
       "Options": [
         {
           "Name": "id",
@@ -280,21 +281,64 @@
               "Method": "direct",
               "Constraints": [
                 {
+                  "Argument": {
+                    "Name": "id",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "uint64",
+                        "Constraints": [
+                          {
+                            "Op": "\u003e=",
+                            "Args": [
+                              5
+                            ]
+                          },
+                          {
+                            "Op": "\u003c",
+                            "Args": [
+                              10
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
                   "Op": "\u003e=",
-                  "Args": [
-                    5
-                  ]
+                  "Parameter": 5
                 },
                 {
+                  "Argument": {
+                    "Name": "id",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "uint64",
+                        "Constraints": [
+                          {
+                            "Op": "\u003e=",
+                            "Args": [
+                              5
+                            ]
+                          },
+                          {
+                            "Op": "\u003c",
+                            "Args": [
+                              10
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
                   "Op": "\u003c",
-                  "Args": [
-                    10
-                  ]
+                  "Parameter": 10
                 }
               ]
             }
-          ],
-          "IsConstructorArg": false
+          ]
         },
         {
           "Name": "title",
@@ -363,15 +407,30 @@
               "Method": "direct",
               "Constraints": [
                 {
+                  "Argument": {
+                    "Name": "title",
+                    "Type": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string",
+                        "Constraints": [
+                          {
+                            "Op": "minLength",
+                            "Args": [
+                              1
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  },
                   "Op": "minLength",
-                  "Args": [
-                    1
-                  ]
+                  "Parameter": 1
                 }
               ]
             }
-          ],
-          "IsConstructorArg": false
+          ]
         }
       ]
     }

--- a/testdata/jennies/builders/constraints/schema.cue
+++ b/testdata/jennies/builders/constraints/schema.cue
@@ -1,4 +1,4 @@
-package sandbox
+package constraints
 
 import "strings"
 


### PR DESCRIPTION
Similar to #357

With a few tweaks on how assignment constraints are represented in the builder IR, we can reduce the amount of work/manipulations that jennies have to do.