### PR TITLE
Java: Remove unnecessary extensions

### DIFF
--- a/internal/ast/compiler/remove_intersections.go
+++ b/internal/ast/compiler/remove_intersections.go
@@ -1,0 +1,70 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+type RemoveIntersections struct {
+}
+
+func (r RemoveIntersections) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	newSchemas := make([]*ast.Schema, 0)
+	for _, schema := range schemas {
+		if sch, ok := r.processSchema(schema); ok {
+			newSchemas = append(newSchemas, sch)
+		}
+	}
+
+	return newSchemas, nil
+}
+
+func (r RemoveIntersections) processSchema(schema *ast.Schema) (*ast.Schema, bool) {
+	listToRemove := make(map[string]ast.Object)
+	schema.Objects.Iterate(func(key string, value ast.Object) {
+		if value.Type.Kind == ast.KindRef {
+			obj, toRemove := r.processObject(schema, value)
+			schema.Objects.Set(key, obj)
+			listToRemove[toRemove] = obj
+		}
+	})
+
+	schema.Objects.Iterate(func(key string, value ast.Object) {
+		if value.Type.Kind == ast.KindStruct {
+			schema.Objects.Set(key, r.processStruct(value, listToRemove))
+		}
+	})
+
+	// fmt.Println(listToRemove)
+	for toRemove, _ := range listToRemove {
+		schema.Objects.Remove(toRemove)
+	}
+
+	return schema, true
+}
+
+func (r RemoveIntersections) processObject(schema *ast.Schema, object ast.Object) (ast.Object, string) {
+	ref := object.Type.AsRef()
+	locatedObject, ok := schema.LocateObject(ref.ReferredType)
+	if !ok {
+		return object, ""
+	}
+
+	newObject := object
+	newObject.Type = ast.NewStruct(locatedObject.Type.AsStruct().Fields...)
+	newObject.Type.Hints[ast.HintImplementsVariant] = object.Type.ImplementedVariant()
+
+	return newObject, locatedObject.Name
+}
+
+func (r RemoveIntersections) processStruct(object ast.Object, listToRemove map[string]ast.Object) ast.Object {
+	str := object.Type.AsStruct()
+	for i, field := range str.Fields {
+		// fmt.Println(field.Name)
+		if obj, ok := listToRemove[field.Name]; ok {
+			object.Type.AsStruct().Fields[i].Name = obj.Name
+			object.Type.AsStruct().Fields[i].Type = obj.Type
+		}
+	}
+
+	return object
+}

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -65,6 +65,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.DisjunctionWithNullToOptional{},
 		&compiler.DisjunctionInferMapping{},
 		&compiler.DisjunctionToType{},
+		&compiler.RemoveIntersections{},
 	}
 }
 

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
@@ -1,5 +1,7 @@
 package disjunctions;
 
 
-public class BoolOrRef extends BoolOrSomeStruct {
+public class BoolOrRef {
+    public Boolean bool;
+    public SomeStruct someStruct;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrSomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrSomeStruct.java
@@ -1,7 +1,0 @@
-package disjunctions;
-
-
-public class BoolOrSomeStruct {
-    public Boolean bool;
-    public SomeStruct someStruct;
-}

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
@@ -2,5 +2,7 @@ package disjunctions;
 
 
 // Refresh rate or disabled.
-public class RefreshRate extends StringOrBool {
+public class RefreshRate {
+    public String string;
+    public Boolean bool;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
@@ -1,5 +1,8 @@
 package disjunctions;
 
 
-public class SeveralRefs extends SomeStructOrSomeOtherStructOrYetAnotherStruct {
+public class SeveralRefs {
+    public SomeStruct someStruct;
+    public SomeOtherStruct someOtherStruct;
+    public YetAnotherStruct yetAnotherStruct;
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStructOrSomeOtherStructOrYetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStructOrSomeOtherStructOrYetAnotherStruct.java
@@ -1,8 +1,0 @@
-package disjunctions;
-
-
-public class SomeStructOrSomeOtherStructOrYetAnotherStruct {
-    public SomeStruct someStruct;
-    public SomeOtherStruct someOtherStruct;
-    public YetAnotherStruct yetAnotherStruct;
-}

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrBool.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/StringOrBool.java
@@ -1,7 +1,0 @@
-package disjunctions;
-
-
-public class StringOrBool {
-    public String string;
-    public Boolean bool;
-}

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
@@ -2,5 +2,7 @@ package withdashes;
 
 
 // Refresh rate or disabled.
-public class RefreshRate extends StringOrBool {
+public class RefreshRate {
+    public String string;
+    public Boolean bool;
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/StringOrBool.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/StringOrBool.java
@@ -1,7 +1,0 @@
-package withdashes;
-
-
-public class StringOrBool {
-    public String string;
-    public Boolean bool;
-}

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
@@ -1,5 +1,6 @@
 package refs;
 
 
-public class RefToSomeStruct extends SomeStruct {
+public class RefToSomeStruct {
+    public Object fieldAny;
 }

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/SomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/SomeStruct.java
@@ -1,6 +1,0 @@
-package refs;
-
-
-public class SomeStruct {
-    public Object fieldAny;
-}


### PR DESCRIPTION
We have a lot of classes that are used like "alias" for disjunctions. 

This veneer moves the generated code for the disjunctions into the parent class and remove the extension.