### PR TITLE
Define more veneers on dashboards/panels

### DIFF
--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -123,23 +123,21 @@ options:
       fields: [String]
 
   # Append a single `link` value instead of a list of everything
-  - array_to_append:
-      by_name: Dashboard.links
-  # Links() to Link()
-  - rename:
+  - duplicate:
       by_name: Dashboard.links
       as: link
+  - array_to_append:
+      by_name: Dashboard.link
 
   # Dashboard.annotations([]AnnotationQuery) instead of Dashboard.annotations(AnnotationContainer)
   - struct_fields_as_arguments:
       by_name: Dashboard.annotations
   # Append a single `annotation` value instead of a list of everything
-  - array_to_append:
-      by_name: Dashboard.annotations
-  # Annotations() to Annotation()
-  - rename:
+  - duplicate:
       by_name: Dashboard.annotations
       as: annotation
+  - array_to_append:
+      by_name: Dashboard.annotation
 
   # Append a single `panel|row` value instead of a list of everything
   - array_to_append:
@@ -169,12 +167,15 @@ options:
       by_name: Dashboard.templating
       fields: [list]
   # Append a single variable instead forcing to define every variable at once
-  - array_to_append:
-      by_name: Dashboard.templating
-  # Templating() to WithVariable()
-  - rename:
+  - duplicate:
       by_name: Dashboard.templating
       as: withVariable
+  - array_to_append:
+      by_name: Dashboard.withVariable
+  # Templating() to Variables()
+  - rename:
+      by_name: Dashboard.templating
+      as: variables
 
   # We don't want these options at all
   - omit: { by_name: Dashboard.schemaVersion }
@@ -186,28 +187,25 @@ options:
   - omit: { by_names: {object: Panel, options: *UnwantedPanelOptions} }
 
   # Append a single target instead forcing to define all of them at once
-  - array_to_append:
-      by_name: Panel.targets
-  # Targets() to WithTarget()
-  - rename:
+  - duplicate:
       by_name: Panel.targets
       as: withTarget
+  - array_to_append:
+      by_name: Panel.withTarget
 
   # Append a single override instead forcing to define all of them at once
-  - array_to_append:
-      by_name: Panel.overrides
-  # Overrides() to WithOverride()
-  - rename:
+  - duplicate:
       by_name: Panel.overrides
       as: withOverride
+  - array_to_append:
+      by_name: Panel.withOverride
 
   # Append a single transformation instead forcing to define all of them at once
-  - array_to_append:
-      by_name: Panel.transformations
-  # Overrides() to WithOverride()
-  - rename:
+  - duplicate:
       by_name: Panel.transformations
       as: withTransformation
+  - array_to_append:
+      by_name: Panel.withTransformation
 
   # W(), H() instead of explicit GridPos() definition
   - struct_fields_as_options:


### PR DESCRIPTION
While adding one annotation/variable/link/... at a time is convenient, there is no reason why there should be no option to set all the values at once.