### PR TITLE
Fix fields parsing from enveloped types in CUE

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -81,7 +81,7 @@ func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
 }
 
 func (g *generator) walkCueSchemaWithVariantEnvelope(v cue.Value) error {
-	i, err := v.Fields(cue.Definitions(true), cue.All())
+	i, err := v.Fields(cue.Definitions(true), cue.Optional(true))
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,10 @@ func (g *generator) walkCueSchemaWithVariantEnvelope(v cue.Value) error {
 			return err
 		}
 
-		rootObjectFields = append(rootObjectFields, ast.NewStructField(name, nodeType, ast.Comments(commentsFromCueValue(i.Value()))))
+		structField := ast.NewStructField(name, nodeType, ast.Comments(commentsFromCueValue(i.Value())))
+		structField.Required = !i.IsOptional()
+
+		rootObjectFields = append(rootObjectFields, structField)
 	}
 
 	if len(rootObjectFields) == 0 {


### PR DESCRIPTION
Including all CUE expressions when exploring CUE values to envelope is too wide: it means traversing hidden values too, which we don't want.

Additionally, we need to check whether the values we find are optional or not.