### PR TITLE
Simplecue/parse time

### DIFF
--- a/internal/ast/hints.go
+++ b/internal/ast/hints.go
@@ -19,6 +19,10 @@ const (
 	// HintSkipVariantPluginRegistration preserves the variant hint on a type, but
 	// tells the jennies to not register it as a plugin.
 	HintSkipVariantPluginRegistration = "skip_variant_plugin_registration"
+
+	// HintStringFormatDateTime hints refers to a string that should be formatted
+	// as a datetime as defined by RFC 3339, section 5.6 (ex: 2017-07-21T17:32:28Z)
+	HintStringFormatDateTime = "string_format_datetime"
 )
 
 const DiscriminatorCatchAll = "cog_discriminator_catch_all"

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -67,14 +67,14 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 
 		if def.IsScalar() {
 			typeName := def.AsScalar().ScalarKind
+			if def.HasHint(ast.HintStringFormatDateTime) {
+				typeName = "time.Time"
+			}
 			if def.Nullable {
 				typeName = "*" + typeName
 			}
 			if def.AsScalar().ScalarKind == ast.KindBytes {
 				typeName = "[]byte"
-			}
-			if def.HasHint(ast.HintStringFormatDateTime) {
-				typeName = "time.Time"
 			}
 
 			return string(typeName)

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -73,6 +73,9 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			if def.AsScalar().ScalarKind == ast.KindBytes {
 				typeName = "[]byte"
 			}
+			if def.HasHint(ast.HintStringFormatDateTime) {
+				typeName = "time.Time"
+			}
 
 			return string(typeName)
 		}

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -139,9 +139,15 @@ func (jenny Schema) formatScalar(typeDef ast.Type) Definition {
 	case ast.KindAny:
 		definition.Set("type", "object")
 		definition.Set("additionalProperties", map[string]any{})
-	case ast.KindBytes, ast.KindString:
+	case ast.KindBytes:
 		definition.Set("type", "string")
 		jenny.addStringConstraints(definition, typeDef)
+	case ast.KindString:
+		definition.Set("type", "string")
+		jenny.addStringConstraints(definition, typeDef)
+		if typeDef.HasHint(ast.HintStringFormatDateTime) {
+			definition.Set("format", "date-time")
+		}
 	case ast.KindBool:
 		definition.Set("type", "boolean")
 	case ast.KindFloat32, ast.KindFloat64:

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -24,6 +24,8 @@ const (
 	typeString  = "string"
 	typeNumber  = "number"
 	typeInteger = "integer"
+
+	formatDateTime = "date-time"
 )
 
 type Config struct {
@@ -305,6 +307,10 @@ func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 	// ```
 	if schema.Pattern != nil && tools.RegexMatchesConstantString(schema.Pattern.String()) {
 		def.Scalar.Value = tools.ConstantStringFromRegex(schema.Pattern.String())
+	}
+
+	if schema.Format == formatDateTime {
+		def.Hints[ast.HintStringFormatDateTime] = true
 	}
 
 	if schema.MinLength != -1 {

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -176,8 +176,10 @@ func (g *generator) walkArray(schema *openapi3.Schema) (ast.Type, error) {
 func (g *generator) walkString(schema *openapi3.Schema) (ast.Type, error) {
 	var t ast.Type
 	switch schema.Format {
-	case FormatDate, FormatDateTime, FormatPassword:
-		t = ast.String()
+	case FormatDateTime:
+		t = ast.String(ast.Hints(ast.JenniesHints{
+			ast.HintStringFormatDateTime: true,
+		}))
 	case FormatByte:
 		t = ast.Bytes()
 	default:

--- a/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
@@ -1,0 +1,8 @@
+package time_hint
+
+type ObjTime time.Time
+
+type ObjWithTimeField struct {
+	RegisteredAt time.Time `json:"registeredAt"`
+}
+

--- a/testdata/jennies/rawtypes/time_hint/JSONSchema/time_hint.jsonschema.json
+++ b/testdata/jennies/rawtypes/time_hint/JSONSchema/time_hint.jsonschema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "objTime": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "objWithTimeField": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "registeredAt"
+      ],
+      "properties": {
+        "registeredAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
+++ b/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
@@ -1,0 +1,6 @@
+package time_hint;
+
+
+public class ObjWithTimeField {
+    public String registeredAt;
+}

--- a/testdata/jennies/rawtypes/time_hint/OpenAPI/time_hint.openapi.json
+++ b/testdata/jennies/rawtypes/time_hint/OpenAPI/time_hint.openapi.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "time_hint",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "objTime": {
+        "type": "string",
+        "format": "date-time"
+      },
+      "objWithTimeField": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "registeredAt"
+        ],
+        "properties": {
+          "registeredAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/time_hint/PythonRawTypes/models/time_hint.py
+++ b/testdata/jennies/rawtypes/time_hint/PythonRawTypes/models/time_hint.py
@@ -1,0 +1,29 @@
+import typing
+
+
+ObjTime: typing.TypeAlias = str
+
+
+class ObjWithTimeField:
+    registered_at: str
+
+    def __init__(self, registered_at: str = ""):
+        self.registered_at = registered_at
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "registeredAt": self.registered_at,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "registeredAt" in data:
+            args["registered_at"] = data["registeredAt"]        
+
+        return cls(**args)
+
+
+

--- a/testdata/jennies/rawtypes/time_hint/TypescriptRawTypes/src/timeHint/types.gen.ts
+++ b/testdata/jennies/rawtypes/time_hint/TypescriptRawTypes/src/timeHint/types.gen.ts
@@ -1,0 +1,12 @@
+export type objTime = string;
+
+export const defaultObjTime = (): objTime => ("");
+
+export interface objWithTimeField {
+	registeredAt: string;
+}
+
+export const defaultObjWithTimeField = (): objWithTimeField => ({
+	registeredAt: "",
+});
+

--- a/testdata/jennies/rawtypes/time_hint/ir.json
+++ b/testdata/jennies/rawtypes/time_hint/ir.json
@@ -1,0 +1,42 @@
+{
+  "Package": "time_hint",
+  "Objects": {
+    "objTime": {
+      "Name": "objTime",
+      "Type": {
+        "Kind": "scalar",
+        "Scalar": {
+          "ScalarKind": "string"
+        },
+        "Hints": {
+          "string_format_datetime": true
+        }
+      }
+    },
+    "objWithTimeField": {
+      "Name": "objWithTimeField",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "registeredAt",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                },
+                "Hints": {
+                  "string_format_datetime": true
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/testdata/jsonschema/time/GenerateAST/ir.json
+++ b/testdata/jsonschema/time/GenerateAST/ir.json
@@ -1,0 +1,36 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "EntryPoint": "SomeObject",
+  "Objects": {
+    "SomeObject": {
+      "Name": "SomeObject",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "registeredAt",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                },
+                "Hints": {
+                  "string_format_datetime": true
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "SomeObject"
+      }
+    }
+  }
+}

--- a/testdata/jsonschema/time/schema.json
+++ b/testdata/jsonschema/time/schema.json
@@ -1,0 +1,14 @@
+{
+  "$ref": "#/definitions/SomeObject",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeObject": {
+      "properties": {
+        "registeredAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/testdata/openapi/time/GenerateAST/ir.json
+++ b/testdata/openapi/time/GenerateAST/ir.json
@@ -1,0 +1,35 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": {
+    "SomeObject": {
+      "Name": "SomeObject",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "registeredAt",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                },
+                "Hints": {
+                  "string_format_datetime": true
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "SomeObject"
+      }
+    }
+  }
+}

--- a/testdata/openapi/time/schema.json
+++ b/testdata/openapi/time/schema.json
@@ -1,0 +1,21 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "time",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "SomeObject": {
+        "type": "object",
+        "properties": {
+          "registeredAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/simplecue/strings_constraints/GenerateAST/ir.json
+++ b/testdata/simplecue/strings_constraints/GenerateAST/ir.json
@@ -1,0 +1,84 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": {
+    "container": {
+      "Name": "container",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "minLengthConstraints",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Constraints": [
+                    {
+                      "Op": "minLength",
+                      "Args": [
+                        1
+                      ]
+                    }
+                  ]
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "maxLengthConstraints",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Constraints": [
+                    {
+                      "Op": "maxLength",
+                      "Args": [
+                        64
+                      ]
+                    }
+                  ]
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "minMaxLengthConstraints",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string",
+                  "Constraints": [
+                    {
+                      "Op": "minLength",
+                      "Args": [
+                        2
+                      ]
+                    },
+                    {
+                      "Op": "maxLength",
+                      "Args": [
+                        8
+                      ]
+                    }
+                  ]
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "container"
+      }
+    }
+  }
+}

--- a/testdata/simplecue/strings_constraints/schema.cue
+++ b/testdata/simplecue/strings_constraints/schema.cue
@@ -1,0 +1,7 @@
+import "strings"
+
+container: {
+    minLengthConstraints: string & strings.MinRunes(1)
+    maxLengthConstraints: string & strings.MaxRunes(64)
+    minMaxLengthConstraints: string & strings.MinRunes(2) & strings.MaxRunes(8)
+}

--- a/testdata/simplecue/time/GenerateAST/ir.json
+++ b/testdata/simplecue/time/GenerateAST/ir.json
@@ -1,0 +1,49 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "Objects": {
+    "User": {
+      "Name": "User",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "registeredAt",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                },
+                "Hints": {
+                  "string_format_datetime": true
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "subscribedAt",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                },
+                "Hints": {
+                  "string_format_datetime": true
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "User"
+      }
+    }
+  }
+}

--- a/testdata/simplecue/time/schema.cue
+++ b/testdata/simplecue/time/schema.cue
@@ -1,0 +1,6 @@
+import "time"
+
+User: {
+	registeredAt: string & time.Time
+	subscribedAt: time.Time
+}


### PR DESCRIPTION
Relates to #143

For cog to be considered as an option to help with codegen use-cases in https://github.com/grafana/grafana-app-sdk, we need to have at least a basic support of "datetime hinted" strings (especially in Go).