### PR TITLE
Improve tools to visit and modify the types IR

### DIFF
--- a/internal/ast/compiler/add_fields_test.go
+++ b/internal/ast/compiler/add_fields_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddFields(t *testing.T) {
@@ -107,5 +108,6 @@ func TestAddFields_withNonStructObjectRef(t *testing.T) {
 	}
 
 	// Run the compiler pass
-	runPassOnSchema(t, pass, schema, schema)
+	_, err := pass.Process(ast.Schemas{schema})
+	require.Error(t, err)
 }

--- a/internal/ast/compiler/disjunction_with_constant_to_default.go
+++ b/internal/ast/compiler/disjunction_with_constant_to_default.go
@@ -10,92 +10,34 @@ type DisjunctionWithConstantToDefault struct {
 }
 
 func (pass *DisjunctionWithConstantToDefault) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnDisjunction: pass.processDisjunction,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *DisjunctionWithConstantToDefault) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema
-}
-
-func (pass *DisjunctionWithConstantToDefault) processObject(object ast.Object) ast.Object {
-	object.Type = pass.processType(object.Type)
-
-	return object
-}
-
-func (pass *DisjunctionWithConstantToDefault) processType(def ast.Type) ast.Type {
-	if def.IsArray() {
-		return pass.processArray(def)
-	}
-
-	if def.IsMap() {
-		return pass.processMap(def)
-	}
-
-	if def.IsStruct() {
-		return pass.processStruct(def)
-	}
-
-	if def.IsDisjunction() {
-		return pass.processDisjunction(def)
-	}
-
-	if def.IsIntersection() {
-		return pass.processIntersection(def)
-	}
-
-	return def
-}
-
-func (pass *DisjunctionWithConstantToDefault) processArray(def ast.Type) ast.Type {
-	def.Array.ValueType = pass.processType(def.AsArray().ValueType)
-
-	return def
-}
-
-func (pass *DisjunctionWithConstantToDefault) processMap(def ast.Type) ast.Type {
-	def.Map.ValueType = pass.processType(def.AsMap().ValueType)
-
-	return def
-}
-
-func (pass *DisjunctionWithConstantToDefault) processStruct(def ast.Type) ast.Type {
-	for i, field := range def.Struct.Fields {
-		def.Struct.Fields[i].Type = pass.processType(field.Type)
-	}
-
-	return def
-}
-
-func (pass *DisjunctionWithConstantToDefault) processDisjunction(def ast.Type) ast.Type {
+func (pass *DisjunctionWithConstantToDefault) processDisjunction(_ *Visitor, _ *ast.Schema, def ast.Type) (ast.Type, error) {
 	branches := def.Disjunction.Branches
 
 	if len(branches) != 2 {
-		return def
+		return def, nil
 	}
 
 	if branches[0].Kind != branches[1].Kind {
-		return def
+		return def, nil
 	}
 
 	if !branches[0].IsScalar() {
-		return def
+		return def, nil
 	}
 
 	if branches[0].Scalar.ScalarKind != branches[1].Scalar.ScalarKind {
-		return def
+		return def, nil
 	}
 
 	if branches[0].Scalar.IsConcrete() == branches[1].Scalar.IsConcrete() {
-		return def
+		return def, nil
 	}
 
 	if branches[0].Scalar.IsConcrete() {
@@ -108,13 +50,5 @@ func (pass *DisjunctionWithConstantToDefault) processDisjunction(def ast.Type) a
 
 	def.AddToPassesTrail("DisjunctionWithConstantToDefault")
 
-	return def
-}
-
-func (pass *DisjunctionWithConstantToDefault) processIntersection(def ast.Type) ast.Type {
-	for i, branch := range def.Intersection.Branches {
-		def.Intersection.Branches[i] = pass.processType(branch)
-	}
-
-	return def
+	return def, nil
 }

--- a/internal/ast/compiler/disjunctions_with_null_to_optional.go
+++ b/internal/ast/compiler/disjunctions_with_null_to_optional.go
@@ -26,85 +26,24 @@ type DisjunctionWithNullToOptional struct {
 }
 
 func (pass *DisjunctionWithNullToOptional) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	newSchemas := make([]*ast.Schema, 0, len(schemas))
-
-	for _, schema := range schemas {
-		newSchema, err := pass.processSchema(schema)
-		if err != nil {
-			return nil, fmt.Errorf("[%s] %w", schema.Package, err)
-		}
-
-		newSchemas = append(newSchemas, newSchema)
+	visitor := &Visitor{
+		OnDisjunction: pass.processDisjunction,
 	}
 
-	return newSchemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *DisjunctionWithNullToOptional) processSchema(schema *ast.Schema) (*ast.Schema, error) {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema, nil
-}
-
-func (pass *DisjunctionWithNullToOptional) processObject(object ast.Object) ast.Object {
-	object.Type = pass.processType(object.Type)
-
-	return object
-}
-
-func (pass *DisjunctionWithNullToOptional) processType(def ast.Type) ast.Type {
-	if def.IsArray() {
-		return pass.processArray(def)
-	}
-
-	if def.IsMap() {
-		return pass.processMap(def)
-	}
-
-	if def.IsStruct() {
-		return pass.processStruct(def)
-	}
-
-	if def.IsDisjunction() {
-		return pass.processDisjunction(def)
-	}
-
-	return def
-}
-
-func (pass *DisjunctionWithNullToOptional) processArray(def ast.Type) ast.Type {
-	def.Array.ValueType = pass.processType(def.AsArray().ValueType)
-
-	return def
-}
-
-func (pass *DisjunctionWithNullToOptional) processMap(def ast.Type) ast.Type {
-	def.Map.ValueType = pass.processType(def.AsMap().ValueType)
-
-	return def
-}
-
-func (pass *DisjunctionWithNullToOptional) processStruct(def ast.Type) ast.Type {
-	for i, field := range def.AsStruct().Fields {
-		def.Struct.Fields[i].Type = pass.processType(field.Type)
-	}
-
-	return def
-}
-
-func (pass *DisjunctionWithNullToOptional) processDisjunction(def ast.Type) ast.Type {
+func (pass *DisjunctionWithNullToOptional) processDisjunction(_ *Visitor, _ *ast.Schema, def ast.Type) (ast.Type, error) {
 	disjunction := def.AsDisjunction()
 
-	// type | null
-	if len(disjunction.Branches) == 2 && disjunction.Branches.HasNullType() {
-		finalType := disjunction.Branches.NonNullTypes()[0]
-		finalType.Nullable = true
-		finalType.AddToPassesTrail(fmt.Sprintf("DisjunctionWithNullToOptional[%[1]s|null → %[1]s?]", ast.TypeName(finalType)))
-
-		return finalType
+	if len(disjunction.Branches) != 2 || !disjunction.Branches.HasNullType() {
+		return def, nil
 	}
 
-	return def
+	// type | null
+	finalType := disjunction.Branches.NonNullTypes()[0]
+	finalType.Nullable = true
+	finalType.AddToPassesTrail(fmt.Sprintf("DisjunctionWithNullToOptional[%[1]s|null → %[1]s?]", ast.TypeName(finalType)))
+
+	return finalType, nil
 }

--- a/internal/ast/compiler/fields_set_default.go
+++ b/internal/ast/compiler/fields_set_default.go
@@ -14,22 +14,16 @@ type FieldsSetDefault struct {
 }
 
 func (pass *FieldsSetDefault) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *FieldsSetDefault) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(pass.processObject)
-
-	return schema
-}
-
-func (pass *FieldsSetDefault) processObject(_ string, object ast.Object) ast.Object {
+func (pass *FieldsSetDefault) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !object.Type.IsStruct() {
-		return object
+		return object, nil
 	}
 
 	for i, field := range object.Type.AsStruct().Fields {
@@ -45,5 +39,5 @@ func (pass *FieldsSetDefault) processObject(_ string, object ast.Object) ast.Obj
 		}
 	}
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/fields_set_not_required.go
+++ b/internal/ast/compiler/fields_set_not_required.go
@@ -12,22 +12,16 @@ type FieldsSetNotRequired struct {
 }
 
 func (pass *FieldsSetNotRequired) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *FieldsSetNotRequired) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(pass.processObject)
-
-	return schema
-}
-
-func (pass *FieldsSetNotRequired) processObject(_ string, object ast.Object) ast.Object {
+func (pass *FieldsSetNotRequired) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !object.Type.IsStruct() {
-		return object
+		return object, nil
 	}
 
 	for i, field := range object.Type.AsStruct().Fields {
@@ -44,5 +38,5 @@ func (pass *FieldsSetNotRequired) processObject(_ string, object ast.Object) ast
 		}
 	}
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/fields_set_required.go
+++ b/internal/ast/compiler/fields_set_required.go
@@ -12,22 +12,16 @@ type FieldsSetRequired struct {
 }
 
 func (pass *FieldsSetRequired) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *FieldsSetRequired) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(pass.processObject)
-
-	return schema
-}
-
-func (pass *FieldsSetRequired) processObject(_ string, object ast.Object) ast.Object {
+func (pass *FieldsSetRequired) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !object.Type.IsStruct() {
-		return object
+		return object, nil
 	}
 
 	for i, field := range object.Type.AsStruct().Fields {
@@ -44,5 +38,5 @@ func (pass *FieldsSetRequired) processObject(_ string, object ast.Object) ast.Ob
 		}
 	}
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/hint_object.go
+++ b/internal/ast/compiler/hint_object.go
@@ -15,24 +15,16 @@ type HintObject struct {
 }
 
 func (pass *HintObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *HintObject) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema
-}
-
-func (pass *HintObject) processObject(object ast.Object) ast.Object {
+func (pass *HintObject) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !pass.Object.Matches(object) {
-		return object
+		return object, nil
 	}
 
 	hintsTrail := make([]string, 0, len(pass.Hints))
@@ -43,5 +35,5 @@ func (pass *HintObject) processObject(object ast.Object) ast.Object {
 
 	object.AddToPassesTrail(fmt.Sprintf("HintObject[%s]", strings.Join(hintsTrail, ", ")))
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/not_required_as_nullable.go
+++ b/internal/ast/compiler/not_required_as_nullable.go
@@ -12,80 +12,24 @@ type NotRequiredFieldAsNullableType struct {
 }
 
 func (pass *NotRequiredFieldAsNullableType) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnStructField: pass.processStructField,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *NotRequiredFieldAsNullableType) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema
-}
-
-func (pass *NotRequiredFieldAsNullableType) processObject(object ast.Object) ast.Object {
-	if !object.Type.IsStruct() {
-		return object
+func (pass *NotRequiredFieldAsNullableType) processStructField(visitor *Visitor, schema *ast.Schema, field ast.StructField) (ast.StructField, error) {
+	var err error
+	field.Type, err = visitor.VisitType(schema, field.Type)
+	if err != nil {
+		return field, err
 	}
 
-	object.Type = pass.processType(object.Type)
-
-	return object
-}
-
-func (pass *NotRequiredFieldAsNullableType) processType(def ast.Type) ast.Type {
-	if def.IsArray() {
-		return pass.processArray(def)
+	if !field.Required && !field.Type.Nullable {
+		field.Type.Nullable = true
+		field.AddToPassesTrail("NotRequiredFieldAsNullableType[nullable=true]")
 	}
 
-	if def.IsMap() {
-		return pass.processMap(def)
-	}
-
-	if def.IsStruct() {
-		return pass.processStruct(def)
-	}
-
-	if def.IsDisjunction() {
-		return pass.processDisjunction(def)
-	}
-
-	return def
-}
-
-func (pass *NotRequiredFieldAsNullableType) processArray(def ast.Type) ast.Type {
-	def.Array.ValueType = pass.processType(def.Array.ValueType)
-
-	return def
-}
-
-func (pass *NotRequiredFieldAsNullableType) processMap(def ast.Type) ast.Type {
-	def.Map.IndexType = pass.processType(def.Map.IndexType)
-	def.Map.ValueType = pass.processType(def.Map.ValueType)
-
-	return def
-}
-
-func (pass *NotRequiredFieldAsNullableType) processDisjunction(def ast.Type) ast.Type {
-	for i, branch := range def.Disjunction.Branches {
-		def.Disjunction.Branches[i] = pass.processType(branch)
-	}
-
-	return def
-}
-
-func (pass *NotRequiredFieldAsNullableType) processStruct(def ast.Type) ast.Type {
-	for i, field := range def.Struct.Fields {
-		def.Struct.Fields[i].Type = pass.processType(field.Type)
-		if !field.Required && !def.Struct.Fields[i].Type.Nullable {
-			def.Struct.Fields[i].Type.Nullable = true
-			def.Struct.Fields[i].AddToPassesTrail("NotRequiredFieldAsNullableType[nullable=true]")
-		}
-	}
-
-	return def
+	return field, nil
 }

--- a/internal/ast/compiler/retype_field.go
+++ b/internal/ast/compiler/retype_field.go
@@ -15,24 +15,16 @@ type RetypeField struct {
 }
 
 func (pass *RetypeField) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *RetypeField) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema
-}
-
-func (pass *RetypeField) processObject(object ast.Object) ast.Object {
+func (pass *RetypeField) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !object.Type.IsStruct() {
-		return object
+		return object, nil
 	}
 
 	for i, field := range object.Type.Struct.Fields {
@@ -50,5 +42,5 @@ func (pass *RetypeField) processObject(object ast.Object) ast.Object {
 		break
 	}
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/retype_object.go
+++ b/internal/ast/compiler/retype_object.go
@@ -15,24 +15,16 @@ type RetypeObject struct {
 }
 
 func (pass *RetypeObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
-	for i, schema := range schemas {
-		schemas[i] = pass.processSchema(schema)
+	visitor := &Visitor{
+		OnObject: pass.processObject,
 	}
 
-	return schemas, nil
+	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *RetypeObject) processSchema(schema *ast.Schema) *ast.Schema {
-	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
-		return pass.processObject(object)
-	})
-
-	return schema
-}
-
-func (pass *RetypeObject) processObject(object ast.Object) ast.Object {
+func (pass *RetypeObject) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
 	if !pass.Object.Matches(object) {
-		return object
+		return object, nil
 	}
 
 	trailMessage := fmt.Sprintf("RetypeObject[%s → %s]", ast.TypeName(object.Type), ast.TypeName(pass.As))
@@ -44,5 +36,5 @@ func (pass *RetypeObject) processObject(object ast.Object) ast.Object {
 		object.Comments = pass.Comments
 	}
 
-	return object
+	return object, nil
 }

--- a/internal/ast/compiler/types.go
+++ b/internal/ast/compiler/types.go
@@ -16,6 +16,10 @@ func (ref ObjectReference) Matches(object ast.Object) bool {
 	return object.SelfRef.ReferredPkg == ref.Package && strings.EqualFold(object.Name, ref.Object)
 }
 
+func (ref ObjectReference) String() string {
+	return fmt.Sprintf("%s.%s", ref.Package, ref.Object)
+}
+
 func ObjectReferenceFromString(ref string) (ObjectReference, error) {
 	parts := strings.Split(ref, ".")
 	if len(parts) != 2 {

--- a/internal/ast/compiler/visitor.go
+++ b/internal/ast/compiler/visitor.go
@@ -1,0 +1,259 @@
+package compiler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
+)
+
+type VisitSchemaFunc func(visitor *Visitor, schema *ast.Schema) (*ast.Schema, error)
+type VisitObjectFunc func(visitor *Visitor, schema *ast.Schema, object ast.Object) (ast.Object, error)
+type VisitTypeFunc func(visitor *Visitor, schema *ast.Schema, def ast.Type) (ast.Type, error)
+type VisitStructFieldFunc func(visitor *Visitor, schema *ast.Schema, field ast.StructField) (ast.StructField, error)
+
+type Visitor struct {
+	OnSchema       VisitSchemaFunc
+	OnObject       VisitObjectFunc
+	OnStructField  VisitStructFieldFunc
+	OnArray        VisitTypeFunc
+	OnMap          VisitTypeFunc
+	OnStruct       VisitTypeFunc
+	OnDisjunction  VisitTypeFunc
+	OnIntersection VisitTypeFunc
+	OnEnum         VisitTypeFunc
+	OnScalar       VisitTypeFunc
+	OnRef          VisitTypeFunc
+
+	newObjects *orderedmap.Map[string, ast.Object]
+}
+
+func (visitor *Visitor) RegisterNewObject(object ast.Object) {
+	visitor.newObjects.Set(object.SelfRef.String(), object)
+}
+
+func (visitor *Visitor) HasNewObject(ref ast.RefType) bool {
+	return visitor.newObjects.Has(ref.String())
+}
+
+func (visitor *Visitor) VisitSchemas(schemas ast.Schemas) (ast.Schemas, error) {
+	var err error
+
+	for i, schema := range schemas {
+		schemas[i], err = visitor.VisitSchema(schema)
+		if err != nil {
+			return nil, fmt.Errorf("[%s] %w", schema.Package, err)
+		}
+	}
+
+	return schemas, nil
+}
+
+func (visitor *Visitor) VisitSchema(schema *ast.Schema) (*ast.Schema, error) {
+	visitor.newObjects = orderedmap.New[string, ast.Object]()
+	defer func() {
+		visitor.newObjects.Iterate(func(_ string, object ast.Object) {
+			schema.AddObject(object)
+		})
+	}()
+
+	if visitor.OnSchema != nil {
+		return visitor.OnSchema(visitor, schema)
+	}
+
+	var err error
+	var obj ast.Object
+
+	schema.Objects = schema.Objects.Map(func(_ string, object ast.Object) ast.Object {
+		if err != nil {
+			return object
+		}
+
+		obj, err = visitor.VisitObject(schema, object)
+		if err != nil {
+			err = errors.Join(
+				fmt.Errorf("could not process object '%s'", object.Name),
+				err,
+			)
+		}
+
+		return obj
+	})
+
+	return schema, err
+}
+
+func (visitor *Visitor) VisitObject(schema *ast.Schema, object ast.Object) (ast.Object, error) {
+	if visitor.OnObject != nil {
+		return visitor.OnObject(visitor, schema, object)
+	}
+
+	var err error
+
+	object.Type, err = visitor.VisitType(schema, object.Type)
+	if err != nil {
+		return ast.Object{}, err
+	}
+
+	return object, nil
+}
+
+func (visitor *Visitor) VisitType(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if def.IsArray() {
+		return visitor.VisitArray(schema, def)
+	}
+
+	if def.IsMap() {
+		return visitor.VisitMap(schema, def)
+	}
+
+	if def.IsStruct() {
+		return visitor.VisitStruct(schema, def)
+	}
+
+	if def.IsDisjunction() {
+		return visitor.VisitDisjunction(schema, def)
+	}
+
+	if def.IsIntersection() {
+		return visitor.VisitIntersection(schema, def)
+	}
+
+	if def.IsEnum() {
+		return visitor.VisitEnum(schema, def)
+	}
+
+	if def.IsScalar() {
+		return visitor.VisitScalar(schema, def)
+	}
+
+	if def.IsRef() {
+		return visitor.VisitRef(schema, def)
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitArray(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnArray != nil {
+		return visitor.OnArray(visitor, schema, def)
+	}
+
+	var err error
+
+	def.Array.ValueType, err = visitor.VisitType(schema, def.AsArray().ValueType)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitMap(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnMap != nil {
+		return visitor.OnMap(visitor, schema, def)
+	}
+
+	var err error
+
+	def.Map.ValueType, err = visitor.VisitType(schema, def.AsMap().ValueType)
+	if err != nil {
+		return ast.Type{}, err
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitStruct(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnStruct != nil {
+		return visitor.OnStruct(visitor, schema, def)
+	}
+
+	var err error
+
+	for i, field := range def.Struct.Fields {
+		def.Struct.Fields[i], err = visitor.VisitStructField(schema, field)
+		if err != nil {
+			return ast.Type{}, errors.Join(
+				fmt.Errorf("could not process struct field '%s'", field.Name),
+				err,
+			)
+		}
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitDisjunction(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnDisjunction != nil {
+		return visitor.OnDisjunction(visitor, schema, def)
+	}
+
+	var err error
+
+	for i, branch := range def.Disjunction.Branches {
+		def.Disjunction.Branches[i], err = visitor.VisitType(schema, branch)
+		if err != nil {
+			return ast.Type{}, err
+		}
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitIntersection(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnIntersection != nil {
+		return visitor.OnIntersection(visitor, schema, def)
+	}
+
+	var err error
+
+	for i, branch := range def.Intersection.Branches {
+		def.Intersection.Branches[i], err = visitor.VisitType(schema, branch)
+		if err != nil {
+			return ast.Type{}, err
+		}
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitStructField(schema *ast.Schema, field ast.StructField) (ast.StructField, error) {
+	if visitor.OnStructField != nil {
+		return visitor.OnStructField(visitor, schema, field)
+	}
+
+	var err error
+
+	field.Type, err = visitor.VisitType(schema, field.Type)
+	if err != nil {
+		return ast.StructField{}, err
+	}
+
+	return field, nil
+}
+
+func (visitor *Visitor) VisitEnum(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnEnum != nil {
+		return visitor.OnEnum(visitor, schema, def)
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitScalar(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnScalar != nil {
+		return visitor.OnScalar(visitor, schema, def)
+	}
+
+	return def, nil
+}
+
+func (visitor *Visitor) VisitRef(schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	if visitor.OnRef != nil {
+		return visitor.OnRef(visitor, schema, def)
+	}
+
+	return def, nil
+}

--- a/internal/ast/schema.go
+++ b/internal/ast/schema.go
@@ -37,6 +37,16 @@ func (schemas Schemas) LocateObject(pkg string, name string) (Object, bool) {
 	return Object{}, false
 }
 
+func (schemas Schemas) Locate(pkg string) (*Schema, bool) {
+	for _, schema := range schemas {
+		if schema.Package == pkg {
+			return schema, true
+		}
+	}
+
+	return nil, false
+}
+
 func (schemas Schemas) Consolidate() (Schemas, error) {
 	byPackage := make(map[string]Schemas, len(schemas))
 


### PR DESCRIPTION
This PR introduces a "types IR" visitor that provides a reusable way to explore and modify the types IR.

Extracting this logic allows us to simplify a fair few of our existing compiler passes.