### PR TITLE
Java: Allow to skip builders generation

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -18,6 +18,12 @@ type Builders struct {
 }
 
 func parseBuilders(config Config, context languages.Context, formatter *typeFormatter) Builders {
+	if !config.generateBuilders || config.SkipRuntime {
+		return Builders{
+			builders: make(map[string]map[string]ast.Builder),
+			isPanel:  make(map[string]bool),
+		}
+	}
 	b := make(map[string]map[string]ast.Builder)
 	panels := make(map[string]bool)
 	for _, builder := range context.Builders {

--- a/internal/jennies/java/builders_test.go
+++ b/internal/jennies/java/builders_test.go
@@ -17,8 +17,10 @@ func TestBuidlers_Generate(t *testing.T) {
 		},
 	}
 
-	language := New(Config{})
-	jenny := RawTypes{}
+	language := New(Config{
+		generateBuilders: true,
+	})
+	jenny := RawTypes{config: language.config}
 
 	test.Run(t, func(tc *testutils.Test[languages.Context]) {
 		var err error


### PR DESCRIPTION
It allows to skip builder's generation following the same rules than other languages.