### PR TITLE
fix(inputs): get metadata from config

### DIFF
--- a/cmd/cli/loaders/jsonschema.go
+++ b/cmd/cli/loaders/jsonschema.go
@@ -21,6 +21,9 @@ type JSONSchemaInput struct {
 	// Package name to use for the input schema. If empty, it will be guessed
 	// from the input file name.
 	Package string `yaml:"package"`
+
+	// Metadata to add to the schema, this can be used to set Kind and Variant
+	Metadata ast.SchemaMeta `yaml:"metadata"`
 }
 
 func (input *JSONSchemaInput) InterpolateParameters(interpolator ParametersInterpolator) {
@@ -56,7 +59,7 @@ func (input *JSONSchemaInput) LoadSchemas(ctx context.Context) (ast.Schemas, err
 
 	schema, err := jsonschema.GenerateAST(schemaReader, jsonschema.Config{
 		Package:        input.packageName(),
-		SchemaMetadata: ast.SchemaMeta{}, // TODO: extract these from somewhere
+		SchemaMetadata: input.Metadata,
 	})
 	if err != nil {
 		return nil, err

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -36,6 +36,9 @@ inputs:
     jsonschema:
       url: 'https://raw.githubusercontent.com/grafana/grafana/%grafana_version%/pkg/tsdb/grafana-testdata-datasource/kinds/query.panel.schema.json'
       package: testdata
+      metadata:
+        kind: composable
+        variant: dataquery
       transformations:
         - '%__config_dir%/compiler/testdata_passes.yaml'
 

--- a/config/foundation_sdk.yaml
+++ b/config/foundation_sdk.yaml
@@ -39,6 +39,9 @@ inputs:
     jsonschema:
       url: 'https://raw.githubusercontent.com/grafana/grafana/%grafana_version%/pkg/tsdb/grafana-testdata-datasource/kinds/query.panel.schema.json'
       package: testdata
+      metadata:
+        kind: composable
+        variant: dataquery
       transformations:
         - '%__config_dir%/compiler/testdata_passes.yaml'
 


### PR DESCRIPTION
I was relying on this metadata to include the right schema into Grafonnet. This PR fetches the metadata in the main config.