### PR TITLE
Cog as library

### DIFF
--- a/examples/_as_library/main.go
+++ b/examples/_as_library/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/grafana/cog"
+)
+
+const val = `
+// Contains things.
+Container: {
+    str: string
+    trueOrFalse: bool
+    anything: {...}
+    data: bytes
+
+    num_unit8: uint8
+    num_int8: int8
+    num_uint16: uint16
+    num_int16: int16
+    num_uint32: uint32
+    num_int32: int32
+    num_uint64: uint64
+    num_int64: int64
+
+	disjunction: Bar | Baz
+}
+
+// This is a bar.
+Bar: {
+       type: "bar"
+       foo: string
+}
+
+// This is a baz.
+Baz: {
+       type: "baz"
+       boo: string
+}
+`
+
+func main() {
+	v := cuecontext.New().CompileString(val)
+	if v.Err() != nil {
+		panic(v.Err())
+	}
+
+	types, err := cog.TypesFromSchema(
+		context.Background(),
+		cog.CUEValue("sandbox", v),
+		cog.GoTypes(),
+		cog.SchemaTransformations(
+			cog.AppendCommentToObjects("+k8s:openapi-gen=true"),
+			cog.PrefixObjectsNames("Foo"),
+		),
+		//cog.TypescriptTypes(),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(types))
+}

--- a/examples/_as_library/main.go
+++ b/examples/_as_library/main.go
@@ -47,16 +47,15 @@ func main() {
 		panic(v.Err())
 	}
 
-	types, err := cog.TypesFromSchema(
-		context.Background(),
-		cog.CUEValue("sandbox", v),
-		cog.GoTypes(),
-		cog.SchemaTransformations(
+	types, err := cog.TypesFromSchema().
+		CUEValue("sandbox", v).
+		Golang().
+		//Typescript().
+		SchemaTransformations(
 			cog.AppendCommentToObjects("+k8s:openapi-gen=true"),
 			cog.PrefixObjectsNames("Foo"),
-		),
-		//cog.TypescriptTypes(),
-	)
+		).
+		Run(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	cuelang.org/go v0.8.2
 	github.com/expr-lang/expr v1.16.9
-	github.com/getkin/kin-openapi v0.125.0
+	github.com/getkin/kin-openapi v0.123.0
 	github.com/google/go-cmp v0.6.0
 	github.com/grafana/codejen v0.0.4-0.20230321061741-77f656893a3d
 	github.com/huandu/xstrings v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY
 github.com/emicklei/proto v1.13.2/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
 github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/getkin/kin-openapi v0.125.0 h1:jyQCyf2qXS1qvs2U00xQzkGCqYPhEhZDmSmVt65fXno=
-github.com/getkin/kin-openapi v0.125.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.123.0 h1:zIik0mRwFNLyvtXK274Q6ut+dPh6nlxBp0x7mNrPhs8=
+github.com/getkin/kin-openapi v0.123.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=

--- a/helpers.go
+++ b/helpers.go
@@ -27,6 +27,12 @@ func AppendCommentToObjects(comment string) compiler.Pass {
 	}
 }
 
+func PrefixObjectsNames(prefix string) compiler.Pass {
+	return &compiler.PrefixObjectNames{
+		Prefix: prefix,
+	}
+}
+
 type SingleSchemaOption func(*singleSchemaPipeline)
 
 type CUEOption func(*codegen.CueInput)

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,138 @@
+package cog
+
+import (
+	"context"
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/codegen"
+	"github.com/grafana/cog/internal/jennies/golang"
+	"github.com/grafana/cog/internal/jennies/typescript"
+)
+
+// singleSchemaPipeline represents a simplified codegen.Pipeline, meant to
+// take a single input schema and generates types for it in a single output
+// language.
+type singleSchemaPipeline struct {
+	debug       bool
+	input       *codegen.Input
+	finalPasses compiler.Passes
+	output      *codegen.OutputLanguage
+}
+
+func AppendCommentToObjects(comment string) compiler.Pass {
+	return &compiler.AppendCommentObjects{
+		Comment: comment,
+	}
+}
+
+type SingleSchemaOption func(*singleSchemaPipeline)
+
+type CUEOption func(*codegen.CueInput)
+
+func ForceEnvelope(envelopeName string) CUEOption {
+	return func(input *codegen.CueInput) {
+		input.ForcedEnvelope = envelopeName
+	}
+}
+
+func Debug(enabled bool) SingleSchemaOption {
+	return func(pipeline *singleSchemaPipeline) {
+		pipeline.debug = enabled
+	}
+}
+
+func CUEValue(pkgName string, value cue.Value, opts ...CUEOption) SingleSchemaOption {
+	return func(pipeline *singleSchemaPipeline) {
+		cueInput := &codegen.CueInput{
+			Package: pkgName,
+			Value:   &value,
+		}
+
+		for _, opt := range opts {
+			opt(cueInput)
+		}
+
+		pipeline.input = &codegen.Input{
+			Cue: cueInput,
+		}
+	}
+}
+
+func GoTypes() SingleSchemaOption {
+	return func(pipeline *singleSchemaPipeline) {
+		pipeline.output = &codegen.OutputLanguage{
+			Go: &golang.Config{
+				GenerateGoMod: false,
+				SkipRuntime:   true,
+			},
+		}
+	}
+}
+
+func TypescriptTypes() SingleSchemaOption {
+	return func(pipeline *singleSchemaPipeline) {
+		pipeline.output = &codegen.OutputLanguage{
+			Typescript: &typescript.Config{
+				SkipRuntime: true,
+				SkipIndex:   true,
+			},
+		}
+	}
+}
+
+func SchemaTransformations(passes ...compiler.Pass) SingleSchemaOption {
+	return func(pipeline *singleSchemaPipeline) {
+		pipeline.finalPasses = passes
+	}
+}
+
+// TypesFromSchema generates types from a single input schema and a single
+// output language.
+func TypesFromSchema(ctx context.Context, options ...SingleSchemaOption) ([]byte, error) {
+	simplePipeline := &singleSchemaPipeline{}
+
+	for _, option := range options {
+		option(simplePipeline)
+	}
+
+	pipeline, err := codegen.NewPipeline()
+	if err != nil {
+		return nil, err
+	}
+	pipeline.Debug = simplePipeline.debug
+
+	// Inputs
+	if simplePipeline.input == nil {
+		return nil, fmt.Errorf("no input configured")
+	}
+	pipeline.Inputs = []*codegen.Input{simplePipeline.input}
+
+	// Transformations
+	pipeline.Transforms.FinalPasses = simplePipeline.finalPasses
+
+	// Outputs
+	if simplePipeline.output == nil {
+		return nil, fmt.Errorf("no output configured")
+	}
+	pipeline.Output = codegen.Output{
+		Types:     true,
+		Languages: []*codegen.OutputLanguage{simplePipeline.output},
+	}
+
+	// Run the codegen pipeline and return the generated file's content.
+	// Note: since this pipeline is about types with no runtime, we expect a
+	// single file to be generated.
+	generatedFS, err := pipeline.Run(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	generatedFiles := generatedFS.AsFiles()
+	if len(generatedFiles) != 1 {
+		return nil, fmt.Errorf("expected a single generated file, got %d", len(generatedFiles))
+	}
+
+	return generatedFiles[0].Data, nil
+}

--- a/helpers.go
+++ b/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/cog/internal/codegen"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/typescript"
+	"github.com/grafana/cog/internal/simplecue"
 )
 
 // singleSchemaPipeline represents a simplified codegen.Pipeline, meant to
@@ -40,6 +41,12 @@ type CUEOption func(*codegen.CueInput)
 func ForceEnvelope(envelopeName string) CUEOption {
 	return func(input *codegen.CueInput) {
 		input.ForcedEnvelope = envelopeName
+	}
+}
+
+func NameFunc(nameFunc simplecue.NameFunc) CUEOption {
+	return func(input *codegen.CueInput) {
+		input.NameFunc = nameFunc
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -12,132 +12,91 @@ import (
 	"github.com/grafana/cog/internal/simplecue"
 )
 
-// singleSchemaPipeline represents a simplified codegen.Pipeline, meant to
+// SchemaToTypesPipeline represents a simplified codegen.Pipeline, meant to
 // take a single input schema and generates types for it in a single output
 // language.
-type singleSchemaPipeline struct {
+type SchemaToTypesPipeline struct {
 	debug       bool
 	input       *codegen.Input
 	finalPasses compiler.Passes
 	output      *codegen.OutputLanguage
 }
 
+// AppendCommentToObjects adds the given comment to every object definition.
 func AppendCommentToObjects(comment string) compiler.Pass {
 	return &compiler.AppendCommentObjects{
 		Comment: comment,
 	}
 }
 
+// PrefixObjectsNames adds the given prefix to every object's name.
 func PrefixObjectsNames(prefix string) compiler.Pass {
 	return &compiler.PrefixObjectNames{
 		Prefix: prefix,
 	}
 }
 
-type SingleSchemaOption func(*singleSchemaPipeline)
-
 type CUEOption func(*codegen.CueInput)
 
+// ForceEnvelope decorates the parsed cue Value with an envelope whose
+// name is given. This is useful for dataqueries for example, where the
+// schema doesn't define any suitable top-level object.
 func ForceEnvelope(envelopeName string) CUEOption {
 	return func(input *codegen.CueInput) {
 		input.ForcedEnvelope = envelopeName
 	}
 }
 
+// NameFunc specifies the naming strategy used for objects and references.
+// It is called with the value passed to the top level method or function and
+// the path to the entity being parsed.
 func NameFunc(nameFunc simplecue.NameFunc) CUEOption {
 	return func(input *codegen.CueInput) {
 		input.NameFunc = nameFunc
 	}
 }
 
-func Debug(enabled bool) SingleSchemaOption {
-	return func(pipeline *singleSchemaPipeline) {
-		pipeline.debug = enabled
-	}
-}
-
-func CUEValue(pkgName string, value cue.Value, opts ...CUEOption) SingleSchemaOption {
-	return func(pipeline *singleSchemaPipeline) {
-		cueInput := &codegen.CueInput{
-			Package: pkgName,
-			Value:   &value,
-		}
-
-		for _, opt := range opts {
-			opt(cueInput)
-		}
-
-		pipeline.input = &codegen.Input{
-			Cue: cueInput,
-		}
-	}
-}
-
-func GoTypes() SingleSchemaOption {
-	return func(pipeline *singleSchemaPipeline) {
-		pipeline.output = &codegen.OutputLanguage{
-			Go: &golang.Config{
-				GenerateGoMod: false,
-				SkipRuntime:   true,
-			},
-		}
-	}
-}
-
-func TypescriptTypes() SingleSchemaOption {
-	return func(pipeline *singleSchemaPipeline) {
-		pipeline.output = &codegen.OutputLanguage{
-			Typescript: &typescript.Config{
-				SkipRuntime: true,
-				SkipIndex:   true,
-			},
-		}
-	}
-}
-
-func SchemaTransformations(passes ...compiler.Pass) SingleSchemaOption {
-	return func(pipeline *singleSchemaPipeline) {
-		pipeline.finalPasses = passes
-	}
-}
-
 // TypesFromSchema generates types from a single input schema and a single
 // output language.
-func TypesFromSchema(ctx context.Context, options ...SingleSchemaOption) ([]byte, error) {
-	simplePipeline := &singleSchemaPipeline{}
+func TypesFromSchema() *SchemaToTypesPipeline {
+	return &SchemaToTypesPipeline{}
+}
 
-	for _, option := range options {
-		option(simplePipeline)
+// Debug controls whether debug mode is enabled or not.
+// When enabled, more information is included in the generated output,
+// such as an audit trail of applied transformations.
+func (pipeline *SchemaToTypesPipeline) Debug(enabled bool) *SchemaToTypesPipeline {
+	pipeline.debug = enabled
+	return pipeline
+}
+
+// Run executes the codegen pipeline and returns its output.
+func (pipeline *SchemaToTypesPipeline) Run(ctx context.Context) ([]byte, error) {
+	// Validation
+	if pipeline.input == nil {
+		return nil, fmt.Errorf("no input configured")
+	}
+	if pipeline.output == nil {
+		return nil, fmt.Errorf("no output configured")
 	}
 
-	pipeline, err := codegen.NewPipeline()
+	codegenPipeline, err := codegen.NewPipeline()
 	if err != nil {
 		return nil, err
 	}
-	pipeline.Debug = simplePipeline.debug
-
-	// Inputs
-	if simplePipeline.input == nil {
-		return nil, fmt.Errorf("no input configured")
+	codegenPipeline.Inputs = []*codegen.Input{pipeline.input}
+	codegenPipeline.Transforms = codegen.Transforms{
+		FinalPasses: pipeline.finalPasses,
 	}
-	pipeline.Inputs = []*codegen.Input{simplePipeline.input}
-
-	// Transformations
-	pipeline.Transforms.FinalPasses = simplePipeline.finalPasses
-
-	// Outputs
-	if simplePipeline.output == nil {
-		return nil, fmt.Errorf("no output configured")
-	}
-	pipeline.Output = codegen.Output{
+	codegenPipeline.Output = codegen.Output{
 		Types:     true,
-		Languages: []*codegen.OutputLanguage{simplePipeline.output},
+		Languages: []*codegen.OutputLanguage{pipeline.output},
 	}
 
 	// Run the codegen pipeline and return the generated file's content.
 	// Note: since this pipeline is about types with no runtime, we expect a
 	// single file to be generated.
-	generatedFS, err := pipeline.Run(ctx)
+	generatedFS, err := codegenPipeline.Run(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -148,4 +107,62 @@ func TypesFromSchema(ctx context.Context, options ...SingleSchemaOption) ([]byte
 	}
 
 	return generatedFiles[0].Data, nil
+}
+
+/**********
+ * Inputs *
+ **********/
+
+// CUEValue sets the pipeline's input to the given cue value.
+func (pipeline *SchemaToTypesPipeline) CUEValue(pkgName string, value cue.Value, opts ...CUEOption) *SchemaToTypesPipeline {
+	cueInput := &codegen.CueInput{
+		Package: pkgName,
+		Value:   &value,
+	}
+
+	for _, opt := range opts {
+		opt(cueInput)
+	}
+
+	pipeline.input = &codegen.Input{Cue: cueInput}
+
+	return pipeline
+}
+
+/*******************
+ * Transformations *
+ *******************/
+
+// SchemaTransformations adds the given transformations to the set of
+// transformations that will be applied to the input schema.
+func (pipeline *SchemaToTypesPipeline) SchemaTransformations(passes ...compiler.Pass) *SchemaToTypesPipeline {
+	pipeline.finalPasses = append(pipeline.finalPasses, passes...)
+
+	return pipeline
+}
+
+/***********
+ * Outputs *
+ ***********/
+
+// Golang sets the output to Golang types.
+func (pipeline *SchemaToTypesPipeline) Golang() *SchemaToTypesPipeline {
+	pipeline.output = &codegen.OutputLanguage{
+		Go: &golang.Config{
+			GenerateGoMod: false,
+			SkipRuntime:   true,
+		},
+	}
+	return pipeline
+}
+
+// Typescript sets the output to Typescript types.
+func (pipeline *SchemaToTypesPipeline) Typescript() *SchemaToTypesPipeline {
+	pipeline.output = &codegen.OutputLanguage{
+		Typescript: &typescript.Config{
+			SkipRuntime: true,
+			SkipIndex:   true,
+		},
+	}
+	return pipeline
 }

--- a/internal/ast/compiler/prefix_objects_names.go
+++ b/internal/ast/compiler/prefix_objects_names.go
@@ -8,7 +8,7 @@ import (
 
 var _ Pass = (*PrefixObjectNames)(nil)
 
-// PrefixObjectNames appends the given comment to every object definition.
+// PrefixObjectNames adds the given prefix to every object's name.
 type PrefixObjectNames struct {
 	Prefix string
 }

--- a/internal/codegen/input.go
+++ b/internal/codegen/input.go
@@ -17,7 +17,7 @@ type interpolable interface {
 }
 
 type transformable interface {
-	compilerPasses() (compiler.Passes, error)
+	commonPasses() (compiler.Passes, error)
 }
 
 type schemaLoader interface {
@@ -48,7 +48,7 @@ func (input *InputBase) schemaMetadata() ast.SchemaMeta {
 	return ast.SchemaMeta{}
 }
 
-func (input *InputBase) compilerPasses() (compiler.Passes, error) {
+func (input *InputBase) commonPasses() (compiler.Passes, error) {
 	return cogyaml.NewCompilerLoader().PassesFrom(input.Transforms)
 }
 
@@ -170,7 +170,7 @@ func (input *Input) LoadSchemas(ctx context.Context) (ast.Schemas, error) {
 	}
 
 	if transformableLoader, ok := loader.(transformable); ok {
-		passes, err := transformableLoader.compilerPasses()
+		passes, err := transformableLoader.commonPasses()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -129,8 +129,16 @@ func (pipeline *Pipeline) jenniesConfig() languages.Config {
 	}
 }
 
-func (pipeline *Pipeline) compilerPasses() (compiler.Passes, error) {
-	return cogyaml.NewCompilerLoader().PassesFrom(pipeline.Transforms.CompilerPassesFiles)
+func (pipeline *Pipeline) commonPasses() (compiler.Passes, error) {
+	if pipeline.Transforms.CommonPasses != nil {
+		return pipeline.Transforms.CommonPasses, nil
+	}
+
+	return cogyaml.NewCompilerLoader().PassesFrom(pipeline.Transforms.CommonPassesFiles)
+}
+
+func (pipeline *Pipeline) finalPasses() compiler.Passes {
+	return pipeline.Transforms.FinalPasses
 }
 
 func (pipeline *Pipeline) veneers() (*rewrite.Rewriter, error) {

--- a/internal/codegen/transforms.go
+++ b/internal/codegen/transforms.go
@@ -1,13 +1,24 @@
 package codegen
 
 import (
+	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type Transforms struct {
-	// CompilerPassesFiles holds a list of paths to files containing compiler
+	// CommonPassesFiles holds a list of paths to files containing compiler
 	// passes to apply to all the schemas.
-	CompilerPassesFiles []string `yaml:"schemas"`
+	// Note: these compiler passes are applied *before* language-specific passes.
+	CommonPassesFiles []string `yaml:"schemas"`
+
+	// CommonPasses holds a list of compiler passes to apply to all the schemas.
+	// If this field is set, CommonPassesFiles is ignored.
+	// Note: these compiler passes are applied *before* language-specific passes.
+	CommonPasses compiler.Passes `yaml:"-"`
+
+	// FinalPasses holds a list of compiler passes to apply to all the schemas.
+	// Note: these compiler passes are applied *after* language-specific passes.
+	FinalPasses compiler.Passes `yaml:"-"`
 
 	// VeneersDirectories holds a list of paths to directories containing
 	// veneers to apply to all the builders.
@@ -15,6 +26,6 @@ type Transforms struct {
 }
 
 func (transforms *Transforms) interpolateParameters(interpolator ParametersInterpolator) {
-	transforms.CompilerPassesFiles = tools.Map(transforms.CompilerPassesFiles, interpolator)
+	transforms.CommonPassesFiles = tools.Map(transforms.CommonPassesFiles, interpolator)
 	transforms.VeneersDirectories = tools.Map(transforms.VeneersDirectories, interpolator)
 }

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -103,8 +103,7 @@ func (g *generator) walkDefinitions(schema *openapi3.Schema) (ast.Type, error) {
 		return g.walkEnum(schema)
 	}
 
-	schemaType := getSchemaType(schema)
-	switch schemaType {
+	switch schema.Type {
 	case openapi3.TypeString:
 		return g.walkString(schema)
 	case openapi3.TypeBoolean:
@@ -264,12 +263,11 @@ func (g *generator) walkEnum(schema *openapi3.Schema) (ast.Type, error) {
 	// Nullable enums? https://swagger.io/docs/specification/data-models/enums/
 	enums := make([]ast.EnumValue, 0, len(schema.Enum))
 	format := "%#v"
-	schemaType := getSchemaType(schema)
-	if schemaType == openapi3.TypeString {
+	if schema.Type == openapi3.TypeString {
 		format = "%s"
 	}
 
-	enumType, err := getEnumType(schemaType)
+	enumType, err := getEnumType(schema.Type)
 	if err != nil {
 		return ast.Type{}, err
 	}

--- a/internal/openapi/utils.go
+++ b/internal/openapi/utils.go
@@ -37,7 +37,6 @@ func getEnumType(t string) (ast.Type, error) {
 }
 
 func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
-	schemaType := getSchemaType(schema)
 	constraints := make([]ast.TypeConstraint, 0)
 
 	if schema.MinLength > 0 {
@@ -56,7 +55,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 	if schema.MultipleOf != nil {
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   ast.MultipleOfOp,
-			Args: getArgs(schema.MultipleOf, schemaType),
+			Args: getArgs(schema.MultipleOf, schema.Type),
 		})
 	}
 
@@ -67,7 +66,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 		}
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   op,
-			Args: getArgs(schema.Min, schemaType),
+			Args: getArgs(schema.Min, schema.Type),
 		})
 	}
 
@@ -78,7 +77,7 @@ func getConstraints(schema *openapi3.Schema) []ast.TypeConstraint {
 		}
 		constraints = append(constraints, ast.TypeConstraint{
 			Op:   op,
-			Args: getArgs(schema.Max, schemaType),
+			Args: getArgs(schema.Max, schema.Type),
 		})
 	}
 
@@ -95,11 +94,4 @@ func getArgs(v *float64, t string) []any {
 
 func isRef(ref string) bool {
 	return ref != "" && strings.ContainsAny(ref, "#")
-}
-
-func getSchemaType(schema *openapi3.Schema) string {
-	if schema.Type != nil && len(*schema.Type) == 1 {
-		return (*schema.Type)[0] // Handle multiple types?
-	}
-	return ""
 }


### PR DESCRIPTION
Contributes to #408 

[`grafana-app-sdk`](https://github.com/grafana/grafana-app-sdk) wants to rely on cog for some of its codegen-related use-cases, especially to generate Go and Typescript types from a single CUE value.

This PR is a proposition of a minimal API that would allow `grafana-app-sdk` to use cog as a library to achieve these goals.

A sandbox PR is open to see how it would look like on the other side of the fence: https://github.com/grafana/grafana-app-sdk/pull/296