### PR TITLE
Cue/out of root references

### DIFF
--- a/internal/simplecue/utils.go
+++ b/internal/simplecue/utils.go
@@ -216,6 +216,10 @@ func commentsFromCueValue(v cue.Value) []string {
 		}
 	}
 
+	if len(docs) == 0 {
+		return nil
+	}
+
 	ret := make([]string, 0, len(docs))
 	for _, cg := range docs {
 		ret = append(ret, strings.Split(strings.Trim(cg.Text(), "\n "), "\n")...)

--- a/internal/simplecue/utils.go
+++ b/internal/simplecue/utils.go
@@ -272,3 +272,31 @@ func hasStructFields(v cue.Value) bool {
 
 	return false
 }
+
+func areCuePathsFromSameRoot(a cue.Path, b cue.Path) bool {
+	selectorsA := a.Selectors()
+	selectorsB := b.Selectors()
+
+	if len(selectorsA) == 0 || len(selectorsB) == 0 {
+		return false
+	}
+
+	return selectorsA[0].String() == selectorsB[0].String()
+}
+
+func cuePathIsChildOf(root cue.Path, maybeChild cue.Path) bool {
+	selectorsRoot := root.Selectors()
+	selectorsChild := maybeChild.Selectors()
+
+	if len(selectorsRoot) > len(selectorsChild) {
+		return false
+	}
+
+	for i, rootSelector := range selectorsRoot {
+		if rootSelector.String() != selectorsChild[i].String() {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Contributes to #408 

`grafana-app-sdk`'s codegen pipeline supports cases where code is generated from a specific path within a cue file, while types relevant for the codegen are defined outside of that path:

```cue
schema: {
  spec: { // ← codegen runs on this
    title: string
    origin: #Origin // ← "out of root" reference
  }
  #Origin: { creator: string } 
}
```