### PR TITLE
Java: Remove dashes from Java packages and folders

### DIFF
--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -68,14 +68,15 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 			return
 		}
 
-		output, innerErr := jenny.generateSchema(schema.Package, object)
+		pkg := formatPackageName(schema.Package)
+		output, innerErr := jenny.generateSchema(pkg, object)
 		if innerErr != nil {
 			err = innerErr
 			return
 		}
 
 		filename := filepath.Join(
-			strings.ToLower(schema.Package),
+			pkg,
 			fmt.Sprintf("%s.java", tools.UpperCamelCase(object.Name)),
 		)
 

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -2,11 +2,18 @@ package java
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 )
+
+func formatPackageName(pkg string) string {
+	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
+
+	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
+}
 
 func formatFieldPath(fieldPath ast.Path) []string {
 	parts := tools.Map(fieldPath, func(fieldPath ast.PathItem) string {

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
@@ -1,4 +1,4 @@
-package with-dashes;
+package withdashes;
 
 
 // Refresh rate or disabled.

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
@@ -1,4 +1,4 @@
-package with-dashes;
+package withdashes;
 
 
 public class SomeStruct {

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/StringOrBool.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/StringOrBool.java
@@ -1,4 +1,4 @@
-package with-dashes;
+package withdashes;
 
 
 public class StringOrBool {


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cog/issues/235

Java packages don't allow to have dashes in their packages/folders names.