### PR TITLE
Java: Fix alerting generation

### DIFF
--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -93,7 +93,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))
 
-		// Because we need to check the package only, it could have multiple files and we want to generate
+		// Because we need to check the package only, it could have multiple files, and we want to generate
 		// the builder once.
 		if !alreadyValidatedPanel[schema.Package] {
 			panelOutput, innerErr := jenny.generatePanelBuilder(schema.Package)

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -68,6 +68,8 @@ func (tf *typeFormatter) formatReference(def ast.RefType) string {
 		return formatScalarType(object.Type.AsScalar())
 	case ast.KindMap:
 		return tf.formatMap(object.Type.AsMap())
+	case ast.KindArray:
+		return tf.formatArray(object.Type.AsArray())
 	default:
 		tf.packageMapper(def.ReferredPkg, def.ReferredType)
 		return def.ReferredType
@@ -80,12 +82,12 @@ func (tf *typeFormatter) formatArray(def ast.ArrayType) string {
 }
 
 func (tf *typeFormatter) formatMap(def ast.MapType) string {
+	tf.packageMapper("java.util", "Map")
 	mapType := "unknown"
 	switch def.ValueType.Kind {
 	case ast.KindRef:
 		ref := def.ValueType.AsRef()
 		tf.packageMapper(ref.ReferredPkg, ref.ReferredType)
-		tf.packageMapper("java.util", "Map")
 		mapType = ref.ReferredType
 	case ast.KindScalar:
 		mapType = formatScalarType(def.ValueType.AsScalar())

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -1,5 +1,6 @@
 package nullable_map_assignment;
 
+import java.util.Map;
 
 public class SomeStruct {
     public Map<String, String> config;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -1,6 +1,7 @@
 package struct_complex_fields;
 
 import java.util.List;
+import java.util.Map;
 
 // This struct does things.
 public class SomeStruct {


### PR DESCRIPTION
Maps were adding the import only for references and we weren't checking if a reference was an array. In this second case, we were setting values like `Matchers` and `ObjectMatchers` that are array aliases and they aren't allowed in Java.

Before:
```java
public Matchers matchers;
public ObjectMatchers objectMatchers;
```

After:
```java
public List<Matcher> matchers;
public List<List<String>> objectMatchers;
```