### PR TITLE
Expose a way to manually position panels in a dashboard

### DIFF
--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -207,9 +207,14 @@ options:
   - array_to_append:
       by_name: Panel.withTransformation
 
+  # We want to offer both the ability to set gridPos entirely manually,
+  # or to use span/height-based automatic layout
+  - duplicate:
+      by_name: Panel.gridPos
+      as: tmpGridPos
   # W(), H() instead of explicit GridPos() definition
   - struct_fields_as_options:
-      by_name: Panel.gridPos
+      by_name: Panel.tmpGridPos
       fields: [w, h]
   # W() → Span()
   - rename:

--- a/internal/jennies/golang/templates/builders/veneers/assignment_Dashboard_withPanel.tmpl
+++ b/internal/jennies/golang/templates/builders/veneers/assignment_Dashboard_withPanel.tmpl
@@ -1,8 +1,14 @@
 {{- define "pre_assignment_Dashboard_withPanel" }}
 
-	// Position the panel on the grid
-	panelResource.GridPos.X = builder.currentX
-	panelResource.GridPos.Y = builder.currentY
+	if panelResource.GridPos == nil {
+		panelResource.GridPos = &GridPos{}
+	}
+	// The panel either has no position set, or it is the first panel of the dashboard.
+	// In that case, we position it on the grid
+	if panelResource.GridPos.X == 0 && panelResource.GridPos.Y == 0 {
+		panelResource.GridPos.X = builder.currentX
+		panelResource.GridPos.Y = builder.currentY
+	}
 {{- end }}
 
 {{- define "post_assignment_Dashboard_withPanel" }}

--- a/internal/jennies/golang/templates/builders/veneers/assignment_Dashboard_withRow.tmpl
+++ b/internal/jennies/golang/templates/builders/veneers/assignment_Dashboard_withRow.tmpl
@@ -19,9 +19,12 @@
 
 	// Position the row's panels on the grid
 	for _, panel := range rowPanelResource.Panels {
-		// Position the panel on the grid
-		panel.GridPos.X = builder.currentX
-		panel.GridPos.Y = builder.currentY
+		// The panel either has no position set, or it is the first panel of the dashboard.
+		// In that case, we position it on the grid
+		if panel.GridPos.X == 0 && panel.GridPos.Y == 0 {
+			panel.GridPos.X = builder.currentX
+			panel.GridPos.Y = builder.currentY
+		}
 
 		// Prepare the coordinates for the next panel
 		builder.currentX += panel.GridPos.W

--- a/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
+++ b/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
@@ -3,9 +3,12 @@
     if (panelOrRowPanel.panel.gridPos == null) {
         panelOrRowPanel.panel.gridPos = new GridPos();
     }
-	// Position the panel on the grid
-	panelOrRowPanel.panel.gridPos.x = this.currentX;
-	panelOrRowPanel.panel.gridPos.y = this.currentY;
+    // The panel either has no position set, or it is the first panel of the dashboard.
+    // In that case, we position it on the grid
+    if (panelOrRowPanel.panel.gridPos.x == 0 && panelOrRowPanel.panel.gridPos.y == 0) {
+        panelOrRowPanel.panel.gridPos.x = this.currentX;
+        panelOrRowPanel.panel.gridPos.y = this.currentY;
+    }
 {{- end }}
 
 {{- define "post_assignment_Dashboard_withPanel" }}

--- a/internal/jennies/python/templates/builders/veneers/assignment_Dashboard_withPanel.tmpl
+++ b/internal/jennies/python/templates/builders/veneers/assignment_Dashboard_withPanel.tmpl
@@ -1,11 +1,13 @@
 {{- define "pre_assignment_Dashboard_withPanel" }}
 
-# Position the panel on the grid
 if panel_resource.grid_pos is None:
     panel_resource.grid_pos = dashboard.GridPos()
 
-panel_resource.grid_pos.x = self.__current_x
-panel_resource.grid_pos.y = self.__current_y
+# The panel either has no position set, or it is the first panel of the dashboard.
+# In that case, we position it on the grid
+if panel_resource.grid_pos.x == 0 and panel_resource.grid_pos.y == 0:
+    panel_resource.grid_pos.x = self.__current_x
+    panel_resource.grid_pos.y = self.__current_y
 {{- end }}
 
 {{- define "post_assignment_Dashboard_withPanel" }}

--- a/internal/jennies/python/templates/builders/veneers/assignment_Dashboard_withRow.tmpl
+++ b/internal/jennies/python/templates/builders/veneers/assignment_Dashboard_withRow.tmpl
@@ -22,8 +22,11 @@ for panel in row_panel_resource.panels:
     if panel.grid_pos is None:
         panel.grid_pos = dashboard.GridPos()
 
-    panel.grid_pos.x = self.__current_x
-    panel.grid_pos.y = self.__current_y
+    # The panel either has no position set, or it is the first panel of the dashboard.
+    # In that case, we position it on the grid
+    if panel.grid_pos.x == 0 and panel.grid_pos.y == 0:
+        panel.grid_pos.x = self.__current_x
+        panel.grid_pos.y = self.__current_y
 
     # Prepare the coordinates for the next panel
     self.__current_x += panel.grid_pos.w

--- a/internal/jennies/typescript/templates/veneers/assignment_Dashboard_withPanel.tmpl
+++ b/internal/jennies/typescript/templates/veneers/assignment_Dashboard_withPanel.tmpl
@@ -4,9 +4,12 @@
 			panelResource.gridPos = dashboard.defaultGridPos();
 		}
 
-		// Position the panel on the grid
-		panelResource.gridPos.x = this.currentX;
-		panelResource.gridPos.y = this.currentY;
+		// The panel either has no position set, or it is the first panel of the dashboard.
+		// In that case, we position it on the grid
+		if (panelResource.gridPos.x == 0 && panelResource.gridPos.y == 0) {
+			panelResource.gridPos.x = this.currentX;
+			panelResource.gridPos.y = this.currentY;
+		}
 {{- end }}
 
 {{- define "post_assignment_Dashboard_withPanel" }}

--- a/internal/jennies/typescript/templates/veneers/assignment_Dashboard_withRow.tmpl
+++ b/internal/jennies/typescript/templates/veneers/assignment_Dashboard_withRow.tmpl
@@ -23,9 +23,12 @@
 				panel.gridPos = dashboard.defaultGridPos();
 			}
 
-			// Position the panel on the grid
-			panel.gridPos.x = this.currentX;
-			panel.gridPos.y = this.currentY;
+			// The panel either has no position set, or it is the first panel of the dashboard.
+			// In that case, we position it on the grid
+			if (panel.gridPos.x == 0 && panel.gridPos.y == 0) {
+				panel.gridPos.x = this.currentX;
+				panel.gridPos.y = this.currentY;
+			}
 
 			// Prepare the coordinates for the next panel
 			this.currentX += panel.gridPos.w;


### PR DESCRIPTION
While the span/height-based automatic layout for panels is convenient, having a way to manually position panels in a dashboard can be useful (especially when users want a specific and _non-standard_ layout)