### PR TITLE
Configurable compact output for JSONSchema and OpenAPI

### DIFF
--- a/cmd/cli/loaders/config.go
+++ b/cmd/cli/loaders/config.go
@@ -195,9 +195,9 @@ func (config Config) OutputLanguages() (languages.Languages, error) {
 		case output.Java != nil:
 			outputs[java.LanguageRef] = java.New()
 		case output.JSONSchema != nil:
-			outputs[jsonschema.LanguageRef] = jsonschema.New()
+			outputs[jsonschema.LanguageRef] = jsonschema.New(*output.JSONSchema)
 		case output.OpenAPI != nil:
-			outputs[openapi.LanguageRef] = openapi.New()
+			outputs[openapi.LanguageRef] = openapi.New(*output.OpenAPI)
 		case output.Python != nil:
 			outputs[python.LanguageRef] = python.New(*output.Python)
 		case output.Typescript != nil:
@@ -435,12 +435,12 @@ func (output *Output) InterpolateParameters(interpolator ParametersInterpolator)
 }
 
 type OutputLanguage struct {
-	Go         *golang.Config `yaml:"go"`
-	Java       *java.Config   `yaml:"java"`
-	JSONSchema *NoConfig      `yaml:"jsonschema"`
-	OpenAPI    *NoConfig      `yaml:"openapi"`
-	Python     *python.Config `yaml:"python"`
-	Typescript *NoConfig      `yaml:"typescript"`
+	Go         *golang.Config     `yaml:"go"`
+	Java       *java.Config       `yaml:"java"`
+	JSONSchema *jsonschema.Config `yaml:"jsonschema"`
+	OpenAPI    *openapi.Config    `yaml:"openapi"`
+	Python     *python.Config     `yaml:"python"`
+	Typescript *NoConfig          `yaml:"typescript"`
 }
 
 func (outputLanguage *OutputLanguage) InterpolateParameters(interpolator ParametersInterpolator) {

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -13,7 +13,9 @@ import (
 const LanguageRef = "jsonschema"
 
 type Config struct {
-	Debug bool
+	Debug bool `yaml:"-"`
+
+	Compact bool `yaml:"compact"`
 }
 
 func (config Config) MergeWithGlobal(global common.Config) Config {
@@ -27,9 +29,9 @@ type Language struct {
 	config Config
 }
 
-func New() *Language {
+func New(config Config) *Language {
 	return &Language{
-		config: Config{},
+		config: config,
 	}
 }
 

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -47,7 +47,7 @@ func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
 }
 
 func (jenny Schema) toJSON(input any) ([]byte, error) {
-	if jenny.Config.Debug {
+	if !jenny.Config.Compact {
 		return json.MarshalIndent(input, "", "  ")
 	}
 

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -15,12 +15,9 @@ func TestSchema_Generate(t *testing.T) {
 		Name:         "JSONSchema",
 	}
 
-	jenny := Schema{
-		Config: Config{
-			Debug: true,
-		},
-	}
-	compilerPasses := New().CompilerPasses()
+	config := Config{Debug: true}
+	jenny := Schema{Config: config}
+	compilerPasses := New(config).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test) {
 		req := require.New(tc)

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -10,6 +10,8 @@ const LanguageRef = "openapi"
 
 type Config struct {
 	debug bool
+
+	Compact bool `yaml:"compact"`
 }
 
 func (config Config) MergeWithGlobal(global common.Config) Config {
@@ -23,9 +25,9 @@ type Language struct {
 	config Config
 }
 
-func New() *Language {
+func New(config Config) *Language {
 	return &Language{
-		config: Config{},
+		config: config,
 	}
 }
 

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -37,7 +37,8 @@ func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
 func (jenny Schema) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
 	jsonschemaJenny := jsonschema.Schema{
 		Config: jsonschema.Config{
-			Debug: jenny.Config.debug,
+			Debug:   jenny.Config.debug,
+			Compact: jenny.Config.Compact,
 		},
 		ReferenceFormatter: func(ref ast.RefType) string {
 			return fmt.Sprintf("#/components/schemas/%s", ref.ReferredType)
@@ -67,7 +68,7 @@ func (jenny Schema) generateSchema(context common.Context, schema *ast.Schema) (
 }
 
 func (jenny Schema) toJSON(input any) ([]byte, error) {
-	if jenny.Config.debug {
+	if !jenny.Config.Compact {
 		return json.MarshalIndent(input, "", "  ")
 	}
 

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -15,12 +15,9 @@ func TestSchema_Generate(t *testing.T) {
 		Name:         "OpenAPI",
 	}
 
-	jenny := Schema{
-		Config: Config{
-			debug: true,
-		},
-	}
-	compilerPasses := New().CompilerPasses()
+	config := Config{debug: true}
+	jenny := Schema{Config: config}
+	compilerPasses := New(config).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test) {
 		req := require.New(tc)


### PR DESCRIPTION
Whether JSONSchema and OpenAPI schemas are generated in a compact for or not should not be controlled by the debug flag only.