### PR TITLE
Cleanup txtar utils to decouple them from inputs being tested

### DIFF
--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -3,13 +3,14 @@ package golang
 import (
 	"testing"
 
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[common.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "GoBuilder",
 		Skip: map[string]string{
@@ -23,11 +24,11 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(config)
 	jenny := Builder{Config: config}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[common.Context]) {
 		var err error
 		req := require.New(tc)
 
-		context := tc.BuildersContext()
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
 		context, err = languages.GenerateBuilderNilChecks(language, context)
 		req.NoError(err)
 

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRawTypes_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "GoRawTypes",
 	}
@@ -23,13 +23,14 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 	compilerPasses := New(config).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo Go since without them, we
 		// might not be able to translate some of the IR's semantics into Go.
 		// Example: disjunctions.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/java/builders_test.go
+++ b/internal/jennies/java/builders_test.go
@@ -3,13 +3,14 @@ package java
 import (
 	"testing"
 
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuidlers_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[common.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "JavaBuilders",
 		Skip:         map[string]string{
@@ -20,11 +21,11 @@ func TestBuidlers_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := RawTypes{}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[common.Context]) {
 		var err error
 		req := require.New(tc)
 
-		context := tc.BuildersContext()
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
 		context, err = languages.GenerateBuilderNilChecks(language, context)
 		req.NoError(err)
 

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRawTypes_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "JavaRawTypes",
 	}
@@ -20,13 +20,14 @@ func TestRawTypes_Generate(t *testing.T) {
 	jenny := RawTypes{config: cfg}
 	compilerPasses := New(cfg).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo Java since without them, we
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSchema_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "JSONSchema",
 	}
@@ -19,12 +19,13 @@ func TestSchema_Generate(t *testing.T) {
 	jenny := Schema{Config: config}
 	compilerPasses := New(config).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo JSONSchema since without them, we
 		// might not be able to translate some of the IR's semantics.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSchema_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "OpenAPI",
 	}
@@ -19,12 +19,13 @@ func TestSchema_Generate(t *testing.T) {
 	jenny := Schema{Config: config}
 	compilerPasses := New(config).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo OpenAPI since without them, we
 		// might not be able to translate some of the IR's semantics.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/python/builder_test.go
+++ b/internal/jennies/python/builder_test.go
@@ -3,13 +3,14 @@ package python
 import (
 	"testing"
 
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[common.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "PythonBuilder",
 		Skip: map[string]string{
@@ -20,11 +21,11 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := Builder{}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[common.Context]) {
 		var err error
 		req := require.New(tc)
 
-		context := tc.BuildersContext()
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
 		context, err = languages.GenerateBuilderNilChecks(language, context)
 		req.NoError(err)
 

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRawTypes_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "PythonRawTypes",
 		Skip: map[string]string{
@@ -21,13 +21,14 @@ func TestRawTypes_Generate(t *testing.T) {
 	jenny := RawTypes{}
 	compilerPasses := New(Config{}).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo Python since without them, we
 		// might not be able to translate some of the IR's semantics into Python.
 		// Example: anonymous objects.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -3,13 +3,14 @@ package typescript
 import (
 	"testing"
 
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[common.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "TypescriptBuilder",
 	}
@@ -17,11 +18,11 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := Builder{}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[common.Context]) {
 		var err error
 		req := require.New(tc)
 
-		context := tc.BuildersContext()
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
 		context, err = languages.GenerateBuilderNilChecks(language, context)
 		req.NoError(err)
 

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRawTypes_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
 		TestDataRoot: "../../../testdata/jennies/rawtypes",
 		Name:         "TypescriptRawTypes",
 	}
@@ -18,13 +18,14 @@ func TestRawTypes_Generate(t *testing.T) {
 	jenny := RawTypes{}
 	compilerPasses := New(Config{}).CompilerPasses()
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)
 
 		// We run the compiler passes defined fo Go since without them, we
 		// might not be able to translate some of the IR's semantics into TS.
 		// Example: disjunctions.
-		processedAsts, err := compilerPasses.Process(ast.Schemas{tc.TypesIR()})
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jsonschema/generator_test.go
+++ b/internal/jsonschema/generator_test.go
@@ -1,9 +1,6 @@
 package jsonschema
 
 import (
-	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -12,19 +9,19 @@ import (
 )
 
 func TestGenerateAST(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[string]{
 		TestDataRoot: "../../testdata/jsonschema",
 		Name:         "GenerateAST",
 	}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[string]) {
 		req := require.New(tc)
 
-		schemaAst, err := GenerateAST(getSchemaAsReader(tc), Config{Package: "grafanatest"})
+		schemaAst, err := GenerateAST(tc.OpenInput("schema.json"), Config{Package: "grafanatest"})
 		req.NoError(err)
 		req.NotNil(schemaAst)
 
-		testutils.WriteIR(schemaAst, tc)
+		tc.WriteJSON(testutils.GeneratorOutputFile, schemaAst)
 	})
 }
 
@@ -55,15 +52,4 @@ func TestGenerateAST_parsesEnumValues(t *testing.T) {
 	enumType := schemaAst.Objects.At(0).Type.Enum
 
 	req.Equal(int64(1), enumType.Values[0].Value)
-}
-
-func getSchemaAsReader(tc *testutils.Test) io.Reader {
-	tc.Helper()
-
-	file, err := os.Open(filepath.Join(tc.RootDir, "schema.json"))
-	if err != nil {
-		tc.Fatalf("could not open schema: %s", err)
-	}
-
-	return file
 }

--- a/internal/openapi/generator_test.go
+++ b/internal/openapi/generator_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestGenerateAST(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite{
+	test := testutils.GoldenFilesTestSuite[string]{
 		TestDataRoot: "../../testdata/openapi",
 		Name:         "GenerateAST",
 	}
 
-	test.Run(t, func(tc *testutils.Test) {
+	test.Run(t, func(tc *testutils.Test[string]) {
 		req := require.New(tc)
 		ctx := context.TODO()
 
@@ -24,11 +24,11 @@ func TestGenerateAST(t *testing.T) {
 		req.NoError(err)
 		require.NotNil(t, schemaAst)
 
-		testutils.WriteIR(schemaAst, tc)
+		tc.WriteJSON(testutils.GeneratorOutputFile, schemaAst)
 	})
 }
 
-func getSchemaAsReader(tc *testutils.Test) *openapi3.T {
+func getSchemaAsReader(tc *testutils.Test[string]) *openapi3.T {
 	tc.Helper()
 
 	loader := openapi3.NewLoader()

--- a/internal/testutils/constants.go
+++ b/internal/testutils/constants.go
@@ -1,0 +1,6 @@
+package testutils
+
+const RawTypesIRInputFile = "ir.json"
+const BuildersContextInputFile = "builders_context.json"
+
+const GeneratorOutputFile = "ir.json"


### PR DESCRIPTION
A bit of cleaning, to remove duplicated code and unnecessary couplings in txtar test utils.