### PR TITLE
Java: Fix heatmap

### DIFF
--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
-	
+
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
@@ -16,7 +16,7 @@ import (
 type RawTypes struct {
 	config  Config
 	imports *common.DirectImportMap
-	
+
 	typeFormatter *typeFormatter
 	builders      Builders
 }
@@ -30,16 +30,16 @@ func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error)
 	jenny.imports = NewImportMap(jenny.config.PackagePath)
 	jenny.typeFormatter = createFormatter(context, jenny.config)
 	jenny.builders = parseBuilders(jenny.config, context, jenny.typeFormatter)
-	
+
 	for _, schema := range context.Schemas {
 		output, err := jenny.genFilesForSchema(schema)
 		if err != nil {
 			return nil, err
 		}
-		
+
 		files = append(files, output...)
 	}
-	
+
 	return files, nil
 }
 
@@ -61,17 +61,17 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 	var err error
 	files := make(codejen.Files, 0)
 	scalars := make(map[string]ast.ScalarType)
-	
+
 	packageMapper := func(pkg string, class string) string {
 		if jenny.imports.IsIdentical(pkg, schema.Package) {
 			return ""
 		}
-		
+
 		return jenny.imports.Add(class, pkg)
 	}
-	
+
 	jenny.typeFormatter = jenny.typeFormatter.withPackageMapper(packageMapper)
-	
+
 	alreadyValidatedPanel := make(map[string]bool)
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		jenny.imports = NewImportMap(jenny.config.PackagePath)
@@ -84,18 +84,18 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 			}
 			return
 		}
-		
+
 		pkg := formatPackageName(schema.Package)
 		output, innerErr := jenny.generateSchema(pkg, object)
 		if innerErr != nil {
 			err = innerErr
 			return
 		}
-		
+
 		filename := filepath.Join(jenny.config.ProjectPath, pkg, fmt.Sprintf("%s.java", tools.UpperCamelCase(object.Name)))
-		
+
 		files = append(files, *codejen.NewFile(filename, output, jenny))
-		
+
 		// Because we need to check the package only, it could have multiple files, and we want to generate
 		// the builder once.
 		if !alreadyValidatedPanel[schema.Package] {
@@ -104,7 +104,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 				err = innerErr
 				return
 			}
-			
+
 			if panelOutput != nil {
 				alreadyValidatedPanel[schema.Package] = true
 				filename := filepath.Join(jenny.config.ProjectPath, strings.ToLower(schema.Package), "PanelBuilder.java")
@@ -112,21 +112,21 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 			}
 		}
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if len(scalars) > 0 {
 		output, err := jenny.formatScalars(schema.Package, scalars)
 		if err != nil {
 			return nil, err
 		}
-		
+
 		filename := filepath.Join(jenny.config.ProjectPath, strings.ToLower(schema.Package), "Constants.java")
 		files = append(files, *codejen.NewFile(filename, output, jenny))
 	}
-	
+
 	return files, nil
 }
 
@@ -141,7 +141,7 @@ func (jenny RawTypes) generateSchema(pkg string, object ast.Object) ([]byte, err
 	case ast.KindIntersection:
 		return jenny.formatIntersection(pkg, object)
 	}
-	
+
 	return nil, nil
 }
 
@@ -152,20 +152,20 @@ func (jenny RawTypes) generatePanelBuilder(pkg string) ([]byte, error) {
 	if !hasBuilder {
 		return nil, nil
 	}
-	
+
 	builder.Imports = jenny.imports
-	
+
 	var buffer strings.Builder
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/panel_builder.tmpl", builder); err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
 func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) {
 	var buffer strings.Builder
-	
+
 	enum := object.Type.AsEnum()
 	values := make([]EnumValue, len(enum.Values))
 	for i, value := range enum.Values {
@@ -177,12 +177,12 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 			Value: value.Value,
 		}
 	}
-	
+
 	enumType := "Integer"
 	if enum.Values[0].Type.AsScalar().ScalarKind == ast.KindString {
 		enumType = "String"
 	}
-	
+
 	err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/enum.tmpl", EnumTemplate{
 		Package:  jenny.typeFormatter.formatPackage(pkg),
 		Name:     object.Name,
@@ -190,17 +190,17 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 		Type:     enumType,
 		Comments: object.Comments,
 	})
-	
+
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
 func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error) {
 	var buffer strings.Builder
-	
+
 	fields := make([]Field, 0)
 	for _, field := range object.Type.AsStruct().Fields {
 		fields = append(fields, Field{
@@ -209,10 +209,10 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 			Comments: field.Comments,
 		})
 	}
-	
+
 	builder, hasBuilder := jenny.builders.genBuilder(pkg, object.Name)
 	jenny.addJSONImportsIfNeeded()
-	
+
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
 		Package:              jenny.typeFormatter.formatPackage(pkg),
 		Imports:              jenny.imports,
@@ -226,13 +226,13 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 	}); err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
 func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarType) ([]byte, error) {
 	var buffer strings.Builder
-	
+
 	constants := make([]Constant, 0)
 	for name, scalar := range scalars {
 		constants = append(constants, Constant{
@@ -241,7 +241,7 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 			Value: scalar.Value,
 		})
 	}
-	
+
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/constants.tmpl", ConstantTemplate{
 		Package:   jenny.typeFormatter.formatPackage(pkg),
 		Name:      "Constants",
@@ -249,14 +249,14 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 	}); err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
 func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, error) {
 	var buffer strings.Builder
 	reference := jenny.typeFormatter.formatReference(object.Type.AsRef())
-	
+
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
 		Package:  jenny.typeFormatter.formatPackage(pkg),
 		Imports:  jenny.imports,
@@ -267,17 +267,17 @@ func (jenny RawTypes) formatReference(pkg string, object ast.Object) ([]byte, er
 	}); err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
 func (jenny RawTypes) formatIntersection(pkg string, object ast.Object) ([]byte, error) {
 	var buffer strings.Builder
-	
+
 	intersection := object.Type.AsIntersection()
 	extensions := make([]string, 0)
 	fields := make([]Field, 0)
-	
+
 	for _, branch := range intersection.Branches {
 		switch branch.Kind {
 		case ast.KindRef:
@@ -286,7 +286,7 @@ func (jenny RawTypes) formatIntersection(pkg string, object ast.Object) ([]byte,
 			fields = append(fields, jenny.formatFields(branch.AsStruct())...)
 		}
 	}
-	
+
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
 		Package:  jenny.typeFormatter.formatPackage(pkg),
 		Imports:  jenny.imports,
@@ -298,7 +298,7 @@ func (jenny RawTypes) formatIntersection(pkg string, object ast.Object) ([]byte,
 	}); err != nil {
 		return nil, err
 	}
-	
+
 	return []byte(buffer.String()), nil
 }
 
@@ -311,7 +311,7 @@ func (jenny RawTypes) formatFields(def ast.StructType) []Field {
 			Comments: field.Comments,
 		}
 	}
-	
+
 	return fields
 }
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -51,6 +51,7 @@ func (jenny RawTypes) getTemplate() *template.Template {
 		"emptyValueForType":        jenny.typeFormatter.defaultValueFor,
 		"formatCastValue":          jenny.typeFormatter.formatCastValue,
 		"formatAssignmentPath":     jenny.typeFormatter.formatAssignmentPath,
+		"formatPath":               jenny.typeFormatter.formatFieldPath,
 	})
 }
 
@@ -208,7 +209,7 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 	}
 
 	builder, hasBuilder := jenny.builders.genBuilder(pkg, object.Name)
-	jenny.addJSONImportsIfNeeded(hasBuilder)
+	jenny.addJSONImportsIfNeeded()
 
 	if err := jenny.getTemplate().ExecuteTemplate(&buffer, "types/class.tmpl", ClassTemplate{
 		Package:              jenny.typeFormatter.formatPackage(pkg),
@@ -321,8 +322,8 @@ func (jenny RawTypes) getVariant(t ast.Type) string {
 	return variant
 }
 
-func (jenny RawTypes) addJSONImportsIfNeeded(hasBuilder bool) {
-	if hasBuilder && jenny.config.GeneratePOM {
+func (jenny RawTypes) addJSONImportsIfNeeded() {
+	if jenny.config.GeneratePOM {
 		jenny.typeFormatter.packageMapper("com.fasterxml.jackson", "annotation.JsonProperty")
 		jenny.typeFormatter.packageMapper("com.fasterxml.jackson", "core.JsonProcessingException")
 		jenny.typeFormatter.packageMapper("com.fasterxml.jackson", "databind.ObjectMapper")

--- a/internal/jennies/java/templates/types/assigments.tmpl
+++ b/internal/jennies/java/templates/types/assigments.tmpl
@@ -19,11 +19,11 @@
 {{- end }}
 
 {{- define "assignment_setup" }}
+    {{- $castPath := formatCastValue $.Assignment.Path }}
     {{- with .Value.Argument }}
-        {{- $castPath := formatCastValue $.Assignment.Path }}
         {{- if not (eq $castPath.Value "") }}
-        {{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{- $castPath.Class }}) this.internal.{{ $castPath.Path }};
-        {{ $castPath.Value | lowerCamelCase }}Resource.{{ .Name | lowerCamelCase }} = {{ .Name | lowerCamelCase }}{{ if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}.build(){{ end }};
+        {{ if not $castPath.IsNilChecked }}{{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{- $castPath.Class }}) this.internal.{{ $castPath.Path }};{{ end }}
+        {{ $castPath.Value | lowerCamelCase }}Resource.{{ lastPathIdentifier $.Assignment.Path }} = {{ .Name | lowerCamelCase }}{{ if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}.build(){{ end }};
         {{- end }}
     {{- end }}
     {{- with .Value.Envelope }}
@@ -33,14 +33,21 @@
 
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
     {{- end }}
+    {{- if and (not (eq .Value.Constant nil)) (not (eq $castPath.Value "")) }}
+        {{ $castPath.Value | lowerCamelCase }}Resource.{{ lastPathIdentifier $.Assignment.Path }} = {{ .Value.Constant }}
+    {{- end }}
 {{- end }}
 
 {{- define "assignment_value" }}
+    {{- $castPath := formatCastValue $.Assignment.Path }}
     {{- if not (eq .Value.Constant nil) }}
+        {{- if not (eq $castPath.Value "") }}
+        {{- $castPath.Value | lowerCamelCase }}Resource
+        {{- else }}
         {{- formatScalar .Value.Constant }}
+        {{- end }}
     {{- end }}
     {{- with .Value.Argument }}
-        {{- $castPath := formatCastValue $.Assignment.Path }}
         {{- if not (eq $castPath.Value "") }}
             {{- $castPath.Value | lowerCamelCase }}Resource
         {{- else if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
@@ -65,6 +72,6 @@
 
 {{- define "assignment_method" }}
     {{ $path := formatAssignmentPath .Path }}
-    {{- if eq .Method "direct" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
-    {{- if eq .Method "append" }}this.internal.{{ $path }}.add({{ .Value }});{{ end -}}
+        {{- if eq .Method "direct" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "append" }}this.internal.{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/types/nilcheck.tmpl
+++ b/internal/jennies/java/templates/types/nilcheck.tmpl
@@ -1,5 +1,13 @@
 {{- define "nil_check" }}
+        {{- $castPath := formatCastValue .Path }}
+        {{- if $castPath.IsNilChecked }}
+        {{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{ $castPath.Class }}) this.internal.{{ $castPath.Path }};
+        if ({{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} == null) {
+            {{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} = {{ .EmptyValueType|emptyValueForType }};
+        }
+        {{- else }}
 		if (this.internal.{{ .Path|formatPath }} == null) {
 			this.internal.{{ .Path|formatPath }} = {{ .EmptyValueType|emptyValueForType }};
 		}
+		{{- end }}
 {{- end }}

--- a/internal/jennies/java/templates/types/nilcheck.tmpl
+++ b/internal/jennies/java/templates/types/nilcheck.tmpl
@@ -1,7 +1,7 @@
 {{- define "nil_check" }}
         {{- $castPath := shouldCastNilCheck .Path }}
         {{- if $castPath.IsNilChecked }}
-        {{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{ $castPath.Class }}) this.internal.{{ $castPath.Path }};
+        ({{ $castPath.Class }}) {{ $castPath.Value | lowerCamelCase }}Resource = ({{ $castPath.Class }}) this.internal.{{ $castPath.Path }};
         if ({{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} == null) {
             {{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} = {{ .EmptyValueType|emptyValueForType }};
         }

--- a/internal/jennies/java/templates/types/nilcheck.tmpl
+++ b/internal/jennies/java/templates/types/nilcheck.tmpl
@@ -1,5 +1,5 @@
 {{- define "nil_check" }}
-        {{- $castPath := formatCastValue .Path }}
+        {{- $castPath := shouldCastNilCheck .Path }}
         {{- if $castPath.IsNilChecked }}
         {{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{ $castPath.Class }}) this.internal.{{ $castPath.Path }};
         if ({{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} == null) {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"text/template"
-
+	
 	"github.com/grafana/cog/internal/ast"
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
 )
@@ -23,7 +23,7 @@ func init() {
 		Option("missingkey=error").
 		Funcs(cogtemplate.Helpers(base)).
 		Funcs(functions())
-
+	
 	templates = template.Must(cogtemplate.FindAndParseTemplates(templatesFS, base, "templates"))
 }
 
@@ -37,6 +37,9 @@ func functions() template.FuncMap {
 		},
 		"formatCastValue": func(_ ast.Type) string {
 			panic("formatCastValue() needs to be overridden by a jenny")
+		},
+		"shouldCastNilCheck": func(_ ast.Type) string {
+			panic("shouldCastNilCheck() needs to be overridden by a jenny")
 		},
 		"formatPath": func(_ ast.Type) string {
 			panic("formatPath() needs to be overridden by a jenny")
@@ -81,11 +84,11 @@ type ClassTemplate struct {
 	Name     string
 	Extends  []string
 	Comments []string
-
+	
 	Fields     []Field
 	Builder    cogtemplate.Builder
 	HasBuilder bool
-
+	
 	Variant              string
 	ShouldAddMarshalling bool
 }

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -29,14 +29,17 @@ func init() {
 
 func functions() template.FuncMap {
 	return template.FuncMap{
-		"escapeVar":    escapeVarName,
-		"formatScalar": formatScalar,
-		"formatPath":   formatFieldPath,
+		"escapeVar":          escapeVarName,
+		"formatScalar":       formatScalar,
+		"lastPathIdentifier": lastPathIdentifier,
 		"lastItem": func(index int, values []EnumValue) bool {
 			return len(values)-1 == index
 		},
 		"formatCastValue": func(_ ast.Type) string {
 			panic("formatCastValue() needs to be overridden by a jenny")
+		},
+		"formatPath": func(_ ast.Type) string {
+			panic("formatPath() needs to be overridden by a jenny")
 		},
 		"formatAssignmentPath": func(_ ast.Type) string {
 			panic("formatAssignmentPath() needs to be overridden by a jenny")

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"text/template"
-	
+
 	"github.com/grafana/cog/internal/ast"
 	cogtemplate "github.com/grafana/cog/internal/jennies/template"
 )
@@ -23,7 +23,7 @@ func init() {
 		Option("missingkey=error").
 		Funcs(cogtemplate.Helpers(base)).
 		Funcs(functions())
-	
+
 	templates = template.Must(cogtemplate.FindAndParseTemplates(templatesFS, base, "templates"))
 }
 
@@ -84,11 +84,11 @@ type ClassTemplate struct {
 	Name     string
 	Extends  []string
 	Comments []string
-	
+
 	Fields     []Field
 	Builder    cogtemplate.Builder
 	HasBuilder bool
-	
+
 	Variant              string
 	ShouldAddMarshalling bool
 }

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -6,20 +6,12 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/tools"
 )
 
 func formatPackageName(pkg string) string {
 	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
 
 	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
-}
-
-func formatFieldPath(fieldPath ast.Path) string {
-	parts := tools.Map(fieldPath, func(fieldPath ast.PathItem) string {
-		return tools.LowerCamelCase(fieldPath.Identifier)
-	})
-	return strings.Join(parts, ".")
 }
 
 func formatScalar(val any) any {
@@ -37,6 +29,20 @@ func escapeVarName(varName string) string {
 	}
 
 	return varName
+}
+
+func lastPathIdentifier(fieldPath ast.Path) string {
+	lastPath := make([]string, 0)
+	shouldAddPath := false
+	for _, path := range fieldPath {
+		if shouldAddPath {
+			lastPath = append(lastPath, path.Identifier)
+		}
+		if path.Type.IsAny() {
+			shouldAddPath = true
+		}
+	}
+	return strings.Join(lastPath, ".")
 }
 
 // nolint: gocyclo

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -3,7 +3,7 @@ package java
 import (
 	"fmt"
 	"strings"
-	
+
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -40,7 +40,7 @@ func (tf *typeFormatter) formatFieldType(def ast.Type) string {
 		// TODO: Manage anonymous structs
 		return "Object"
 	}
-	
+
 	return "unknown"
 }
 
@@ -58,7 +58,7 @@ func (tf *typeFormatter) formatBuilderFieldType(def ast.Type) string {
 	if tf.resolvesToComposableSlot(def) || tf.typeHasBuilder(def) {
 		value = fmt.Sprintf("%s.Builder<%s>", tf.formatPackage("cog"), value)
 	}
-	
+
 	return value
 }
 
@@ -97,7 +97,7 @@ func (tf *typeFormatter) formatMap(def ast.MapType) string {
 	case ast.KindArray:
 		mapType = tf.formatArray(def.ValueType.AsArray())
 	}
-	
+
 	return fmt.Sprintf("Map<String, %s>", mapType)
 }
 
@@ -109,7 +109,7 @@ func (tf *typeFormatter) formatComposable(def ast.ComposableSlotType) string {
 
 func formatScalarType(def ast.ScalarType) string {
 	scalarType := "unknown"
-	
+
 	switch def.ScalarKind {
 	case ast.KindString:
 		scalarType = "String"
@@ -130,7 +130,7 @@ func formatScalarType(def ast.ScalarType) string {
 	case ast.KindAny:
 		scalarType = "Object"
 	}
-	
+
 	return scalarType
 }
 
@@ -158,15 +158,15 @@ func (tf *typeFormatter) defaultValueFor(def ast.Type) string {
 func (tf *typeFormatter) formatScalar(v any) string {
 	if list, ok := v.([]any); ok {
 		items := make([]string, 0, len(list))
-		
+
 		for _, item := range list {
 			items = append(items, tf.formatScalar(item))
 		}
-		
+
 		// FIXME: this is wrong, we can't just assume a list of strings.
 		return strings.Join(items, ", ")
 	}
-	
+
 	return fmt.Sprintf("%#v", v)
 }
 
@@ -188,20 +188,20 @@ func (tf *typeFormatter) formatCastValue(fieldPath ast.Path) CastPath {
 			refType = path.TypeHint.AsRef().ReferredType
 		}
 	}
-	
+
 	if refType == "" {
 		return CastPath{}
 	}
-	
+
 	castedPath := fieldPath[0].Identifier
 	isNilChecked := false
 	genericFound := false
-	
+
 	for i, p := range fieldPath {
 		if i > 0 && fieldPath[i-1].Type.IsAny() && i != len(fieldPath)-1 {
 			isNilChecked = true
 		}
-		
+
 		if !genericFound {
 			if i > 0 {
 				castedPath = fmt.Sprintf("%s.%s", castedPath, tools.LowerCamelCase(p.Identifier))
@@ -209,7 +209,7 @@ func (tf *typeFormatter) formatCastValue(fieldPath ast.Path) CastPath {
 			genericFound = p.Type.IsAny()
 		}
 	}
-	
+
 	return CastPath{
 		Class:        fmt.Sprintf("%s.%s", tf.formatPackage(refPkg), refType),
 		Value:        refType,
@@ -227,21 +227,21 @@ func (tf *typeFormatter) shouldCastNilCheck(fieldPath ast.Path) CastPath {
 			refType = path.Type.AsRef().ReferredType
 		}
 	}
-	
+
 	if refType == "" {
 		return CastPath{}
 	}
-	
+
 	castedPath := fieldPath[0].Identifier
 	isNilChecked := false
 	genericFound := false
-	
+
 	for i, p := range fieldPath {
 		if i > 0 && p.Type.IsRef() && !fieldPath[i-1].Type.IsRef() {
 			refType = fieldPath[i-1].Identifier
 			isNilChecked = true
 		}
-		
+
 		if !genericFound {
 			if i > 0 {
 				castedPath = fmt.Sprintf("%s.%s", castedPath, tools.LowerCamelCase(p.Identifier))
@@ -249,28 +249,28 @@ func (tf *typeFormatter) shouldCastNilCheck(fieldPath ast.Path) CastPath {
 			genericFound = p.Type.IsAny()
 		}
 	}
-	
+
 	return CastPath{
-		Class:        fmt.Sprintf("%s.%s", tf.formatPackage(refPkg), refType),
+		Class:        fmt.Sprintf("%s.%s", tf.formatPackage(refPkg), tools.UpperCamelCase(refType)),
 		Value:        refType,
 		Path:         castedPath,
 		IsNilChecked: isNilChecked,
 	}
-	
+
 }
 
 func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
 	parts := make([]string, 0)
 	for i, part := range fieldPath {
 		output := tools.LowerCamelCase(part.Identifier)
-		
+
 		if i > 0 && fieldPath[i-1].Type.IsAny() {
 			return output
 		}
-		
+
 		parts = append(parts, output)
 	}
-	
+
 	return strings.Join(parts, ".")
 }
 
@@ -278,22 +278,22 @@ func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
 // we should return until this pad to set the object to it.
 func (tf *typeFormatter) formatAssignmentPath(fieldPath ast.Path) string {
 	path := escapeVarName(tools.LowerCamelCase(fieldPath[0].Identifier))
-	
+
 	if len(fieldPath[1:]) == 1 && fieldPath[0].TypeHint != nil && fieldPath[0].TypeHint.Kind == ast.KindRef {
 		return path
 	}
-	
+
 	for i, p := range fieldPath[1:] {
 		if fieldPath[i].Type.IsAny() && i != len(fieldPath)-1 {
 			return path
 		}
-		
+
 		path = fmt.Sprintf("%s.%s", path, tools.LowerCamelCase(p.Identifier))
 		if p.TypeHint != nil {
 			return path
 		}
 	}
-	
+
 	return path
 }
 
@@ -301,6 +301,6 @@ func (tf *typeFormatter) formatPackage(pkg string) string {
 	if tf.config.PackagePath != "" {
 		return fmt.Sprintf("%s.%s", tf.config.PackagePath, pkg)
 	}
-	
+
 	return pkg
 }


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/395

The PR could be a bit annoying. When we modify a builder using a veneer, in Java, we need to cast some values in the `nil_check` step. At the same time, if we need to add this cast here, we should skip the casting in the assignment step.

I tried to reuse `formatCastValue` function but it doesn't work because for `nil checks`, the Object is detected as a `ref`, while in the assignment is detected as an `any`. Its why I created `shouldCastNilCheck`, that it's similar but only used for the nil checks.

Also I found that some paths aren't well set, since it was setting the whole path for the casting/nil checks. So the change return's the latest path until it reaches a generic to avoid to set an invalid value.