### PR TITLE
Java: Fix empty enum values and escape reserved words

### DIFF
--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -118,15 +118,15 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 	var buffer strings.Builder
 
 	enum := object.Type.AsEnum()
-	values := make([]EnumValue, 0, len(enum.Values))
-	for _, value := range enum.Values {
+	values := make([]EnumValue, len(enum.Values))
+	for i, value := range enum.Values {
 		if value.Name == "" {
-			continue
+			value.Name = "None"
 		}
-		values = append(values, EnumValue{
+		values[i] = EnumValue{
 			Name:  tools.UpperSnakeCase(value.Name),
 			Value: value.Value,
-		})
+		}
 	}
 
 	enumType := "Integer"

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -118,12 +118,15 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 	var buffer strings.Builder
 
 	enum := object.Type.AsEnum()
-	values := make([]EnumValue, len(enum.Values))
-	for i, value := range enum.Values {
-		values[i] = EnumValue{
+	values := make([]EnumValue, 0, len(enum.Values))
+	for _, value := range enum.Values {
+		if value.Name == "" {
+			continue
+		}
+		values = append(values, EnumValue{
 			Name:  tools.UpperSnakeCase(value.Name),
 			Value: value.Value,
-		}
+		})
 	}
 
 	enumType := "Integer"
@@ -211,7 +214,7 @@ func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, er
 	if err := templates.ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
 		Package:  pkg,
 		Imports:  jenny.imports,
-		Name:     object.Name,
+		Name:     tools.UpperCamelCase(object.Name),
 		Extends:  []string{reference},
 		Comments: object.Comments,
 		Variant:  tools.UpperCamelCase(object.Type.ImplementedVariant()),

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -56,14 +56,14 @@ func formatScalar(val any) any {
 }
 
 func formatAssignmentPath(fieldPath ast.Path) string {
-	path := tools.LowerCamelCase(fieldPath[0].Identifier)
+	path := escapeVarName(tools.LowerCamelCase(fieldPath[0].Identifier))
 
 	if len(fieldPath[1:]) == 1 && fieldPath[0].TypeHint != nil && fieldPath[0].TypeHint.Kind == ast.KindRef {
-		return tools.LowerCamelCase(path)
+		return path
 	}
 
 	for i, p := range fieldPath[1:] {
-		identifier := tools.LowerCamelCase(p.Identifier)
+		identifier := escapeVarName(tools.LowerCamelCase(p.Identifier))
 		if i == 0 && p.TypeHint != nil && p.TypeHint.Kind == ast.KindRef {
 			return tools.LowerCamelCase(identifier)
 		}


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cog/issues/360

* It sets default "None" value when enum name doesn't exist. It generates the model like in Go.
* It escapes reserved words from paths to make it works.