### PR TITLE
Move common.{Config,Context} to the languages package

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/codegen"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +65,7 @@ func inspectBuilderIR(schemas []*ast.Schema) error {
 	var err error
 	generator := &ast.BuilderGenerator{}
 
-	codegenCtx := common.Context{
+	codegenCtx := languages.Context{
 		Schemas:  schemas,
 		Builders: generator.FromAST(schemas),
 	}

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/ast/compiler"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/java"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
@@ -121,8 +120,8 @@ func (pipeline *Pipeline) interpolate(input string) string {
 	return interpolated
 }
 
-func (pipeline *Pipeline) jenniesConfig() common.Config {
-	return common.Config{
+func (pipeline *Pipeline) jenniesConfig() languages.Config {
+	return languages.Config{
 		Debug:    pipeline.Debug,
 		Types:    pipeline.Output.Types,
 		Builders: pipeline.Output.Builders,

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -87,9 +87,9 @@ func (pipeline *Pipeline) Run(ctx context.Context) (*codejen.FS, error) {
 	return generatedFS, nil
 }
 
-func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, schemas ast.Schemas, commonCompilerPasses compiler.Passes, veneers *rewrite.Rewriter) (common.Context, error) {
+func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, schemas ast.Schemas, commonCompilerPasses compiler.Passes, veneers *rewrite.Rewriter) (languages.Context, error) {
 	var err error
-	jenniesInput := common.Context{
+	jenniesInput := languages.Context{
 		Schemas: schemas,
 	}
 
@@ -97,7 +97,7 @@ func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, s
 	compilerPasses := commonCompilerPasses.Concat(language.CompilerPasses())
 	jenniesInput.Schemas, err = compilerPasses.Process(jenniesInput.Schemas)
 	if err != nil {
-		return common.Context{}, err
+		return languages.Context{}, err
 	}
 
 	if !pipeline.Output.Builders {
@@ -111,13 +111,13 @@ func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, s
 	// apply veneers to builders
 	jenniesInput.Builders, err = veneers.ApplyTo(jenniesInput.Schemas, jenniesInput.Builders, language.Name())
 	if err != nil {
-		return common.Context{}, err
+		return languages.Context{}, err
 	}
 
 	// with the veneers applied, generate "nil-checks" for assignments
 	jenniesInput, err = languages.GenerateBuilderNilChecks(language, jenniesInput)
 	if err != nil {
-		return common.Context{}, err
+		return languages.Context{}, err
 	}
 
 	return jenniesInput, nil

--- a/internal/codegen/tools.go
+++ b/internal/codegen/tools.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -78,13 +79,13 @@ func repositoryTemplatesJenny(pipeline *Pipeline) (*codejen.JennyList[common.Bui
 	return repoTemplatesJenny, nil
 }
 
-func packageTemplatesJenny(pipeline *Pipeline, language string) (*codejen.JennyList[common.Context], error) {
+func packageTemplatesJenny(pipeline *Pipeline, language string) (*codejen.JennyList[languages.Context], error) {
 	outputDir, err := pipeline.languageOutputDir(pipeline.currentDirectory, language)
 	if err != nil {
 		return nil, err
 	}
 
-	pkgTemplatesJenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+	pkgTemplatesJenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return "PackageTemplates" + tools.UpperCamelCase(language)
 	})
 	pkgTemplatesJenny.AppendOneToMany(&common.PackageTemplate{

--- a/internal/jennies/common/codejen.go
+++ b/internal/jennies/common/codejen.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type noopOneToManyJenny[Input any] struct {
@@ -31,7 +32,7 @@ func If[Input any](condition bool, innerJenny codejen.OneToMany[Input]) codejen.
 // GeneratedCommentHeader produces a FileMapper that injects a comment header onto
 // a [codejen.File] indicating  the jenny or jennies that constructed the
 // file.
-func GeneratedCommentHeader(config Config) codejen.FileMapper {
+func GeneratedCommentHeader(config languages.Config) codejen.FileMapper {
 	genHeader := `{{ .Leader }} Code generated - EDITING IS FUTILE. DO NOT EDIT.
 {{- with .Using }}
 {{ $.Leader }}

--- a/internal/jennies/common/codejen_test.go
+++ b/internal/jennies/common/codejen_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -126,7 +127,7 @@ With some content`
 		t.Run(tc.name, func(t *testing.T) {
 			req := require.New(t)
 
-			resultFile, err := GeneratedCommentHeader(Config{Debug: tc.debug})(*tc.inputFile)
+			resultFile, err := GeneratedCommentHeader(languages.Config{Debug: tc.debug})(*tc.inputFile)
 			req.NoError(err)
 
 			req.Equal(tc.expectedContent, string(resultFile.Data))

--- a/internal/jennies/common/packagetemplate.go
+++ b/internal/jennies/common/packagetemplate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/codejen"
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type PackageTemplate struct {
@@ -25,7 +26,7 @@ func (jenny PackageTemplate) JennyName() string {
 	return fmt.Sprintf("PackageTemplate[%s]", jenny.Language)
 }
 
-func (jenny PackageTemplate) Generate(context Context) (codejen.Files, error) {
+func (jenny PackageTemplate) Generate(context languages.Context) (codejen.Files, error) {
 	var files codejen.Files
 
 	templateRoot := filepath.Join(jenny.TemplateDir, jenny.Language)
@@ -75,7 +76,7 @@ func (jenny PackageTemplate) Generate(context Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny PackageTemplate) templateData(context Context) map[string]any {
+func (jenny PackageTemplate) templateData(context languages.Context) map[string]any {
 	packages := make([]string, 0, len(context.Schemas))
 	for _, schema := range context.Schemas {
 		packages = append(packages, schema.Package)

--- a/internal/jennies/common/repotemplate.go
+++ b/internal/jennies/common/repotemplate.go
@@ -13,6 +13,10 @@ import (
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
 )
 
+type BuildOptions struct {
+	Languages []string
+}
+
 type RepositoryTemplate struct {
 	TemplateDir string
 	ExtraData   map[string]string

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -24,7 +24,7 @@ func (jenny *Builder) JennyName() string {
 	return "GoBuilder"
 }
 
-func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
+func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error) {
 	files := codejen.Files{}
 
 	for _, builder := range context.Builders {
@@ -44,7 +44,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builder) ([]byte, error) {
+func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
 	var buffer strings.Builder
 
 	imports := NewImportMap()
@@ -112,7 +112,7 @@ func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builde
 	return []byte(buffer.String()), nil
 }
 
-func (jenny *Builder) genDefaultOptionsCalls(context common.Context, builder ast.Builder) []template.OptionCall {
+func (jenny *Builder) genDefaultOptionsCalls(context languages.Context, builder ast.Builder) []template.OptionCall {
 	calls := make([]template.OptionCall, 0)
 	for _, opt := range builder.Options {
 		if opt.Default == nil {
@@ -150,7 +150,7 @@ func hasTypedDefaults(opt ast.Option) bool {
 	return false
 }
 
-func (jenny *Builder) formatDefaultTypedArgs(context common.Context, opt ast.Option) []string {
+func (jenny *Builder) formatDefaultTypedArgs(context languages.Context, opt ast.Option) []string {
 	args := make([]string, 0)
 	for i, arg := range opt.Default.ArgsValues {
 		val, _ := arg.(map[string]interface{})

--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -3,14 +3,13 @@ package golang
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite[common.Context]{
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "GoBuilder",
 		Skip: map[string]string{
@@ -24,7 +23,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(config)
 	jenny := Builder{Config: config}
 
-	test.Run(t, func(tc *testutils.Test[common.Context]) {
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
 		var err error
 		req := require.New(tc)
 

--- a/internal/jennies/golang/gomod.go
+++ b/internal/jennies/golang/gomod.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type GoMod struct {
@@ -15,7 +15,7 @@ func (jenny GoMod) JennyName() string {
 	return "GoMod"
 }
 
-func (jenny GoMod) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny GoMod) Generate(_ languages.Context) (codejen.Files, error) {
 	return codejen.Files{
 		*codejen.NewFile("go.mod", []byte(jenny.generateGoMod()), jenny),
 	}, nil

--- a/internal/jennies/golang/gomod_test.go
+++ b/internal/jennies/golang/gomod_test.go
@@ -3,7 +3,7 @@ package golang
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +14,7 @@ func TestGoMod_Generate(t *testing.T) {
 		Config: Config{PackageRoot: "github.com/grafana/heey"},
 	}
 
-	files, err := jenny.Generate(common.Context{})
+	files, err := jenny.Generate(languages.Context{})
 	req.NoError(err)
 
 	req.Len(files, 1)

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -35,7 +35,7 @@ func (config *Config) InterpolateParameters(interpolator func(input string) stri
 	config.PackageRoot = interpolator(config.PackageRoot)
 }
 
-func (config Config) MergeWithGlobal(global common.Config) Config {
+func (config Config) MergeWithGlobal(global languages.Config) Config {
 	newConfig := config
 	newConfig.debug = global.Debug
 	newConfig.generateBuilders = global.Builders
@@ -62,21 +62,21 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
 
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		common.If[common.Context](!config.SkipRuntime, Runtime{Config: config}),
-		common.If[common.Context](!config.SkipRuntime, VariantsPlugins{Config: config}),
+		common.If[languages.Context](!config.SkipRuntime, Runtime{Config: config}),
+		common.If[languages.Context](!config.SkipRuntime, VariantsPlugins{Config: config}),
 
-		common.If[common.Context](config.GenerateGoMod, GoMod{Config: config}),
+		common.If[languages.Context](config.GenerateGoMod, GoMod{Config: config}),
 
-		common.If[common.Context](globalConfig.Types, RawTypes{Config: config}),
+		common.If[languages.Context](globalConfig.Types, RawTypes{Config: config}),
 
-		common.If[common.Context](!config.SkipRuntime && globalConfig.Builders, &Builder{Config: config}),
+		common.If[languages.Context](!config.SkipRuntime && globalConfig.Builders, &Builder{Config: config}),
 	)
 	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -29,7 +29,7 @@ func (jenny JSONMarshalling) generateForSchema(buffer *strings.Builder, schema *
 	return nil
 }
 
-func (jenny JSONMarshalling) generateForObject(buffer *strings.Builder, context common.Context, schema *ast.Schema, object ast.Object) error {
+func (jenny JSONMarshalling) generateForObject(buffer *strings.Builder, context languages.Context, schema *ast.Schema, object ast.Object) error {
 	if jenny.objectNeedsCustomMarshal(object) {
 		jsonMarshal, err := jenny.renderCustomMarshal(object)
 		if err != nil {
@@ -87,7 +87,7 @@ func (jenny JSONMarshalling) renderCustomMarshal(obj ast.Object) (string, error)
 	return "", fmt.Errorf("could not determine how to render custom marshal")
 }
 
-func (jenny JSONMarshalling) objectNeedsCustomUnmarshal(context common.Context, obj ast.Object) bool {
+func (jenny JSONMarshalling) objectNeedsCustomUnmarshal(context languages.Context, obj ast.Object) bool {
 	// an object needs a custom unmarshal if:
 	// - it is a struct that was generated from a disjunction by the `DisjunctionToType` compiler pass.
 	// - it is a struct and one or more of its fields is a KindComposableSlot, or an array of KindComposableSlot
@@ -111,7 +111,7 @@ func (jenny JSONMarshalling) objectNeedsCustomUnmarshal(context common.Context, 
 	return false
 }
 
-func (jenny JSONMarshalling) renderCustomUnmarshal(context common.Context, obj ast.Object) (string, error) {
+func (jenny JSONMarshalling) renderCustomUnmarshal(context languages.Context, obj ast.Object) (string, error) {
 	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDisjunctionOfScalars) {
 		return jenny.renderTemplate("types/disjunction_of_scalars.json_unmarshal.tmpl", map[string]any{
 			"def": obj,
@@ -128,7 +128,7 @@ func (jenny JSONMarshalling) renderCustomUnmarshal(context common.Context, obj a
 	return jenny.renderCustomComposableSlotUnmarshal(context, obj)
 }
 
-func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context common.Context, obj ast.Object) (string, error) {
+func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languages.Context, obj ast.Object) (string, error) {
 	var buffer strings.Builder
 	fields := obj.Type.AsStruct().Fields
 

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -21,7 +21,7 @@ func (jenny RawTypes) JennyName() string {
 	return "GoRawTypes"
 }
 
-func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
+func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
@@ -41,7 +41,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
+func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Schema) ([]byte, error) {
 	var buffer strings.Builder
 	var err error
 

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +35,7 @@ func TestRawTypes_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{
+		files, err := jenny.Generate(languages.Context{
 			Schemas: processedAsts,
 		})
 		req.NoError(err)

--- a/internal/jennies/golang/runtime.go
+++ b/internal/jennies/golang/runtime.go
@@ -2,7 +2,7 @@ package golang
 
 import (
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type Runtime struct {
@@ -13,7 +13,7 @@ func (jenny Runtime) JennyName() string {
 	return "GoRuntime"
 }
 
-func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny Runtime) Generate(_ languages.Context) (codejen.Files, error) {
 	runtime, err := jenny.Runtime()
 	if err != nil {
 		return nil, err

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -15,10 +15,10 @@ type typeFormatter struct {
 	config        Config
 
 	forBuilder bool
-	context    common.Context
+	context    languages.Context
 }
 
-func defaultTypeFormatter(config Config, context common.Context, packageMapper func(pkg string) string) *typeFormatter {
+func defaultTypeFormatter(config Config, context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
 		packageMapper: packageMapper,
 		config:        config,
@@ -26,7 +26,7 @@ func defaultTypeFormatter(config Config, context common.Context, packageMapper f
 	}
 }
 
-func builderTypeFormatter(config Config, context common.Context, packageMapper func(pkg string) string) *typeFormatter {
+func builderTypeFormatter(config Config, context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
 		packageMapper: packageMapper,
 		config:        config,

--- a/internal/jennies/golang/variantsplugins.go
+++ b/internal/jennies/golang/variantsplugins.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type VariantsPlugins struct {
@@ -16,7 +16,7 @@ func (jenny VariantsPlugins) JennyName() string {
 	return "GoVariantsPlugins"
 }
 
-func (jenny VariantsPlugins) Generate(context common.Context) (codejen.Files, error) {
+func (jenny VariantsPlugins) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	registries, err := jenny.variantPlugins(context)
@@ -39,7 +39,7 @@ func (jenny VariantsPlugins) variantModels() (string, error) {
 	return renderTemplate("runtime/variant_models.tmpl", map[string]any{})
 }
 
-func (jenny VariantsPlugins) variantPlugins(context common.Context) (string, error) {
+func (jenny VariantsPlugins) variantPlugins(context languages.Context) (string, error) {
 	imports := NewImportMap()
 	var panelSchemas []*ast.Schema
 	var dataquerySchemas []*ast.Schema

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -4,20 +4,20 @@ import (
 	"fmt"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type Builders struct {
 	config        Config
-	context       common.Context
+	context       languages.Context
 	typeFormatter *typeFormatter
 	builders      map[string]map[string]ast.Builder
 	isPanel       map[string]bool
 }
 
-func parseBuilders(config Config, context common.Context, formatter *typeFormatter) Builders {
+func parseBuilders(config Config, context languages.Context, formatter *typeFormatter) Builders {
 	b := make(map[string]map[string]ast.Builder)
 	panels := make(map[string]bool)
 	for _, builder := range context.Builders {

--- a/internal/jennies/java/builders_test.go
+++ b/internal/jennies/java/builders_test.go
@@ -3,14 +3,13 @@ package java
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuidlers_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite[common.Context]{
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "JavaBuilders",
 		Skip:         map[string]string{
@@ -21,7 +20,7 @@ func TestBuidlers_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := RawTypes{}
 
-	test.Run(t, func(tc *testutils.Test[common.Context]) {
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
 		var err error
 		req := require.New(tc)
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -42,14 +42,14 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		common.If[common.Context](!language.config.SkipRuntime, Runtime{config: language.config}),
+		common.If[languages.Context](!language.config.SkipRuntime, Runtime{config: language.config}),
 		RawTypes{config: language.config},
-		common.If[common.Context](language.config.GeneratePOM, Pom{language.config}),
+		common.If[languages.Context](language.config.GeneratePOM, Pom{language.config}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/java/pom.go
+++ b/internal/jennies/java/pom.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type Pom struct {
@@ -15,7 +15,7 @@ func (jenny Pom) JennyName() string {
 	return "Pom"
 }
 
-func (jenny Pom) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny Pom) Generate(_ languages.Context) (codejen.Files, error) {
 	return codejen.Files{
 		*codejen.NewFile("pom.xml", []byte(jenny.generatePom()), jenny),
 	}, nil

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -24,7 +25,7 @@ func (jenny RawTypes) JennyName() string {
 	return "JavaRawTypes"
 }
 
-func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
+func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0)
 	jenny.imports = NewImportMap(jenny.config.PackagePath)
 	jenny.typeFormatter = createFormatter(context, jenny.config)

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestRawTypes_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{
+		files, err := jenny.Generate(languages.Context{
 			Schemas: processedAsts,
 		})
 		req.NoError(err)

--- a/internal/jennies/java/runtime.go
+++ b/internal/jennies/java/runtime.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type Runtime struct {
@@ -17,7 +17,7 @@ func (jenny Runtime) JennyName() string {
 	return "JavaRuntime"
 }
 
-func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny Runtime) Generate(_ languages.Context) (codejen.Files, error) {
 	variants, err := jenny.renderDataQueryVariant("Dataquery")
 	if err != nil {
 		return nil, err

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type typeFormatter struct {
 	config        Config
 	packageMapper func(pkg string, class string) string
-	context       common.Context
+	context       languages.Context
 }
 
-func createFormatter(ctx common.Context, config Config) *typeFormatter {
+func createFormatter(ctx languages.Context, config Config) *typeFormatter {
 	return &typeFormatter{context: ctx, config: config}
 }
 

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast/compiler"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -18,7 +18,7 @@ type Config struct {
 	Compact bool `yaml:"compact"`
 }
 
-func (config Config) MergeWithGlobal(global common.Config) Config {
+func (config Config) MergeWithGlobal(global languages.Config) Config {
 	newConfig := config
 	newConfig.Debug = global.Debug
 
@@ -39,9 +39,9 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -27,7 +27,7 @@ func (jenny Schema) JennyName() string {
 	return "JSONSchema"
 }
 
-func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
+func (jenny Schema) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	if jenny.ReferenceFormatter == nil {
@@ -54,7 +54,7 @@ func (jenny Schema) toJSON(input any) ([]byte, error) {
 	return json.Marshal(input)
 }
 
-func (jenny Schema) GenerateSchema(context common.Context, schema *ast.Schema) Definition {
+func (jenny Schema) GenerateSchema(context languages.Context, schema *ast.Schema) Definition {
 	jenny.foreignObjects = orderedmap.New[string, ast.Object]()
 
 	jenny.isForeignReference = func(ref ast.RefType) bool {

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func TestSchema_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{
+		files, err := jenny.Generate(languages.Context{
 			Schemas: processedAsts,
 		})
 		req.NoError(err)

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast/compiler"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 const LanguageRef = "openapi"
@@ -14,7 +14,7 @@ type Config struct {
 	Compact bool `yaml:"compact"`
 }
 
-func (config Config) MergeWithGlobal(global common.Config) Config {
+func (config Config) MergeWithGlobal(global languages.Config) Config {
 	newConfig := config
 	newConfig.debug = global.Debug
 
@@ -35,9 +35,9 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 )
 
@@ -19,7 +19,7 @@ func (jenny Schema) JennyName() string {
 	return "OpenAPI"
 }
 
-func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
+func (jenny Schema) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
@@ -34,7 +34,7 @@ func (jenny Schema) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny Schema) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
+func (jenny Schema) generateSchema(context languages.Context, schema *ast.Schema) ([]byte, error) {
 	jsonschemaJenny := jsonschema.Schema{
 		Config: jsonschema.Config{
 			Debug:   jenny.Config.debug,

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func TestSchema_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{
+		files, err := jenny.Generate(languages.Context{
 			Schemas: processedAsts,
 		})
 		req.NoError(err)

--- a/internal/jennies/python/builder.go
+++ b/internal/jennies/python/builder.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -22,7 +22,7 @@ func (jenny *Builder) JennyName() string {
 	return "PythonBuilder"
 }
 
-func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
+func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error) {
 	files := codejen.Files{}
 	buildersByPackage := make(map[string][]ast.Builder)
 
@@ -64,7 +64,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builder) ([]byte, error) {
+func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
 	var buffer strings.Builder
 
 	// every builder uses the following imports

--- a/internal/jennies/python/builder_test.go
+++ b/internal/jennies/python/builder_test.go
@@ -3,14 +3,13 @@ package python
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite[common.Context]{
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "PythonBuilder",
 		Skip: map[string]string{
@@ -21,7 +20,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := Builder{}
 
-	test.Run(t, func(tc *testutils.Test[common.Context]) {
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
 		var err error
 		req := require.New(tc)
 

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -37,16 +37,16 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
 		ModuleInit{},
-		common.If[common.Context](!language.config.SkipRuntime, Runtime{}),
+		common.If[languages.Context](!language.config.SkipRuntime, Runtime{}),
 
-		common.If[common.Context](globalConfig.Types, RawTypes{}),
-		common.If[common.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{}),
+		common.If[languages.Context](globalConfig.Types, RawTypes{}),
+		common.If[languages.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/python/module_init.go
+++ b/internal/jennies/python/module_init.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type ModuleInit struct {
@@ -14,7 +14,7 @@ func (jenny ModuleInit) JennyName() string {
 	return "PythonModuleInit"
 }
 
-func (jenny ModuleInit) Generate(context common.Context) (codejen.Files, error) {
+func (jenny ModuleInit) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas)+2)
 
 	files = append(files, *codejen.NewFile("__init__.py", jenny.module("root"), jenny))

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -22,7 +22,7 @@ func (jenny RawTypes) JennyName() string {
 	return "PythonRawTypes"
 }
 
-func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
+func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
 	for _, schema := range context.Schemas {
@@ -39,7 +39,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
+func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Schema) ([]byte, error) {
 	var buffer strings.Builder
 	var err error
 
@@ -190,7 +190,7 @@ func (jenny RawTypes) generateToJSONMethod(object ast.Object) string {
 	return buffer.String()
 }
 
-func (jenny RawTypes) generateFromJSONMethod(context common.Context, object ast.Object) string {
+func (jenny RawTypes) generateFromJSONMethod(context languages.Context, object ast.Object) string {
 	var buffer strings.Builder
 
 	typingPkg := jenny.importPkg("typing", "typing")
@@ -375,7 +375,7 @@ func (jenny RawTypes) disjunctionFromJSON(disjunction ast.DisjunctionType, input
 	return decodingMap, decodingCall
 }
 
-func (jenny RawTypes) composableSlotFromJSON(context common.Context, parentStruct ast.StructType, field ast.StructField) string {
+func (jenny RawTypes) composableSlotFromJSON(context languages.Context, parentStruct ast.StructType, field ast.StructField) string {
 	slot, _ := context.ResolveToComposableSlot(field.Type)
 	if slot.AsComposableSlot().Variant != ast.SchemaVariantDataQuery {
 		return "unknown composable slot variant"

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func TestRawTypes_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{Schemas: processedAsts})
+		files, err := jenny.Generate(languages.Context{Schemas: processedAsts})
 		req.NoError(err)
 
 		tc.WriteFiles(files)

--- a/internal/jennies/python/runtime.go
+++ b/internal/jennies/python/runtime.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type Runtime struct {
@@ -15,7 +15,7 @@ func (jenny Runtime) JennyName() string {
 	return "PythonRuntime"
 }
 
-func (jenny Runtime) Generate(context common.Context) (codejen.Files, error) {
+func (jenny Runtime) Generate(context languages.Context) (codejen.Files, error) {
 	builder, err := renderTemplate("runtime/builder.tmpl", map[string]any{})
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (jenny Runtime) Generate(context common.Context) (codejen.Files, error) {
 	}, nil
 }
 
-func (jenny Runtime) variantPlugins(context common.Context) (string, error) {
+func (jenny Runtime) variantPlugins(context languages.Context) (string, error) {
 	imports := NewImportMap()
 	var panelSchemas []string
 	var dataquerySchemas []string

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -17,10 +17,10 @@ type typeFormatter struct {
 	importModule moduleImporter
 
 	forBuilder bool
-	context    common.Context
+	context    languages.Context
 }
 
-func defaultTypeFormatter(context common.Context, importPkg pkgImporter, importModule moduleImporter) *typeFormatter {
+func defaultTypeFormatter(context languages.Context, importPkg pkgImporter, importModule moduleImporter) *typeFormatter {
 	return &typeFormatter{
 		context:      context,
 		importPkg:    importPkg,
@@ -28,7 +28,7 @@ func defaultTypeFormatter(context common.Context, importPkg pkgImporter, importM
 	}
 }
 
-func builderTypeFormatter(context common.Context, importPkg pkgImporter, importModule moduleImporter) *typeFormatter {
+func builderTypeFormatter(context languages.Context, importPkg pkgImporter, importModule moduleImporter) *typeFormatter {
 	return &typeFormatter{
 		importPkg:    importPkg,
 		importModule: importModule,

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
@@ -23,7 +24,7 @@ func (jenny *Builder) JennyName() string {
 	return "TypescriptBuilder"
 }
 
-func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
+func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error) {
 	files := codejen.Files{}
 	jenny.rawTypes = RawTypes{
 		schemas: context.Schemas,
@@ -47,7 +48,7 @@ func (jenny *Builder) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny *Builder) generateBuilder(context common.Context, builder ast.Builder) ([]byte, error) {
+func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
 	var buffer strings.Builder
 
 	jenny.imports = NewImportMap()

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -3,14 +3,13 @@ package typescript
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Generate(t *testing.T) {
-	test := testutils.GoldenFilesTestSuite[common.Context]{
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "TypescriptBuilder",
 	}
@@ -18,7 +17,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(Config{})
 	jenny := Builder{}
 
-	test.Run(t, func(tc *testutils.Test[common.Context]) {
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
 		var err error
 		req := require.New(tc)
 

--- a/internal/jennies/typescript/index.go
+++ b/internal/jennies/typescript/index.go
@@ -6,19 +6,19 @@ import (
 	"strings"
 
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type Index struct {
-	Targets common.Config
+	Targets languages.Config
 }
 
 func (jenny Index) JennyName() string {
 	return "TypescriptIndex"
 }
 
-func (jenny Index) Generate(context common.Context) (codejen.Files, error) {
+func (jenny Index) Generate(context languages.Context) (codejen.Files, error) {
 	packages := make(map[string][]string, len(context.Schemas))
 	files := codejen.Files{}
 

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -36,17 +36,17 @@ func (language *Language) Name() string {
 	return LanguageRef
 }
 
-func (language *Language) Jennies(globalConfig common.Config) *codejen.JennyList[common.Context] {
-	jenny := codejen.JennyListWithNamer[common.Context](func(_ common.Context) string {
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
+	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		common.If[common.Context](!language.config.SkipRuntime, Runtime{}),
+		common.If[languages.Context](!language.config.SkipRuntime, Runtime{}),
 
-		common.If[common.Context](globalConfig.Types, RawTypes{}),
-		common.If[common.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{}),
+		common.If[languages.Context](globalConfig.Types, RawTypes{}),
+		common.If[languages.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{}),
 
-		common.If[common.Context](!language.config.SkipIndex, Index{Targets: globalConfig}),
+		common.If[languages.Context](!language.config.SkipIndex, Index{Targets: globalConfig}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -25,7 +25,7 @@ func (jenny RawTypes) JennyName() string {
 	return "TypescriptRawTypes"
 }
 
-func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
+func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	jenny.schemas = context.Schemas
 	files := make(codejen.Files, 0, len(context.Schemas))
 
@@ -47,7 +47,7 @@ func (jenny RawTypes) Generate(context common.Context) (codejen.Files, error) {
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(context common.Context, schema *ast.Schema) ([]byte, error) {
+func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Schema) ([]byte, error) {
 	var buffer strings.Builder
 	var err error
 

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func TestRawTypes_Generate(t *testing.T) {
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
 
-		files, err := jenny.Generate(common.Context{
+		files, err := jenny.Generate(languages.Context{
 			Schemas: processedAsts,
 		})
 		req.NoError(err)

--- a/internal/jennies/typescript/runtime.go
+++ b/internal/jennies/typescript/runtime.go
@@ -2,7 +2,7 @@ package typescript
 
 import (
 	"github.com/grafana/codejen"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 )
 
 type Runtime struct {
@@ -12,7 +12,7 @@ func (jenny Runtime) JennyName() string {
 	return "TypescriptRuntime"
 }
 
-func (jenny Runtime) Generate(_ common.Context) (codejen.Files, error) {
+func (jenny Runtime) Generate(_ languages.Context) (codejen.Files, error) {
 	return codejen.Files{
 		*codejen.NewFile("src/cog/variants_gen.ts", []byte(jenny.generateVariantsFile()), jenny),
 		*codejen.NewFile("src/cog/builder_gen.ts", []byte(jenny.generateOptionsBuilderFile()), jenny),

--- a/internal/jennies/typescript/runtime_test.go
+++ b/internal/jennies/typescript/runtime_test.go
@@ -3,7 +3,7 @@ package typescript
 import (
 	"testing"
 
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,7 +11,7 @@ func TestRuntime(t *testing.T) {
 	req := require.New(t)
 	jenny := Runtime{}
 
-	files, err := jenny.Generate(common.Context{})
+	files, err := jenny.Generate(languages.Context{})
 	req.NoError(err)
 
 	req.Len(files, 3)

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -14,17 +14,17 @@ type typeFormatter struct {
 	packageMapper func(pkg string) string
 
 	forBuilder bool
-	context    common.Context
+	context    languages.Context
 }
 
-func defaultTypeFormatter(context common.Context, packageMapper func(pkg string) string) *typeFormatter {
+func defaultTypeFormatter(context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
 		packageMapper: packageMapper,
 		context:       context,
 	}
 }
 
-func builderTypeFormatter(context common.Context, packageMapper func(pkg string) string) *typeFormatter {
+func builderTypeFormatter(context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
 		packageMapper: packageMapper,
 		forBuilder:    true,

--- a/internal/languages/config.go
+++ b/internal/languages/config.go
@@ -1,4 +1,4 @@
-package common
+package languages
 
 // Config represents global configuration options, to be used by all jennies.
 type Config struct {

--- a/internal/languages/context.go
+++ b/internal/languages/context.go
@@ -1,4 +1,4 @@
-package common
+package languages
 
 import (
 	"github.com/grafana/cog/internal/ast"
@@ -89,8 +89,4 @@ func (context *Context) ResolveToStruct(def ast.Type) bool {
 	}
 
 	return context.ResolveToStruct(referredObj.Type)
-}
-
-type BuildOptions struct {
-	Languages []string
 }

--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -4,12 +4,11 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/ast/compiler"
-	"github.com/grafana/cog/internal/jennies/common"
 )
 
 type Language interface {
 	Name() string
-	Jennies(config common.Config) *codejen.JennyList[common.Context]
+	Jennies(config Config) *codejen.JennyList[Context]
 	CompilerPasses() compiler.Passes
 }
 

--- a/internal/languages/nilchecks.go
+++ b/internal/languages/nilchecks.go
@@ -2,10 +2,9 @@ package languages
 
 import (
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/jennies/common"
 )
 
-func GenerateBuilderNilChecks(language Language, context common.Context) (common.Context, error) {
+func GenerateBuilderNilChecks(language Language, context Context) (Context, error) {
 	var err error
 	nullableKinds := NullableConfig{
 		Kinds:              nil,


### PR DESCRIPTION
Just a bit of housekeeping: these types make more sense in the `languages` package.