### PR TITLE
Java: Update paths

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -58,6 +58,7 @@ func (b Builders) genPanelBuilder(pkg string) (template.Builder, bool) {
 		return template.Builder{}, false
 	}
 
+	b.typeFormatter.packageMapper("dashboard", "Panel")
 	return b.genBuilder(pkg, "Panel")
 }
 

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -43,7 +43,7 @@ func (b Builders) genBuilder(pkg string, name string) (template.Builder, bool) {
 
 	object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
 	return template.Builder{
-		Package:     builder.Package,
+		Package:     fmt.Sprintf("%s.%s", packagePath, builder.Package),
 		ObjectName:  tools.UpperCamelCase(object.Name),
 		BuilderName: builder.Name,
 		Constructor: builder.Constructor,

--- a/internal/jennies/java/imports.go
+++ b/internal/jennies/java/imports.go
@@ -7,6 +7,10 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 )
 
+var ignorePaths = map[string]bool{
+	"java.util": true,
+}
+
 func NewImportMap() *common.DirectImportMap {
 	return common.NewDirectImportMap(
 		common.WithAliasSanitizer[common.DirectImportMap](func(alias string) string {
@@ -19,10 +23,18 @@ func NewImportMap() *common.DirectImportMap {
 
 			statements := make([]string, 0, importMap.Imports.Len())
 			importMap.Imports.Iterate(func(class string, importPath string) {
-				statements = append(statements, fmt.Sprintf("import %s.%s;", importPath, class))
+				statements = append(statements, fmt.Sprintf("import %s.%s;", setPackagePath(importPath), class))
 			})
 
 			return strings.Join(statements, "\n") + "\n"
 		}),
 	)
+}
+
+func setPackagePath(importPath string) string {
+	if _, ok := ignorePaths[importPath]; ok {
+		return importPath
+	}
+
+	return fmt.Sprintf("%s.%s", packagePath, importPath)
 }

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -13,6 +13,7 @@ import (
 )
 
 const projectPath = "src/main/java/com/grafana/foundation"
+const packagePath = "com.grafana.foundation"
 
 type RawTypes struct {
 	imports *common.DirectImportMap
@@ -209,7 +210,7 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 	builder, hasBuilder := jenny.builders.genBuilder(pkg, object.Name)
 
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
-		Package:    pkg,
+		Package:    fmt.Sprintf("%s.%s", packagePath, pkg),
 		Imports:    jenny.imports,
 		Name:       tools.UpperCamelCase(object.Name),
 		Fields:     fields,
@@ -237,7 +238,7 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 	}
 
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/constants.tmpl", ConstantTemplate{
-		Package:   pkg,
+		Package:   fmt.Sprintf("%s.%s", packagePath, pkg),
 		Name:      "Constants",
 		Constants: constants,
 	}); err != nil {
@@ -252,7 +253,7 @@ func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, er
 	reference := jenny.typeFormatter.formatReference(object.Type.AsRef())
 
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
-		Package:  pkg,
+		Package:  fmt.Sprintf("%s.%s", packagePath, pkg),
 		Imports:  jenny.imports,
 		Name:     tools.UpperCamelCase(object.Name),
 		Extends:  []string{reference},
@@ -282,7 +283,7 @@ func (jenny RawTypes) formatIntersection(pkg string, object ast.Object) ([]byte,
 	}
 
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
-		Package:  pkg,
+		Package:  fmt.Sprintf("%s.%s", packagePath, pkg),
 		Imports:  jenny.imports,
 		Name:     object.Name,
 		Extends:  extensions,

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -12,6 +12,8 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
+const projectPath = "src/main/java/com/grafana/foundation"
+
 type RawTypes struct {
 	imports *common.DirectImportMap
 
@@ -86,10 +88,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 			return
 		}
 
-		filename := filepath.Join(
-			pkg,
-			fmt.Sprintf("%s.java", tools.UpperCamelCase(object.Name)),
-		)
+		filename := filepath.Join(projectPath, pkg, fmt.Sprintf("%s.java", tools.UpperCamelCase(object.Name)))
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))
 
@@ -104,7 +103,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 
 			if panelOutput != nil {
 				alreadyValidatedPanel[schema.Package] = true
-				filename := filepath.Join(strings.ToLower(schema.Package), "PanelBuilder.java")
+				filename := filepath.Join(projectPath, strings.ToLower(schema.Package), "PanelBuilder.java")
 				files = append(files, *codejen.NewFile(filename, panelOutput, jenny))
 			}
 		}
@@ -120,7 +119,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 			return nil, err
 		}
 
-		filename := filepath.Join(strings.ToLower(schema.Package), "Constants.java")
+		filename := filepath.Join(projectPath, strings.ToLower(schema.Package), "Constants.java")
 		files = append(files, *codejen.NewFile(filename, output, jenny))
 	}
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -181,7 +181,7 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 	}
 
 	err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/enum.tmpl", EnumTemplate{
-		Package:  pkg,
+		Package:  fmt.Sprintf("%s.%s", packagePath, pkg),
 		Name:     object.Name,
 		Values:   values,
 		Type:     enumType,

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -215,7 +215,7 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 		Name:       tools.UpperCamelCase(object.Name),
 		Fields:     fields,
 		Comments:   object.Comments,
-		Variant:    tools.UpperCamelCase(object.Type.ImplementedVariant()),
+		Variant:    prefixVariant(object.Type.ImplementedVariant()),
 		Builder:    builder,
 		HasBuilder: hasBuilder,
 	}); err != nil {
@@ -258,7 +258,7 @@ func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, er
 		Name:     tools.UpperCamelCase(object.Name),
 		Extends:  []string{reference},
 		Comments: object.Comments,
-		Variant:  tools.UpperCamelCase(object.Type.ImplementedVariant()),
+		Variant:  prefixVariant(object.Type.ImplementedVariant()),
 	}); err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func (jenny RawTypes) formatIntersection(pkg string, object ast.Object) ([]byte,
 		Extends:  extensions,
 		Comments: object.Comments,
 		Fields:   fields,
-		Variant:  tools.UpperCamelCase(object.Type.ImplementedVariant()),
+		Variant:  prefixVariant(object.Type.ImplementedVariant()),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/jennies/java/runtime.go
+++ b/internal/jennies/java/runtime.go
@@ -3,6 +3,7 @@ package java
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/jennies/common"
@@ -27,8 +28,8 @@ func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
 	}
 
 	return codejen.Files{
-		*codejen.NewFile("cog/variants/Dataquery.java", variants, jenny),
-		*codejen.NewFile("cog/Builder.java", builder, jenny),
+		*codejen.NewFile(filepath.Join(projectPath, "cog/variants/Dataquery.java"), variants, jenny),
+		*codejen.NewFile(filepath.Join(projectPath, "cog/Builder.java"), builder, jenny),
 	}, nil
 }
 

--- a/internal/jennies/java/templates/runtime/builder.tmpl
+++ b/internal/jennies/java/templates/runtime/builder.tmpl
@@ -1,4 +1,4 @@
-package cog;
+package com.grafana.foundation.cog;
 
 public interface Builder<T> {
     public T build();

--- a/internal/jennies/java/templates/runtime/variants.tmpl
+++ b/internal/jennies/java/templates/runtime/variants.tmpl
@@ -1,4 +1,4 @@
-package cog.variants;
+package com.grafana.foundation.cog.variants;
 
 public interface {{ .Variant }} {
 }

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -9,7 +9,7 @@ package {{ .Package }};
 {{- range .Comments }}
 // {{ . }}
 {{- end }}
-public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements cog.variants.{{ .Variant }}{{ end }} {
+public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements {{ .Variant }}{{ end }} {
     {{- template "types" dict "Fields" .Fields }}
 
     {{- if .HasBuilder }}

--- a/internal/jennies/java/templates/types/panel_builder.tmpl
+++ b/internal/jennies/java/templates/types/panel_builder.tmpl
@@ -8,10 +8,10 @@ package {{ .Package }};
 
 {{- define "panelBuilder" }}
 public class PanelBuilder {
-    private dashboard.Panel internal;
+    private Panel internal;
 
     public PanelBuilder({{- template "args" .Constructor.Args }}) {
-        this.internal = new dashboard.Panel();
+        this.internal = new Panel();
         {{- range .Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
         {{- end }}
@@ -26,7 +26,7 @@ public class PanelBuilder {
     }
     {{- end }}
     
-    public dashboard.Panel build() {
+    public Panel build() {
         return this.internal;
     }
 }

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -50,7 +50,7 @@ func formatCastValue(fieldPath ast.Path) CastPath {
 	}
 
 	return CastPath{
-		Class: fmt.Sprintf("%s.%s", refPkg, refType),
+		Class: fmt.Sprintf("%s.%s.%s", packagePath, refPkg, refType),
 		Value: refType,
 		Path:  castedPath,
 	}

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -83,3 +83,11 @@ func formatAssignmentPath(fieldPath ast.Path) string {
 
 	return path
 }
+
+func prefixVariant(variant string) string {
+	if variant != "" {
+		return fmt.Sprintf("%s.cog.variants.%s", packagePath, tools.UpperCamelCase(variant))
+	}
+
+	return ""
+}

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -55,7 +55,7 @@ func (tf *typeFormatter) resolvesToComposableSlot(typeDef ast.Type) bool {
 func (tf *typeFormatter) formatBuilderFieldType(def ast.Type) string {
 	value := tf.formatFieldType(def)
 	if tf.resolvesToComposableSlot(def) || tf.typeHasBuilder(def) {
-		value = fmt.Sprintf("cog.Builder<%s>", value)
+		value = fmt.Sprintf("%s.cog.Builder<%s>", packagePath, value)
 	}
 
 	return value

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -144,9 +144,9 @@ func (tf *typeFormatter) defaultValueFor(def ast.Type) string {
 	case ast.KindRef:
 		refDef := fmt.Sprintf("%s.%s", def.AsRef().ReferredPkg, def.AsRef().ReferredType)
 		if tf.typeHasBuilder(def) {
-			return fmt.Sprintf("new %s.Builder().build()", refDef)
+			return fmt.Sprintf("new %s.%s.Builder().build()", packagePath, refDef)
 		}
-		return fmt.Sprintf("new %s()", refDef)
+		return fmt.Sprintf("new %s.%s()", packagePath, refDef)
 	case ast.KindStruct:
 		return "new Object()"
 	default:


### PR DESCRIPTION
It moves all packages/imports under `com.grafana.foundation` all generated files into `src/main/java/com/grafana/foundation` to follow the Java project convention. 

It simplifies the library generation for Maven.