### PR TITLE
Java: Use schema object name to create the map of builders

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -25,8 +25,7 @@ func parseBuilders(config Config, context languages.Context, formatter *typeForm
 			b[builder.Package] = map[string]ast.Builder{}
 		}
 
-		obj, _ := context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
-		b[builder.Package][obj.Name] = builder
+		b[builder.Package][builder.For.SelfRef.ReferredType] = builder
 		panels[builder.Package] = builder.Name == "Panel" && builder.Package != "dashboard" // TODO: Ugh! Maybe a compiler pass??
 	}
 

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -24,7 +24,9 @@ func parseBuilders(config Config, context languages.Context, formatter *typeForm
 		if _, ok := b[builder.Package]; !ok {
 			b[builder.Package] = map[string]ast.Builder{}
 		}
-		b[builder.Package][builder.Name] = builder
+
+		obj, _ := context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
+		b[builder.Package][obj.Name] = builder
 		panels[builder.Package] = builder.Name == "Panel" && builder.Package != "dashboard" // TODO: Ugh! Maybe a compiler pass??
 	}
 

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -6,4 +6,24 @@ import java.util.List;
 public class Dashboard {
     public Dataquery target;
     public List<Dataquery> targets;
+    
+    public static class Builder {
+        private Dashboard internal;
+        
+        public Builder() {
+            this.internal = new Dashboard();
+        }
+    public Builder setTarget(cog.Builder<Dataquery> target) {
+    this.internal.target = target.build();
+        return this;
+    }
+    
+    public Builder setTargets(cog.Builder<List<Dataquery>> targets) {
+    this.internal.targets = targets.build();
+        return this;
+    }
+    public Dashboard build() {
+            return this.internal;
+        }
+    }
 }

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -3,4 +3,19 @@ package dataquery_variant_builder;
 
 public class Loki implements cog.variants.Dataquery {
     public String expr;
+    
+    public static class Builder {
+        private Loki internal;
+        
+        public Builder() {
+            this.internal = new Loki();
+        }
+    public Builder setExpr(String expr) {
+    this.internal.expr = expr;
+        return this;
+    }
+    public Loki build() {
+            return this.internal;
+        }
+    }
 }

--- a/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
@@ -4,15 +4,15 @@ import (
 	cog "github.com/grafana/cog/generated/cog"
 )
 
-var _ cog.Builder[Options] = (*PanelBuilder)(nil)
+var _ cog.Builder[Panel] = (*PanelBuilder)(nil)
 
 type PanelBuilder struct {
-    internal *Options
+    internal *Panel
     errors map[string]cog.BuildErrors
 }
 
 func NewPanelBuilder() *PanelBuilder {
-	resource := &Options{}
+	resource := &Panel{}
 	builder := &PanelBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
@@ -23,7 +23,7 @@ func NewPanelBuilder() *PanelBuilder {
 	return builder
 }
 
-func (builder *PanelBuilder) Build() (Options, error) {
+func (builder *PanelBuilder) Build() (Panel, error) {
 	var errs cog.BuildErrors
 
 	for _, err := range builder.errors {
@@ -31,7 +31,7 @@ func (builder *PanelBuilder) Build() (Options, error) {
 	}
 
 	if len(errs) != 0 {
-		return Options{}, errs
+		return Panel{}, errs
 	}
 
 	return *builder.internal, nil

--- a/testdata/jennies/builders/panel_builders/PythonBuilder/builders/panelbuilder.py
+++ b/testdata/jennies/builders/panel_builders/PythonBuilder/builders/panelbuilder.py
@@ -3,13 +3,13 @@ from ..cog import builder as cogbuilder
 from ..models import panelbuilder
 
 
-class Panel(cogbuilder.Builder[panelbuilder.Options]):    
-    _internal: panelbuilder.Options
+class Panel(cogbuilder.Builder[panelbuilder.Panel]):    
+    _internal: panelbuilder.Panel
 
     def __init__(self):
-        self._internal = panelbuilder.Options()
+        self._internal = panelbuilder.Panel()
 
-    def build(self) -> panelbuilder.Options:
+    def build(self) -> panelbuilder.Panel:
         return self._internal    
     
     def only_from_this_dashboard(self, only_from_this_dashboard: bool) -> typing.Self:        

--- a/testdata/jennies/builders/panel_builders/TypescriptBuilder/src/panelbuilder/panelBuilder.gen.ts
+++ b/testdata/jennies/builders/panel_builders/TypescriptBuilder/src/panelbuilder/panelBuilder.gen.ts
@@ -1,14 +1,14 @@
 import * as cog from '../cog';
 import * as panelbuilder from '../panelbuilder';
 
-export class PanelBuilder implements cog.Builder<panelbuilder.Options> {
-    protected readonly internal: panelbuilder.Options;
+export class PanelBuilder implements cog.Builder<panelbuilder.Panel> {
+    protected readonly internal: panelbuilder.Panel;
 
     constructor() {
-        this.internal = panelbuilder.defaultOptions();
+        this.internal = panelbuilder.defaultPanel();
     }
 
-    build(): panelbuilder.Options {
+    build(): panelbuilder.Panel {
         return this.internal;
     }
 

--- a/testdata/jennies/builders/panel_builders/builders_context.json
+++ b/testdata/jennies/builders/panel_builders/builders_context.json
@@ -8,7 +8,7 @@
         "Identifier": "annolist"
       },
       "Objects": {
-        "Options": {
+        "Panel": {
           "Name": "Options",
           "Type": {
             "Kind": "struct",
@@ -144,8 +144,8 @@
             }
           },
           "SelfRef": {
-            "ReferredPkg": "annotationslist",
-            "ReferredType": "Options"
+            "ReferredPkg": "panelbuilder",
+            "ReferredType": "Panel"
           }
         }
       }
@@ -154,7 +154,7 @@
   "Builders": [
     {
       "For": {
-        "Name": "Options",
+        "Name": "Panel",
         "Type": {
           "Kind": "struct",
           "Nullable": false,
@@ -290,7 +290,7 @@
         },
         "SelfRef": {
           "ReferredPkg": "panelbuilder",
-          "ReferredType": "Options"
+          "ReferredType": "Panel"
         }
       },
       "Package": "panelbuilder",


### PR DESCRIPTION
In Java we have a map of builders used to decide if we should add the builder or not inside the class (common way to do in Java).

The problem is we were iterating the builder structure only and the names of the Builders differs from the one in Schema and it was impossible to find them.