### PR TITLE
Define some missing default values for timeseries and legends

### DIFF
--- a/config/compiler/kind_registry.yaml
+++ b/config/compiler/kind_registry.yaml
@@ -128,6 +128,26 @@ passes:
         kind: ref
         ref: { referred_pkg: heatmap, referred_type: HeatmapTooltip }
 
+  ###########################
+  # common.VizLegendOptions #
+  ###########################
+
+  # Without these values, some panels might misbehave when displayed in a dashboard
+  - fields_set_default:
+      defaults:
+        common.VizLegendOptions.displayMode: "list"
+        common.VizLegendOptions.placement: "bottom"
+        common.VizLegendOptions.calcs: []
+
+  ####################
+  # timeseries panel #
+  ####################
+
+  # Without these values, timeseries might not display any data or crash when editing in the UI
+  - fields_set_default:
+      defaults:
+        timeseries.Options.legend: { placement: "bottom", displayMode: "list", calcs: [] }
+
   ##########
   # Others #
   ##########


### PR DESCRIPTION
Without these defaults, some panels display no data and/or crash when editing them from the UI.