### PR TITLE
Add a compiler pass to turn undiscriminated disjunctions to any

### DIFF
--- a/internal/ast/compiler/undiscriminated_disjunctions_to_any.go
+++ b/internal/ast/compiler/undiscriminated_disjunctions_to_any.go
@@ -1,0 +1,79 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*UndiscriminatedDisjunctionToAny)(nil)
+
+// UndiscriminatedDisjunctionToAny turns any undiscriminated disjunction into
+// the `any` type.
+// Disjunctions of scalars are not impacted, disjunctions having a configured
+// discriminator field and mapping are not impacted (see DisjunctionInferMapping).
+// Note: this pass _should_ run after DisjunctionInferMapping.
+type UndiscriminatedDisjunctionToAny struct {
+}
+
+func (pass *UndiscriminatedDisjunctionToAny) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	visitor := &Visitor{
+		OnDisjunction: pass.processDisjunction,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (pass *UndiscriminatedDisjunctionToAny) processDisjunction(_ *Visitor, schema *ast.Schema, def ast.Type) (ast.Type, error) {
+	disjunction := def.AsDisjunction()
+
+	// Ex: "some concrete value" | "some other value" | string
+	if pass.hasOnlySingleTypeScalars(schema, disjunction) {
+		return def, nil
+	}
+
+	if disjunction.Branches.HasOnlyScalarOrArrayOrMap() {
+		return def, nil
+	}
+
+	if disjunction.Branches.HasOnlyRefs() {
+		if len(disjunction.Discriminator) == 0 || len(disjunction.DiscriminatorMapping) == 0 {
+			return ast.Any(ast.Trail("UndiscriminatedDisjunctionToAny")), nil
+		}
+	}
+
+	return def, nil
+}
+
+func (pass *UndiscriminatedDisjunctionToAny) hasOnlySingleTypeScalars(schema *ast.Schema, disjunction ast.DisjunctionType) bool {
+	branches := disjunction.Branches
+
+	if len(branches) == 0 {
+		return false
+	}
+
+	firstBranchType, found := schema.Resolve(branches[0])
+	if !found {
+		return false
+	}
+
+	if !firstBranchType.IsScalar() {
+		return false
+	}
+
+	scalarKind := firstBranchType.AsScalar().ScalarKind
+	for _, t := range branches {
+		resolvedType, found := schema.Resolve(t)
+		if !found {
+			return false
+		}
+
+		if !resolvedType.IsScalar() {
+			return false
+		}
+
+		if resolvedType.AsScalar().ScalarKind != scalarKind {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/ast/compiler/undiscriminated_disjunctions_to_any_test.go
+++ b/internal/ast/compiler/undiscriminated_disjunctions_to_any_test.go
@@ -1,0 +1,55 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+func TestUndiscriminatedDisjunctionToAny(t *testing.T) {
+	// Prepare test input
+	disjunctionTypeNoMapping := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	disjunctionTypeNoMapping.Disjunction.Discriminator = "Type"
+	disjunctionTypeMapping := ast.NewDisjunction([]ast.Type{
+		ast.NewRef("test", "SomeStruct"),
+		ast.NewRef("test", "OtherStruct"),
+	})
+	disjunctionTypeMapping.Disjunction.Discriminator = "Type"
+	disjunctionTypeMapping.Disjunction.DiscriminatorMapping = map[string]string{
+		"some-struct":  "SomeStruct",
+		"other-struct": "OtherStruct",
+	}
+
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunctionOfRefsNoMapping", disjunctionTypeNoMapping),
+		ast.NewObject("test", "ADisjunctionOfRefsMapping", disjunctionTypeMapping),
+		ast.NewObject("test", "ADisjunctionOfScalars", ast.NewDisjunction([]ast.Type{
+			ast.String(),
+			ast.Bool(),
+		})),
+
+		ast.NewObject("test", "SomeStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String()), // Not a concrete scalar
+			ast.NewStructField("FieldFoo", ast.String()),
+		)),
+		ast.NewObject("test", "OtherStruct", ast.NewStruct(
+			ast.NewStructField("Type", ast.String(ast.Value("other-struct"))),
+			ast.NewStructField("FieldBar", ast.Bool()),
+		)),
+	}
+
+	disjunctionOfRefNoMapping := objects[0].DeepCopy()
+	disjunctionOfRefNoMapping.Type = ast.Any(ast.Trail("UndiscriminatedDisjunctionToAny"))
+	expected := []ast.Object{
+		disjunctionOfRefNoMapping,
+		objects[1],
+		objects[2],
+		objects[3],
+		objects[4],
+	}
+
+	runPassOnObjects(t, &UndiscriminatedDisjunctionToAny{}, objects, expected)
+}

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -288,8 +288,8 @@ func Discriminator(discriminator string, mapping map[string]string) TypeOption {
 	}
 }
 
-func Any() Type {
-	return NewScalar(KindAny)
+func Any(opts ...TypeOption) Type {
+	return NewScalar(KindAny, opts...)
 }
 
 func Null() Type {

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -92,6 +92,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.DisjunctionOfAnonymousStructsToExplicit{},
 		&compiler.DisjunctionInferMapping{},
+		&compiler.UndiscriminatedDisjunctionToAny{},
 		&compiler.DisjunctionToType{},
 	}
 }


### PR DESCRIPTION
Rather than failing if we can't handle a disjunction correctly, let's "degrade gracefully" and turn the disjunction to an `any` type.