### PR TITLE
Java: Fix reference defaults

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -91,6 +91,9 @@ func (b Builders) genDefaults(options []ast.Option) []OptionCall {
 	return calls
 }
 
+// formatInitializers initialises objects with their defaults before set the value in the corresponding setter.
+// TODO: It could have conflicts if we have different fields with the same kind of argument.
+// TODO: It means that we need to initialize the objects with different names in that case.
 func (b Builders) formatInitializers(args []ast.Argument) []string {
 	initializers := make([]string, 0)
 	for _, arg := range args {

--- a/internal/jennies/java/pom.go
+++ b/internal/jennies/java/pom.go
@@ -30,7 +30,7 @@ func (jenny Pom) generatePom() string {
 	<groupId>com.grafana.foundation</groupId>
 	<artifactId>sdk</artifactId>
 	<version>%s</version>
-	<packaging>pom</packaging>
+	<packaging>jar</packaging>
 
 	<name>Grafana foundation SDK</name>
 	<description>Grafana Java library</description>

--- a/internal/jennies/java/pom.go
+++ b/internal/jennies/java/pom.go
@@ -30,7 +30,7 @@ func (jenny Pom) generatePom() string {
 	<groupId>com.grafana.foundation</groupId>
 	<artifactId>sdk</artifactId>
 	<version>%s</version>
-	<packaging>jar</packaging>
+	<packaging>pom</packaging>
 
 	<name>Grafana foundation SDK</name>
 	<description>Grafana Java library</description>

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -13,6 +13,9 @@
         {{- end }}
         
         {{- range .Defaults }}
+        {{- range .Initializers }}
+        {{ . }}
+        {{- end }}
         this.set{{ .OptionName }}({{ .Args|join ", " }});
         {{- end }}
         }

--- a/internal/jennies/java/templates/types/panel_builder.tmpl
+++ b/internal/jennies/java/templates/types/panel_builder.tmpl
@@ -17,6 +17,9 @@ public class PanelBuilder {
         {{- end }}
         
         {{- range .Defaults }}
+        {{- range .Initializers }}
+        {{ . }}
+        {{- end }}
         this.set{{ .OptionName }}({{ .Args|join ", " }});
         {{- end }}
     }

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -86,7 +86,7 @@ type ClassTemplate struct {
 	Comments []string
 
 	Fields     []Field
-	Builder    cogtemplate.Builder
+	Builder    Builder
 	HasBuilder bool
 
 	Variant              string
@@ -109,4 +109,24 @@ type Constant struct {
 	Name  string
 	Type  string
 	Value any
+}
+
+type Builder struct {
+	Package              string
+	BuilderSignatureType string
+	BuilderName          string
+	ObjectName           string
+	Imports              fmt.Stringer
+	ImportAlias          string // alias to the pkg in which the object being built lives.
+	Comments             []string
+	Constructor          ast.Constructor
+	Properties           []ast.StructField
+	Options              []ast.Option
+	Defaults             []OptionCall
+}
+
+type OptionCall struct {
+	Initializers []string
+	OptionName   string
+	Args         []string
 }

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -22,6 +22,33 @@ func formatScalar(val any) any {
 	return newVal
 }
 
+func formatType(t ast.ScalarKind, val any) string {
+	// When the default is 0, is detected as integer even if it's a float.
+	parseFloatVal := func(val any) any {
+		if v, ok := val.(int64); ok {
+			val = float64(v)
+		} else {
+			val = val.(float64)
+		}
+		return val
+	}
+
+	switch t {
+	case ast.KindInt64:
+		return fmt.Sprintf("%dL", val.(int64))
+	case ast.KindUint64:
+		return fmt.Sprintf("%dL", val.(int64))
+	case ast.KindInt32:
+		return fmt.Sprintf("%d", val.(int64))
+	case ast.KindFloat32:
+		return fmt.Sprintf("%.1ff", parseFloatVal(val))
+	case ast.KindFloat64:
+		return fmt.Sprintf("%.1f", parseFloatVal(val))
+	}
+
+	return fmt.Sprintf("%#v", val)
+}
+
 // TODO: Need to say to the serializer the correct name.
 func escapeVarName(varName string) string {
 	if isReservedJavaKeyword(varName) {

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -26,20 +26,18 @@ func formatType(t ast.ScalarKind, val any) string {
 	// When the default is 0, is detected as integer even if it's a float.
 	parseFloatVal := func(val any) any {
 		if v, ok := val.(int64); ok {
-			val = float64(v)
-		} else {
-			val = val.(float64)
+			return float64(v)
 		}
-		return val
+		return val.(float64)
 	}
 
 	// Integers could be floats in JSON
 	parseIntVal := func(val any) any {
 		if v, ok := val.(float64); ok {
 			return int64(v)
-		} else {
-			return val.(int64)
 		}
+
+		return val.(int64)
 	}
 
 	switch t {

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -33,13 +33,22 @@ func formatType(t ast.ScalarKind, val any) string {
 		return val
 	}
 
+	// Integers could be floats in JSON
+	parseIntVal := func(val any) any {
+		if v, ok := val.(float64); ok {
+			return int64(v)
+		} else {
+			return val.(int64)
+		}
+	}
+
 	switch t {
 	case ast.KindInt64:
-		return fmt.Sprintf("%dL", val.(int64))
+		return fmt.Sprintf("%dL", parseIntVal(val))
 	case ast.KindUint64:
-		return fmt.Sprintf("%dL", val.(int64))
+		return fmt.Sprintf("%dL", parseIntVal(val))
 	case ast.KindInt32:
-		return fmt.Sprintf("%d", val.(int64))
+		return fmt.Sprintf("%d", parseIntVal(val))
 	case ast.KindFloat32:
 		return fmt.Sprintf("%.1ff", parseFloatVal(val))
 	case ast.KindFloat64:

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -179,6 +179,12 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 				constraints = field.Type.AsScalar().Constraints
 			}
 
+			// It sets the default to the args to simplify the process to extract the values in each language
+			// since defaults don't have enough information to detect a reference.
+			if def, ok := defaults[field.Name]; ok {
+				field.Type.Default = def
+			}
+
 			newArg := ast.Argument{
 				Name: field.Name,
 				Type: field.Type,

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -13,7 +13,7 @@ public class SomeStruct {
         
         public Builder() {
             this.internal = new SomeStruct();
-        this.setId(42);
+        this.setId(42L);
         this.setUid("default-uid");
         this.setTags(List.of("generated", "cog"));
         this.setLiveNow(true);

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
@@ -13,8 +13,13 @@ public class Struct {
         
         public Builder() {
             this.internal = new Struct();
-        this.setAllFields(new NestedStruct.Builder().setStringVal("hello").setIntVal(3).build());
-        this.setPartialFields(new NestedStruct.Builder().setIntVal(4).build());
+        NestedStruct.Builder nestedStructResource = new NestedStruct.Builder();
+        nestedStructResource.setStringVal("hello");
+        nestedStructResource.setIntVal(3L);
+        this.setAllFields(nestedStructResource);
+        NestedStruct.Builder nestedStructResource = new NestedStruct.Builder();
+        nestedStructResource.setIntVal(4L);
+        this.setPartialFields(nestedStructResource);
         this.setComplexField(new Object());
         this.setPartialComplexField(new Object());
         }


### PR DESCRIPTION
Unlike the other languages, we cannot initialise a builder/object with values directly in the setter of the function.
For that, it adds an initialiser array to create the object or builder for that default and set the result into the setter.

There is a lot of issues with the defaults between floats and integers. Sometimes an integer could be a float or vice versa, and its why there are some comments related to this.

Finally I found an issue where we can have setters with the same argument and defaults could have a conflict generating the same object/builder names. You can see in [one](https://github.com/grafana/cog/compare/java/fix-defaults?expand=1#diff-d24b024fa03915ad74ad425eb05b6c6d00d03bf1306b2ee7b0da71092a2ecf75R16) of the tests. There is a `TODO` comment for this.