### PR TITLE
Support custom object naming strategies in cue parser

### DIFF
--- a/internal/codegen/cue.go
+++ b/internal/codegen/cue.go
@@ -49,6 +49,8 @@ type CueInput struct {
 	// CueImports allows importing additional libraries.
 	// Format: [path]:[import]. Example: '../grafana/common-library:github.com/grafana/grafana/packages/grafana-schema/src/common
 	CueImports []string `yaml:"cue_imports"`
+
+	NameFunc simplecue.NameFunc `yaml:"-"`
 }
 
 func (input *CueInput) packageName() string {
@@ -99,6 +101,7 @@ func cueLoader(input CueInput) (ast.Schemas, error) {
 		ForceNamedEnvelope: input.ForcedEnvelope,
 		SchemaMetadata:     input.schemaMetadata(),
 		Libraries:          libraries,
+		NameFunc:           input.NameFunc,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -42,6 +42,8 @@ func ParseImports(cueImports []string) ([]LibraryInclude, error) {
 	return imports, nil
 }
 
+type NameFunc func(value cue.Value, path cue.Path) string
+
 type Config struct {
 	// Package name used to generate code into.
 	Package string
@@ -54,12 +56,19 @@ type Config struct {
 	SchemaMetadata ast.SchemaMeta
 
 	Libraries []LibraryInclude
+
+	// NameFunc allows users to specify an alternative naming strategy for
+	// objects and references. It is called with the value passed to the top
+	// level method or function and the path to the entity being parsed.
+	NameFunc NameFunc
 }
 
 type generator struct {
 	schema      *ast.Schema
 	refResolver *referenceResolver
+	rootVal     cue.Value
 	rootPath    cue.Path
+	namingFunc  NameFunc
 }
 
 func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
@@ -68,7 +77,16 @@ func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
 		refResolver: newReferenceResolver(val, referenceResolverConfig{
 			Libraries: c.Libraries,
 		}),
-		rootPath: val.Path(),
+		rootVal:    val,
+		rootPath:   val.Path(),
+		namingFunc: c.NameFunc,
+	}
+
+	if g.namingFunc == nil {
+		g.namingFunc = func(value cue.Value, path cue.Path) string {
+			selectors := path.Selectors()
+			return selectorLabel(selectors[len(selectors)-1])
+		}
 	}
 
 	if c.ForceNamedEnvelope != "" {
@@ -92,10 +110,8 @@ func (g *generator) walkCueSchemaWithEnvelope(envelopeName string, v cue.Value) 
 
 	var rootObjectFields []ast.StructField
 	for i.Next() {
-		sel := i.Selector()
-		name := selectorLabel(sel)
-
 		if i.Selector().IsDefinition() {
+			name := g.namingFunc(g.rootVal, i.Value().Path())
 			n, err := g.declareObject(name, i.Value())
 			if err != nil {
 				return err
@@ -110,6 +126,7 @@ func (g *generator) walkCueSchemaWithEnvelope(envelopeName string, v cue.Value) 
 			return err
 		}
 
+		name := selectorLabel(i.Selector())
 		structField := ast.NewStructField(name, nodeType, ast.Comments(commentsFromCueValue(i.Value())))
 		structField.Required = !i.IsOptional()
 
@@ -147,9 +164,9 @@ func (g *generator) walkCueSchema(v cue.Value) error {
 	}
 
 	for i.Next() {
-		sel := i.Selector()
+		name := g.namingFunc(g.rootVal, i.Value().Path())
 
-		n, err := g.declareObject(selectorLabel(sel), i.Value())
+		n, err := g.declareObject(name, i.Value())
 		if err != nil {
 			return err
 		}
@@ -422,8 +439,7 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 	// }
 	// ```
 	if areCuePathsFromSameRoot(g.rootPath, path) && !cuePathIsChildOf(g.rootPath, path) {
-		selectors := path.Selectors()
-		refType := selectorLabel(selectors[len(selectors)-1])
+		refType := g.namingFunc(g.rootVal, path)
 		if !g.schema.Objects.Has(refType) {
 			obj, err := g.declareObject(refType, referenceRootValue.LookupPath(path))
 			if err != nil {
@@ -442,7 +458,6 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 	}
 
 	if path.String() != "" {
-		selectors := path.Selectors()
 		refPkg, err := g.refResolver.PackageForNode(v.Source(), g.schema.Package)
 		if err != nil {
 			return ast.Type{}, errorWithCueRef(v, err.Error())
@@ -453,7 +468,7 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 			return ast.Type{}, err
 		}
 
-		refType := selectorLabel(selectors[len(selectors)-1])
+		refType := g.namingFunc(g.rootVal, path)
 
 		if refPkg == "time" && refType == "Time" {
 			return ast.String(ast.Default(defValue), ast.Hints(ast.JenniesHints{


### PR DESCRIPTION
Contributes to #408

This PR allows the object naming strategy used in our CUE parser to be configured. This ability is needed for `grafana-app-sdk`: https://github.com/grafana/grafana-app-sdk/blob/9481a3eaa83c509c6a35cc0f71bd201955cbfa8e/codegen/jennies/gotypes.go#L182-L196