### PR TITLE
Compiler pass/prefix object names

### DIFF
--- a/internal/ast/compiler/prefix_object_names_test.go
+++ b/internal/ast/compiler/prefix_object_names_test.go
@@ -1,0 +1,43 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestPrefixObjectNames(t *testing.T) {
+	// Prepare test input
+	schema := &ast.Schema{
+		Package: "prefix_names",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("prefix_names", "SomeObject", ast.NewStruct(
+				ast.NewStructField("foo", ast.String(ast.Nullable())),
+				ast.NewStructField("ref_to_nice_object", ast.NewRef("prefix_names", "NotANiceName")),
+			)),
+			ast.NewObject("prefix_names", "NotANiceName", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable())),
+			)),
+		),
+	}
+	expected := &ast.Schema{
+		Package: "prefix_names",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("prefix_names", "PreSomeObject", ast.NewStruct(
+				ast.NewStructField("foo", ast.String(ast.Nullable())),
+				ast.NewStructField("ref_to_nice_object", ast.NewRef("prefix_names", "PreNotANiceName", ast.Trail("PrefixObjectNames[NotANiceName → PreNotANiceName]"))),
+			), "PrefixObjectNames[SomeObject → PreSomeObject]"),
+			ast.NewObject("prefix_names", "PreNotANiceName", ast.NewStruct(
+				ast.NewStructField("AString", ast.String(ast.Nullable())),
+			), "PrefixObjectNames[NotANiceName → PreNotANiceName]"),
+		),
+	}
+
+	pass := &PrefixObjectNames{
+		Prefix: "Pre",
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, pass, schema, expected)
+}

--- a/internal/ast/compiler/prefix_objects_names.go
+++ b/internal/ast/compiler/prefix_objects_names.go
@@ -20,15 +20,32 @@ func (pass *PrefixObjectNames) Process(schemas []*ast.Schema) ([]*ast.Schema, er
 
 	visitor := &Visitor{
 		OnObject: pass.processObject,
+		OnRef:    pass.processRef,
 	}
 
 	return visitor.VisitSchemas(schemas)
 }
 
-func (pass *PrefixObjectNames) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
+func (pass *PrefixObjectNames) processObject(visitor *Visitor, schema *ast.Schema, object ast.Object) (ast.Object, error) {
+	var err error
+
 	originalName := object.Name
 	object.Name = pass.Prefix + originalName
+	object.SelfRef.ReferredType = object.Name
 	object.AddToPassesTrail(fmt.Sprintf("PrefixObjectNames[%s → %s]", originalName, object.Name))
 
+	object.Type, err = visitor.VisitType(schema, object.Type)
+	if err != nil {
+		return ast.Object{}, err
+	}
+
 	return object, nil
+}
+
+func (pass *PrefixObjectNames) processRef(_ *Visitor, _ *ast.Schema, ref ast.Type) (ast.Type, error) {
+	originalName := ref.Ref.ReferredType
+	ref.Ref.ReferredType = pass.Prefix + originalName
+	ref.AddToPassesTrail(fmt.Sprintf("PrefixObjectNames[%s → %s]", originalName, ref.Ref.ReferredType))
+
+	return ref, nil
 }

--- a/internal/ast/compiler/prefix_objects_names.go
+++ b/internal/ast/compiler/prefix_objects_names.go
@@ -1,0 +1,34 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*PrefixObjectNames)(nil)
+
+// PrefixObjectNames appends the given comment to every object definition.
+type PrefixObjectNames struct {
+	Prefix string
+}
+
+func (pass *PrefixObjectNames) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	if pass.Prefix == "" {
+		return schemas, nil
+	}
+
+	visitor := &Visitor{
+		OnObject: pass.processObject,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (pass *PrefixObjectNames) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
+	originalName := object.Name
+	object.Name = pass.Prefix + originalName
+	object.AddToPassesTrail(fmt.Sprintf("PrefixObjectNames[%s → %s]", originalName, object.Name))
+
+	return object, nil
+}


### PR DESCRIPTION
Adds a compiler pass that alters object names to add a prefix to them.

This is to support an existing feature in grafana-app-sdk's codegen: https://github.com/grafana/grafana-app-sdk/blob/9643ce43ef07d9218303db5722be6e04ab9d1f3b/codegen/jennies/gotypes.go#L174-L175

Contributes to #408 
