### PR TITLE
Add an option to skip runtime generation for all languages

### DIFF
--- a/cmd/cli/codegen/output.go
+++ b/cmd/cli/codegen/output.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/jsonschema"
 	"github.com/grafana/cog/internal/jennies/openapi"
 	"github.com/grafana/cog/internal/jennies/python"
+	"github.com/grafana/cog/internal/jennies/typescript"
 )
 
 type Output struct {
@@ -77,7 +78,7 @@ type OutputLanguage struct {
 	JSONSchema *jsonschema.Config `yaml:"jsonschema"`
 	OpenAPI    *openapi.Config    `yaml:"openapi"`
 	Python     *python.Config     `yaml:"python"`
-	Typescript *NoConfig          `yaml:"typescript"`
+	Typescript *typescript.Config `yaml:"typescript"`
 }
 
 func (outputLanguage *OutputLanguage) interpolateParameters(interpolator ParametersInterpolator) {
@@ -87,7 +88,4 @@ func (outputLanguage *OutputLanguage) interpolateParameters(interpolator Paramet
 	if outputLanguage.Python != nil {
 		outputLanguage.Python.InterpolateParameters(interpolator)
 	}
-}
-
-type NoConfig struct {
 }

--- a/cmd/cli/codegen/pipeline.go
+++ b/cmd/cli/codegen/pipeline.go
@@ -187,7 +187,7 @@ func (pipeline *Pipeline) outputLanguages() (languages.Languages, error) {
 		case output.Python != nil:
 			outputs[python.LanguageRef] = python.New(*output.Python)
 		case output.Typescript != nil:
-			outputs[typescript.LanguageRef] = typescript.New()
+			outputs[typescript.LanguageRef] = typescript.New(*output.Typescript)
 		default:
 			return nil, fmt.Errorf("empty language configuration")
 		}

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -22,6 +22,8 @@ type Config struct {
 	GenerateGoMod bool `yaml:"go_mod"`
 
 	// SkipRuntime disables runtime-related code generation when enabled.
+	// Note: builders can NOT be generated with this flag turned on, as they
+	// rely on the runtime to function.
 	SkipRuntime bool `yaml:"skip_runtime"`
 
 	// Root path for imports.
@@ -74,7 +76,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 
 		common.If[common.Context](globalConfig.Types, RawTypes{Config: config}),
 
-		common.If[common.Context](globalConfig.Builders, &Builder{Config: config}),
+		common.If[common.Context](!config.SkipRuntime && globalConfig.Builders, &Builder{Config: config}),
 	)
 	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -16,6 +16,11 @@ const LanguageRef = "java"
 type Config struct {
 	ProjectPath string `yaml:"-"`
 	PackagePath string `yaml:"package_path"`
+
+	// SkipRuntime disables runtime-related code generation when enabled.
+	// Note: builders can NOT be generated with this flag turned on, as they
+	// rely on the runtime to function.
+	SkipRuntime bool `yaml:"skip_runtime"`
 }
 
 func (config *Config) InterpolateParameters(interpolator func(input string) string) {
@@ -41,7 +46,7 @@ func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList
 	})
 
 	jenny.AppendOneToMany(
-		Runtime{config: language.config},
+		common.If[common.Context](!language.config.SkipRuntime, Runtime{config: language.config}),
 		RawTypes{config: language.config},
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -14,7 +14,7 @@ func TestBuilder_Generate(t *testing.T) {
 		Name:         "TypescriptBuilder",
 	}
 
-	language := New()
+	language := New(Config{})
 	jenny := Builder{}
 
 	test.Run(t, func(tc *testutils.Test) {

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -16,7 +16,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	jenny := RawTypes{}
-	compilerPasses := New().CompilerPasses()
+	compilerPasses := New(Config{}).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test) {
 		req := require.New(tc)


### PR DESCRIPTION
Mirrors #409 for every other language supported by cog.