### PR TITLE
Java: Fix float defaults

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -98,7 +98,7 @@ func (b Builders) formatDefaultValues(args []ast.Argument) []string {
 			if scalar.ScalarKind == ast.KindFloat32 || scalar.ScalarKind == ast.KindFloat64 {
 				val := arg.Type.Default
 				if v, ok := val.(int64); ok {
-					val = v
+					val = float64(v)
 				} else {
 					val = val.(float64)
 				}


### PR DESCRIPTION
0 value is interpreted as integer and we need to map it into a float when the ScalarKind is set as float.