### PR TITLE
Add an "AppendCommentObjects" compiler pass

### DIFF
--- a/internal/ast/compiler/append_comment_objects.go
+++ b/internal/ast/compiler/append_comment_objects.go
@@ -1,0 +1,29 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*AppendCommentObjects)(nil)
+
+// AppendCommentObjects appends the given comment to every object definition.
+type AppendCommentObjects struct {
+	Comment string
+}
+
+func (pass *AppendCommentObjects) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	visitor := &Visitor{
+		OnObject: pass.processObject,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (pass *AppendCommentObjects) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
+	object.Comments = append(object.Comments, pass.Comment)
+	object.AddToPassesTrail(fmt.Sprintf("AppendCommentObjects[%s]", pass.Comment))
+
+	return object, nil
+}

--- a/internal/ast/compiler/append_comment_objects_test.go
+++ b/internal/ast/compiler/append_comment_objects_test.go
@@ -1,0 +1,32 @@
+package compiler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestAppendCommentObjects(t *testing.T) {
+	comment := "+k8s:openapi-gen=true"
+
+	// Prepare test input
+	obj := ast.NewObject("sandbox", "AString", ast.String())
+	obj.Comments = []string{"This is a string"}
+	schema := &ast.Schema{
+		Package: "sandbox",
+		Objects: testutils.ObjectsMap(obj),
+	}
+
+	expectedObj := obj.DeepCopy()
+	expectedObj.AddToPassesTrail(fmt.Sprintf("AppendCommentObjects[%s]", comment))
+	expectedObj.Comments = []string{"This is a string", comment}
+	expected := &ast.Schema{
+		Package: "sandbox",
+		Objects: testutils.ObjectsMap(expectedObj),
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, &AppendCommentObjects{Comment: comment}, schema, expected)
+}


### PR DESCRIPTION
`grafana-app-sdk` needs to add a specific comment to every generated object: https://github.com/grafana/grafana-app-sdk/blob/e46439fe213e5e34126d25d66dcd2670db2c95c1/codegen/jennies/dstutil.go#L13-L27

Relates to #408 