### PR TITLE
Support conditional schema loading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cuelang.org/go v0.8.2
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/expr-lang/expr v1.16.7
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY=
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
+github.com/expr-lang/expr v1.16.7 h1:gCIiHt5ODA0xIaDbD0DPKyZpM9Drph3b3lolYAYq2Kw=
+github.com/expr-lang/expr v1.16.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,56 @@
+package semver
+
+import (
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"golang.org/x/mod/semver"
+)
+
+type Version struct {
+	version string
+}
+
+func Parse(version string) Version {
+	return Version{
+		version: version,
+	}
+}
+
+// registryToSemver turns a "v10.2.x" input (version string coming from the
+// kind-registry) into a semver-compatible version "10.2.0"
+func ParseTolerant(version string) Version {
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	if strings.HasSuffix(version, "x") {
+		version = version[:len(version)-1] + "0"
+	}
+
+	return Parse(version)
+}
+
+func (v Version) Equal(other Version) bool {
+	return semver.Compare(v.version, other.version) == 0
+}
+
+func (v Version) LessThan(other Version) bool {
+	return semver.Compare(v.version, other.version) == -1
+}
+
+func (v Version) LessThanEqual(other Version) bool {
+	cmp := semver.Compare(v.version, other.version)
+	return cmp == -1 || cmp == 0
+}
+
+func (v Version) MoreThan(other Version) bool {
+	return semver.Compare(v.version, other.version) == 1
+}
+
+func (v Version) MoreThanEqual(other Version) bool {
+	cmp := semver.Compare(v.version, other.version)
+	spew.Dump(v.version, other.version, cmp)
+
+	return cmp == 1 || cmp == 0
+}


### PR DESCRIPTION
Will be useful for #374, for which we need to load a schema from Grafana only for versions >= v11.0.x

The config looks like:

```yaml
inputs:
  # The schema for testdata queries was included in the kind-registry until v11.0.x
  - if: '"%grafana_version%" == "main" || semver("%grafana_version%").MoreThanEqual(semver("v11.0.x"))'
    jsonschema:
      url: 'https://raw.githubusercontent.com/grafana/grafana/%grafana_version%/pkg/tsdb/grafana-testdata-datasource/kinds/query.panel.schema.json'
      package: testdata
```