### PR TITLE
Add a quick and dirty script to generate a list of configurable compiler passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ tests:
 .PHONY: deps
 deps:
 	go mod vendor
+
+.PHONY: docs
+docs:
+	go run cmd/compiler-passes-docs/*

--- a/cmd/compiler-passes-docs/main.go
+++ b/cmd/compiler-passes-docs/main.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/grafana/cog/internal/tools"
+	"github.com/grafana/cog/internal/yaml"
+)
+
+//nolint:gosec
+const compilerPassTypesSourceDir = "./internal/ast/compiler"
+
+//nolint:gosec
+const yamlCompilerPassTypesSourceDir = "./internal/yaml"
+
+const outputFile = "./docs/compiler_passes.md"
+
+type compilerPassParam struct {
+	Name          string
+	Type          string
+	Documentation string
+}
+
+type compilerPassDocEntry struct {
+	YamlName      string
+	Parameters    []compilerPassParam
+	Documentation string
+}
+
+func yamlNameForField(field reflect.StructField) string {
+	yamlName := field.Tag.Get("yaml")
+	if yamlName == "" {
+		yamlName = tools.SnakeCase(field.Name)
+	}
+
+	return yamlName
+}
+
+func compilerPassParameters(yamlCompilerPassComments map[string]string, compilerPassType reflect.Type) []compilerPassParam {
+	params := make([]compilerPassParam, 0, compilerPassType.NumField())
+	for i := 0; i < compilerPassType.NumField(); i++ {
+		field := compilerPassType.Field(i)
+		fieldType := field.Type.Name()
+		if field.Type.Name() == "" {
+			fieldType = field.Type.String()
+		}
+
+		params = append(params, compilerPassParam{
+			Name:          yamlNameForField(field),
+			Type:          fieldType,
+			Documentation: yamlCompilerPassComments[fmt.Sprintf("%s.%s", compilerPassType.Name(), field.Name)],
+		})
+	}
+
+	return params
+}
+
+func buildYamlCompilerPassTypesCommentsMap(yamlTypesInputDir string) (map[string]string, error) {
+	commentsMap := make(map[string]string)
+
+	packages, err := parser.ParseDir(token.NewFileSet(), yamlTypesInputDir, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, packageAst := range packages {
+		packageDocs := doc.New(packageAst, "./", doc.AllDecls)
+
+		for _, t := range packageDocs.Types {
+			if t.Decl == nil {
+				continue
+			}
+
+			if len(t.Decl.Specs) != 1 {
+				continue
+			}
+
+			if _, ok := t.Decl.Specs[0].(*ast.TypeSpec); !ok {
+				continue
+			}
+
+			typeSpec := t.Decl.Specs[0].(*ast.TypeSpec)
+			if _, ok := typeSpec.Type.(*ast.StructType); !ok {
+				continue
+			}
+			structType := typeSpec.Type.(*ast.StructType)
+
+			for _, fields := range structType.Fields.List {
+				for _, field := range fields.Names {
+					fieldRef := fmt.Sprintf("%s.%s", t.Name, field.Name)
+					commentsMap[fieldRef] = fields.Doc.Text()
+				}
+			}
+		}
+	}
+
+	return commentsMap, nil
+}
+
+func compilerPassDocEntries(compilerPassComments map[string]string, yamlCompilerPassComments map[string]string) []compilerPassDocEntry {
+	var entries []compilerPassDocEntry
+	yamlCompilerPassTypeOf := reflect.TypeOf(yaml.CompilerPass{})
+
+	for i := 0; i < yamlCompilerPassTypeOf.NumField(); i++ {
+		field := yamlCompilerPassTypeOf.Field(i)
+
+		compilerPassMethod, found := field.Type.MethodByName("AsCompilerPass")
+		if !found {
+			continue
+		}
+
+		compilerPassType := compilerPassMethod.Type.Out(0)
+		compilerPassTypeName := compilerPassType.Elem().Name()
+
+		entries = append(entries, compilerPassDocEntry{
+			YamlName:      yamlNameForField(field),
+			Parameters:    compilerPassParameters(yamlCompilerPassComments, field.Type.Elem()),
+			Documentation: compilerPassComments[compilerPassTypeName],
+		})
+	}
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].YamlName < entries[j].YamlName
+	})
+
+	return entries
+}
+
+func buildCompilerPassTypesCommentsMap(typesInputDir string) (map[string]string, error) {
+	compilerPassComments := make(map[string]string)
+
+	packages, err := parser.ParseDir(token.NewFileSet(), typesInputDir, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, packageAst := range packages {
+		packageDocs := doc.New(packageAst, "./", doc.AllDecls)
+
+		for _, t := range packageDocs.Types {
+			if t.Doc == "" {
+				continue
+			}
+
+			compilerPassComments[t.Name] = t.Doc
+		}
+	}
+
+	return compilerPassComments, nil
+}
+
+func docEntriesToMarkdown(entries []compilerPassDocEntry) []byte {
+	var markdown bytes.Buffer
+
+	markdown.WriteString("<!-- Generated with `make docs` -->\n")
+
+	markdown.WriteString("# Compiler passes\n\n")
+	for _, entry := range entries {
+		markdown.WriteString(fmt.Sprintf("## `%s`\n", entry.YamlName))
+		markdown.WriteString("\n")
+
+		if entry.Documentation == "" {
+			markdown.WriteString("N/A\n")
+		} else {
+			markdown.WriteString(entry.Documentation)
+		}
+		markdown.WriteString("\n")
+
+		markdown.WriteString("### Usage\n\n")
+
+		markdown.WriteString("```yaml\n")
+		markdown.WriteString(fmt.Sprintf("%s:", entry.YamlName))
+
+		if len(entry.Parameters) == 0 {
+			markdown.WriteString(" {}")
+		}
+
+		markdown.WriteString("\n")
+
+		for _, param := range entry.Parameters {
+			if param.Documentation != "" {
+				markdown.WriteString("  # " + strings.TrimSuffix(param.Documentation, "\n") + "\n")
+			}
+			markdown.WriteString(fmt.Sprintf("  %s: %s\n", param.Name, param.Type))
+		}
+
+		markdown.WriteString("```\n\n")
+	}
+
+	return markdown.Bytes()
+}
+
+func main() {
+	compilerPassComments, err := buildCompilerPassTypesCommentsMap(compilerPassTypesSourceDir)
+	if err != nil {
+		panic(err)
+	}
+
+	yamlCompilerPassComments, err := buildYamlCompilerPassTypesCommentsMap(yamlCompilerPassTypesSourceDir)
+	if err != nil {
+		panic(err)
+	}
+
+	docEntries := compilerPassDocEntries(compilerPassComments, yamlCompilerPassComments)
+
+	if err := os.WriteFile(outputFile, docEntriesToMarkdown(docEntries), 0600); err != nil {
+		panic(err)
+	}
+}

--- a/docs/compiler_passes.md
+++ b/docs/compiler_passes.md
@@ -1,0 +1,384 @@
+<!-- Generated with `make docs` -->
+# Compiler passes
+
+## `add_fields`
+
+AddFields rewrites the definition of an object to add new fields.
+Note: existing fields will not be overwritten.
+
+### Usage
+
+```yaml
+add_fields:
+  # Expected format: [package].[object]
+  to: string
+  fields: []ast.StructField
+```
+
+## `anonymous_structs_to_named`
+
+AnonymousStructsToNamed turns "anonymous structs" into a named object.
+
+Example:
+
+	```
+	Panel struct {
+		Options struct {
+			Title string
+		}
+	}
+	```
+
+Will become:
+
+	```
+	Panel struct {
+		Options PanelOptions
+	}
+
+	PanelOptions struct {
+		Title string
+	}
+	```
+
+### Usage
+
+```yaml
+anonymous_structs_to_named: {}
+```
+
+## `cloudwatch`
+
+Cloudwatch rewrites a part of the cloudwatch schema.
+
+In that schema, the `QueryEditorExpression` type is defined as a disjunction
+for which the discriminator and mapping can not be inferred.
+This compiler pass is here to define that mapping.
+
+The `QueryEditorArrayExpression` struct type is also modified to simplify the
+definition of its `expression` field from `[...#QueryEditorExpression] | [...#QueryEditorArrayExpression]` to
+`[...#QueryEditorExpression]`.
+This should be semantically equivalent since `#QueryEditorExpression` is a
+union type that includes `#QueryEditorArrayExpression`.
+
+The Cloudwatch pass also alerts the definition of the `#CloudWatchMetricsQuery`, `#CloudWatchLogsQuery` and
+`#CloudWatchAnnotationQuery` types.
+It removes the "dataquery variant" hint they carry, and defines a `CloudWatchQuery` type instead as a disjunction.
+That disjunction serves as "dataquery entrypoint" for cloudwatch.
+
+### Usage
+
+```yaml
+cloudwatch: {}
+```
+
+## `dashboard_panels`
+
+DashboardPanelsRewrite rewrites the definition of "panels" fields in the "dashboard" package.
+
+In the original schema, panels are defined as follows:
+
+	```
+	# In the Dashboard object
+	panels?: [...#Panel | #RowPanel | #GraphPanel | #HeatmapPanel]
+
+	# In the RowPanel object
+	panels: [...#Panel | #GraphPanel | #HeatmapPanel]
+	```
+
+These definitions become:
+
+	```
+	# In the Dashboard object
+	panels?: [...#Panel | #RowPanel]
+
+	# In the RowPanel object
+	panels: [...#Panel]
+	```
+
+### Usage
+
+```yaml
+dashboard_panels: {}
+```
+
+## `dataquery_identification`
+
+N/A
+
+### Usage
+
+```yaml
+dataquery_identification: {}
+```
+
+## `disjunction_infer_mapping`
+
+DisjunctionInferMapping infers the discriminator field and mapping used to
+describe a disjunction of references.
+See https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+
+### Usage
+
+```yaml
+disjunction_infer_mapping: {}
+```
+
+## `disjunction_of_anonymous_structs_to_explicit`
+
+DisjunctionOfAnonymousStructsToExplicit looks for anonymous structs used as
+branches of disjunctions and turns them into explicitly named types.
+
+### Usage
+
+```yaml
+disjunction_of_anonymous_structs_to_explicit: {}
+```
+
+## `disjunction_to_type`
+
+DisjunctionToType transforms disjunction into a struct, mapping disjunction branches to
+an optional and nullable field in that struct.
+
+Example:
+
+		```
+		SomeType: {
+			type: "some-type"
+	 	}
+		SomeOtherType: {
+			type: "other-type"
+	 	}
+		SomeStruct: {
+			foo: string | bool
+		}
+		OtherStruct: {
+			bar: SomeType | SomeOtherType
+		}
+		```
+
+Will become:
+
+		```
+		SomeType: {
+			type: "some-type"
+	 	}
+		SomeOtherType: {
+			type: "other-type"
+	 	}
+		StringOrBool: {
+			string: *string
+			bool: *string
+		}
+		SomeStruct: {
+			foo: StringOrBool
+		}
+		SomeTypeOrSomeOtherType: {
+			SomeType: *SomeType
+			SomeOtherType: *SomeOtherType
+		}
+		OtherStruct: {
+			bar: SomeTypeOrSomeOtherType
+		}
+		```
+
+### Usage
+
+```yaml
+disjunction_to_type: {}
+```
+
+## `disjunction_with_constant_to_default`
+
+N/A
+
+### Usage
+
+```yaml
+disjunction_with_constant_to_default: {}
+```
+
+## `entrypoint_identification`
+
+N/A
+
+### Usage
+
+```yaml
+entrypoint_identification: {}
+```
+
+## `fields_set_default`
+
+FieldsSetDefault sets the default value for the given fields.
+
+### Usage
+
+```yaml
+fields_set_default:
+  defaults: map[string]interface {}
+```
+
+## `fields_set_not_required`
+
+FieldsSetNotRequired rewrites the definition of given fields to mark them as nullable and not required.
+
+### Usage
+
+```yaml
+fields_set_not_required:
+  fields: []string
+```
+
+## `fields_set_required`
+
+FieldsSetRequired rewrites the definition of given fields to mark them as not nullable and required.
+
+### Usage
+
+```yaml
+fields_set_required:
+  fields: []string
+```
+
+## `google_cloud_monitoring`
+
+GoogleCloudMonitoring rewrites a part of the googlecloudmonitoring schema.
+
+Older schemas (pre 10.2.x) define `CloudMonitoringQuery.timeSeriesList`
+as a disjunction that cog can't handle: `timeSeriesList?: #TimeSeriesList | #AnnotationQuery`,
+where `AnnotationQuery` is a type that extends `TimeSeriesList` to add two
+fields.
+
+This compiler pass checks for the presence of that disjunction, and rewrites
+it as a reference to `TimeSeriesList`. It also adds the two missing fields
+to this type if they aren't already defined.
+
+### Usage
+
+```yaml
+google_cloud_monitoring: {}
+```
+
+## `hint_object`
+
+N/A
+
+### Usage
+
+```yaml
+hint_object:
+  object: string
+  hints: JenniesHints
+```
+
+## `library_panels`
+
+LibraryPanels rewrites the definition of the "LibraryPanel" object in the "librarypanel" package.
+
+In the original schema, the "model" field is left mainly undefined but a comment indicates
+that it should be the same panel schema defined in dashboard with a few fields omitted.
+
+This compiler pass implements the modifications described in that comment to define the
+"model" field as:
+
+	```
+	# In the LibraryPanel object
+	model: Omit<dashboard.Panel, 'gridPos' | 'id' | 'libraryPanel'>
+	```
+
+Note: this pass needs the "dashboard.Panel" schema to be parsed. Barring that, it leaves
+the schemas untouched.
+
+### Usage
+
+```yaml
+library_panels: {}
+```
+
+## `name_anonymous_struct`
+
+NameAnonymousStruct rewrites the definition of a struct field typed as an
+anonymous struct to instead refer to a named type.
+
+### Usage
+
+```yaml
+name_anonymous_struct:
+  field: string
+  as: string
+```
+
+## `omit`
+
+Omit rewrites schemas to omit the configured objects.
+
+### Usage
+
+```yaml
+omit:
+  objects: []string
+```
+
+## `rename_object`
+
+N/A
+
+### Usage
+
+```yaml
+rename_object:
+  from: string
+  to: string
+```
+
+## `retype_field`
+
+N/A
+
+### Usage
+
+```yaml
+retype_field:
+  field: string
+  as: Type
+  comments: []string
+```
+
+## `retype_object`
+
+N/A
+
+### Usage
+
+```yaml
+retype_object:
+  object: string
+  as: Type
+  comments: []string
+```
+
+## `schema_set_identifier`
+
+SchemaSetIdentifier overwrites the Metadata.Identifier field of a schema.
+
+### Usage
+
+```yaml
+schema_set_identifier:
+  package: string
+  identifier: string
+```
+
+## `unspec`
+
+Unspec removes the Kubernetes-style envelope added by kindsys.
+
+Objects named "spec" will be renamed, using the package as new name.
+
+### Usage
+
+```yaml
+unspec: {}
+```
+

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -119,21 +119,21 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 type EntrypointIdentification struct {
 }
 
-func (pass EntrypointIdentification) AsCompilerPass() compiler.Pass {
+func (pass EntrypointIdentification) AsCompilerPass() *compiler.InferEntrypoint {
 	return &compiler.InferEntrypoint{}
 }
 
 type DataqueryIdentification struct {
 }
 
-func (pass DataqueryIdentification) AsCompilerPass() compiler.Pass {
+func (pass DataqueryIdentification) AsCompilerPass() *compiler.DataqueryIdentification {
 	return &compiler.DataqueryIdentification{}
 }
 
 type Unspec struct {
 }
 
-func (pass Unspec) AsCompilerPass() compiler.Pass {
+func (pass Unspec) AsCompilerPass() *compiler.Unspec {
 	return &compiler.Unspec{}
 }
 
@@ -141,7 +141,7 @@ type FieldsSetDefault struct {
 	Defaults map[string]any // Expected format: [package].[object].[field] → value
 }
 
-func (pass FieldsSetDefault) AsCompilerPass() (compiler.Pass, error) {
+func (pass FieldsSetDefault) AsCompilerPass() (*compiler.FieldsSetDefault, error) {
 	defaults := make(map[compiler.FieldReference]any, len(pass.Defaults))
 
 	for ref, value := range pass.Defaults {
@@ -160,7 +160,7 @@ type FieldsSetRequired struct {
 	Fields []string // Expected format: [package].[object].[field]
 }
 
-func (pass FieldsSetRequired) AsCompilerPass() (compiler.Pass, error) {
+func (pass FieldsSetRequired) AsCompilerPass() (*compiler.FieldsSetRequired, error) {
 	fieldRefs := make([]compiler.FieldReference, 0, len(pass.Fields))
 
 	for _, ref := range pass.Fields {
@@ -179,7 +179,7 @@ type FieldsSetNotRequired struct {
 	Fields []string // Expected format: [package].[object].[field]
 }
 
-func (pass FieldsSetNotRequired) AsCompilerPass() (compiler.Pass, error) {
+func (pass FieldsSetNotRequired) AsCompilerPass() (*compiler.FieldsSetNotRequired, error) {
 	fieldRefs := make([]compiler.FieldReference, 0, len(pass.Fields))
 
 	for _, ref := range pass.Fields {
@@ -198,7 +198,7 @@ type Omit struct {
 	Objects []string // Expected format: [package].[object]
 }
 
-func (pass Omit) AsCompilerPass() (compiler.Pass, error) {
+func (pass Omit) AsCompilerPass() (*compiler.Omit, error) {
 	objectRefs := make([]compiler.ObjectReference, 0, len(pass.Objects))
 
 	for _, ref := range pass.Objects {
@@ -214,11 +214,12 @@ func (pass Omit) AsCompilerPass() (compiler.Pass, error) {
 }
 
 type AddFields struct {
-	To     string // Expected format: [package].[object]
+	// Expected format: [package].[object]
+	To     string
 	Fields []ast.StructField
 }
 
-func (pass AddFields) AsCompilerPass() (compiler.Pass, error) {
+func (pass AddFields) AsCompilerPass() (*compiler.AddFields, error) {
 	objectRef, err := compiler.ObjectReferenceFromString(pass.To)
 	if err != nil {
 		return nil, err
@@ -235,7 +236,7 @@ type NameAnonymousStruct struct {
 	As    string
 }
 
-func (pass NameAnonymousStruct) AsCompilerPass() (compiler.Pass, error) {
+func (pass NameAnonymousStruct) AsCompilerPass() (*compiler.NameAnonymousStruct, error) {
 	fieldRef, err := compiler.FieldReferenceFromString(pass.Field)
 	if err != nil {
 		return nil, err
@@ -253,7 +254,7 @@ type RetypeObject struct {
 	Comments []string
 }
 
-func (pass RetypeObject) AsCompilerPass() (compiler.Pass, error) {
+func (pass RetypeObject) AsCompilerPass() (*compiler.RetypeObject, error) {
 	objectRef, err := compiler.ObjectReferenceFromString(pass.Object)
 	if err != nil {
 		return nil, err
@@ -271,7 +272,7 @@ type HintObject struct {
 	Hints  ast.JenniesHints
 }
 
-func (pass HintObject) AsCompilerPass() (compiler.Pass, error) {
+func (pass HintObject) AsCompilerPass() (*compiler.HintObject, error) {
 	objectRef, err := compiler.ObjectReferenceFromString(pass.Object)
 	if err != nil {
 		return nil, err
@@ -288,7 +289,7 @@ type RenameObject struct {
 	To   string
 }
 
-func (pass RenameObject) AsCompilerPass() (compiler.Pass, error) {
+func (pass RenameObject) AsCompilerPass() (*compiler.RenameObject, error) {
 	objectRef, err := compiler.ObjectReferenceFromString(pass.From)
 	if err != nil {
 		return nil, err
@@ -306,7 +307,7 @@ type RetypeField struct {
 	Comments []string
 }
 
-func (pass RetypeField) AsCompilerPass() (compiler.Pass, error) {
+func (pass RetypeField) AsCompilerPass() (*compiler.RetypeField, error) {
 	fieldRef, err := compiler.FieldReferenceFromString(pass.Field)
 	if err != nil {
 		return nil, err
@@ -324,7 +325,7 @@ type SchemaSetIdentifier struct {
 	Identifier string
 }
 
-func (pass SchemaSetIdentifier) AsCompilerPass() (compiler.Pass, error) {
+func (pass SchemaSetIdentifier) AsCompilerPass() (*compiler.SchemaSetIdentifier, error) {
 	return &compiler.SchemaSetIdentifier{
 		Package:    pass.Package,
 		Identifier: pass.Identifier,
@@ -334,62 +335,62 @@ func (pass SchemaSetIdentifier) AsCompilerPass() (compiler.Pass, error) {
 type AnonymousStructsToNamed struct {
 }
 
-func (pass AnonymousStructsToNamed) AsCompilerPass() (compiler.Pass, error) {
+func (pass AnonymousStructsToNamed) AsCompilerPass() (*compiler.AnonymousStructsToNamed, error) {
 	return &compiler.AnonymousStructsToNamed{}, nil
 }
 
 type DisjunctionToType struct {
 }
 
-func (pass DisjunctionToType) AsCompilerPass() (compiler.Pass, error) {
+func (pass DisjunctionToType) AsCompilerPass() (*compiler.DisjunctionToType, error) {
 	return &compiler.DisjunctionToType{}, nil
 }
 
 type DisjunctionOfAnonymousStructsToExplicit struct {
 }
 
-func (pass DisjunctionOfAnonymousStructsToExplicit) AsCompilerPass() (compiler.Pass, error) {
+func (pass DisjunctionOfAnonymousStructsToExplicit) AsCompilerPass() (*compiler.DisjunctionOfAnonymousStructsToExplicit, error) {
 	return &compiler.DisjunctionOfAnonymousStructsToExplicit{}, nil
 }
 
 type DisjunctionInferMapping struct {
 }
 
-func (pass DisjunctionInferMapping) AsCompilerPass() (compiler.Pass, error) {
+func (pass DisjunctionInferMapping) AsCompilerPass() (*compiler.DisjunctionInferMapping, error) {
 	return &compiler.DisjunctionInferMapping{}, nil
 }
 
 type DisjunctionWithConstantToDefault struct {
 }
 
-func (pass DisjunctionWithConstantToDefault) AsCompilerPass() (compiler.Pass, error) {
+func (pass DisjunctionWithConstantToDefault) AsCompilerPass() (*compiler.DisjunctionWithConstantToDefault, error) {
 	return &compiler.DisjunctionWithConstantToDefault{}, nil
 }
 
 type DashboardPanels struct {
 }
 
-func (pass DashboardPanels) AsCompilerPass() compiler.Pass {
+func (pass DashboardPanels) AsCompilerPass() *compiler.DashboardPanelsRewrite {
 	return &compiler.DashboardPanelsRewrite{}
 }
 
 type Cloudwatch struct {
 }
 
-func (pass Cloudwatch) AsCompilerPass() compiler.Pass {
+func (pass Cloudwatch) AsCompilerPass() *compiler.Cloudwatch {
 	return &compiler.Cloudwatch{}
 }
 
 type GoogleCloudMonitoring struct {
 }
 
-func (pass GoogleCloudMonitoring) AsCompilerPass() compiler.Pass {
+func (pass GoogleCloudMonitoring) AsCompilerPass() *compiler.GoogleCloudMonitoring {
 	return &compiler.GoogleCloudMonitoring{}
 }
 
 type LibraryPanels struct {
 }
 
-func (pass LibraryPanels) AsCompilerPass() compiler.Pass {
+func (pass LibraryPanels) AsCompilerPass() *compiler.LibraryPanels {
 	return &compiler.LibraryPanels{}
 }


### PR DESCRIPTION
Rather than having to look at the source to know which compiler passes are usable, we could generate a markdown file to list them.

Warning: the generation process for this doc relies on dark magic :see_no_evil: 