### PR TITLE
Make working with instant/range prometheus queries more intuitive

### DIFF
--- a/config/veneers/prometheus.yaml
+++ b/config/veneers/prometheus.yaml
@@ -1,0 +1,44 @@
+language: all
+
+package: prometheus
+
+builders:
+  # Like the UI, support a "both instant and range" query
+  - add_option:
+      by_object: Dataquery
+      option:
+        name: rangeAndInstant
+        assignments:
+          - path: range
+            method: direct
+            value: { constant: true }
+          - path: instant
+            method: direct
+            value: { constant: true }
+
+options:
+  # Ensure that enabling "range query mode" disables other modes
+  - unfold_boolean:
+      by_name: Dataquery.range
+      true_as: range
+      false_as: notRange
+  - omit: { by_name: Dataquery.notRange }
+  - add_assignment:
+      by_name: Dataquery.range
+      assignment:
+        path: instant
+        method: direct
+        value: { constant: false }
+
+  # Ensure that enabling "instant query mode" disables other modes
+  - unfold_boolean:
+      by_name: Dataquery.instant
+      true_as: instant
+      false_as: notInstant
+  - omit: { by_name: Dataquery.notInstant }
+  - add_assignment:
+      by_name: Dataquery.instant
+      assignment:
+        path: range
+        method: direct
+        value: { constant: false }

--- a/examples/_go/common.go
+++ b/examples/_go/common.go
@@ -28,7 +28,7 @@ func basicLokiQuery(query string) *loki.DataqueryBuilder {
 func tablePrometheusQuery(query string, ref string) *prometheus.DataqueryBuilder {
 	return prometheus.NewDataqueryBuilder().
 		Expr(query).
-		Instant(true).
+		Instant().
 		Format(prometheus.PromQueryFormatTable).
 		RefId(ref)
 }

--- a/examples/_go_alerting/main.go
+++ b/examples/_go_alerting/main.go
@@ -39,7 +39,7 @@ func main() {
 					prometheus.NewDataqueryBuilder().
 						// RefId("A"). // needed?
 						Expr("go_memstats_alloc_bytes_total").
-						Instant(true).
+						Instant().
 						LegendFormat("__auto"),
 				)).
 			WithQuery(alerting.NewQueryBuilder("B").

--- a/examples/python/raspberry/common.py
+++ b/examples/python/raspberry/common.py
@@ -61,7 +61,7 @@ def table_prometheus_query(query: str, ref_id: str) -> PrometheusQueryBuilder:
     return (
         PrometheusQueryBuilder()
         .expr(query)
-        .instant(True)
+        .instant()
         .format_val(PromQueryFormat.TABLE)
         .ref_id(ref_id)
     )

--- a/examples/typescript/common.ts
+++ b/examples/typescript/common.ts
@@ -29,7 +29,7 @@ export const basicLokiQuery = (query: string): loki.DataqueryBuilder => {
 export const tablePrometheusQuery = (query: string, ref: string): prometheus.DataqueryBuilder => {
     return new prometheus.DataqueryBuilder()
         .expr(query)
-        .instant(true)
+        .instant()
         .format(PromQueryFormat.Table)
         .refId(ref);
 };

--- a/internal/veneers/option/rules.go
+++ b/internal/veneers/option/rules.go
@@ -1,5 +1,9 @@
 package option
 
+import (
+	"github.com/grafana/cog/internal/veneers"
+)
+
 type RewriteRule struct {
 	Selector Selector
 	Action   RewriteAction
@@ -65,5 +69,12 @@ func Duplicate(selector Selector, duplicateName string) RewriteRule {
 	return RewriteRule{
 		Selector: selector,
 		Action:   DuplicateAction(duplicateName),
+	}
+}
+
+func AddAssignment(selector Selector, assignment veneers.Assignment) RewriteRule {
+	return RewriteRule{
+		Selector: selector,
+		Action:   AddAssignmentAction(assignment),
 	}
 }

--- a/internal/veneers/types.go
+++ b/internal/veneers/types.go
@@ -1,0 +1,47 @@
+package veneers
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+type Option struct {
+	Name        string       `yaml:"name"`
+	Assignments []Assignment `yaml:"assignments"`
+}
+
+func (opt Option) AsIR(builders ast.Builders, root ast.Builder) (ast.Option, error) {
+	assignments := make([]ast.Assignment, 0, len(opt.Assignments))
+	for _, assignment := range opt.Assignments {
+		irAssignment, err := assignment.AsIR(builders, root)
+		if err != nil {
+			return ast.Option{}, err
+		}
+
+		assignments = append(assignments, irAssignment)
+	}
+
+	return ast.Option{
+		Name:        opt.Name,
+		Assignments: assignments,
+	}, nil
+}
+
+type Assignment struct {
+	Path   string               `yaml:"path"`
+	Method ast.AssignmentMethod `yaml:"method"`
+	Value  ast.AssignmentValue  `yaml:"value"`
+}
+
+func (assignment Assignment) AsIR(builders ast.Builders, root ast.Builder) (ast.Assignment, error) {
+	// TODO
+	path, err := root.MakePath(builders, assignment.Path)
+	if err != nil {
+		return ast.Assignment{}, err
+	}
+
+	return ast.Assignment{
+		Path:   path,
+		Value:  assignment.Value,
+		Method: assignment.Method,
+	}, nil
+}

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
+	"github.com/grafana/cog/internal/veneers"
 	"github.com/grafana/cog/internal/veneers/builder"
 )
 
@@ -21,6 +22,7 @@ type BuilderRule struct {
 	Duplicate                *Duplicate                `yaml:"duplicate"`
 	Initialize               *Initialize               `yaml:"initialize"`
 	PromoteOptsToConstructor *PromoteOptsToConstructor `yaml:"promote_options_to_constructor"`
+	AddOption                *AddOption                `yaml:"add_option"`
 }
 
 func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
@@ -59,6 +61,10 @@ func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 	if rule.PromoteOptsToConstructor != nil {
 		return rule.PromoteOptsToConstructor.AsRewriteRule(pkg)
+	}
+
+	if rule.AddOption != nil {
+		return rule.AddOption.AsRewriteRule(pkg)
 	}
 
 	return nil, fmt.Errorf("empty rule")
@@ -182,6 +188,20 @@ func (rule PromoteOptsToConstructor) AsRewriteRule(pkg string) (builder.RewriteR
 	}
 
 	return builder.PromoteOptionsToConstructor(selector, rule.Options), nil
+}
+
+type AddOption struct {
+	BuilderSelector `yaml:",inline"`
+	Option          veneers.Option `yaml:"option"`
+}
+
+func (rule AddOption) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.AddOption(selector, rule.Option), nil
 }
 
 /******************************************************************************

--- a/internal/yaml/option.go
+++ b/internal/yaml/option.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/grafana/cog/internal/veneers"
 	"github.com/grafana/cog/internal/veneers/option"
 )
 
@@ -20,6 +21,7 @@ type OptionRule struct {
 	ArrayToAppend           *ArrayToAppend           `yaml:"array_to_append"`
 	DisjunctionAsOptions    *DisjunctionAsOptions    `yaml:"disjunction_as_options"`
 	Duplicate               *DuplicateOption         `yaml:"duplicate"`
+	AddAssignment           *AddAssignment           `yaml:"add_assignment"`
 }
 
 func (rule OptionRule) AsRewriteRule(pkg string) (option.RewriteRule, error) {
@@ -58,6 +60,10 @@ func (rule OptionRule) AsRewriteRule(pkg string) (option.RewriteRule, error) {
 
 	if rule.Duplicate != nil {
 		return rule.Duplicate.AsRewriteRule(pkg)
+	}
+
+	if rule.AddAssignment != nil {
+		return rule.AddAssignment.AsRewriteRule(pkg)
 	}
 
 	return option.RewriteRule{}, fmt.Errorf("empty rule")
@@ -163,6 +169,20 @@ func (rule DuplicateOption) AsRewriteRule(pkg string) (option.RewriteRule, error
 	}
 
 	return option.Duplicate(selector, rule.As), nil
+}
+
+type AddAssignment struct {
+	OptionSelector `yaml:",inline"`
+	Assignment     veneers.Assignment `yaml:"assignment"`
+}
+
+func (rule AddAssignment) AsRewriteRule(pkg string) (option.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return option.RewriteRule{}, err
+	}
+
+	return option.AddAssignment(selector, rule.Assignment), nil
 }
 
 /******************************************************************************


### PR DESCRIPTION
This PR makes it more intuitive to define range/instant queries in prometheus. The API now exposed for this follows what the UI does.