### PR TITLE
Add InlineScalarAliases compiler pass

### DIFF
--- a/internal/ast/compiler/inline_scalar_aliases.go
+++ b/internal/ast/compiler/inline_scalar_aliases.go
@@ -1,0 +1,91 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
+)
+
+var _ Pass = (*InlineScalarAliases)(nil)
+
+// InlineScalarAliases inlines objects defined as an alias to a scalar type.
+// Inlined types are: ast.KindScalar, ast.KindArray and ast.KindMap.
+// This compiler pass is meant to be used to generate code in languages that
+// don't support type aliases on scalars.
+//
+// Note: constants are not impacted.
+//
+// Example:
+//
+//	```
+//	TimeZone string
+//	Details map[string, any]
+//	Targets []string
+//
+//	Foo struct {
+//	  TimezoneField TimeZone
+//	  DetailsField Details
+//	  TargetsField Targets
+//	}
+//	```
+//
+// Will become:
+//
+//	```
+//	Foo struct {
+//	  TimezoneField string
+//	  DetailsField map[string, any]
+//	  TargetsField []string
+//	}
+//	```
+type InlineScalarAliases struct {
+	objectsToInline *orderedmap.Map[string, ast.Type]
+}
+
+func (pass *InlineScalarAliases) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectsToInline = orderedmap.New[string, ast.Type]()
+
+	for _, schema := range schemas {
+		schema.Objects.Iterate(func(_ string, object ast.Object) {
+			if !object.Type.IsAnyOf(ast.KindScalar, ast.KindArray, ast.KindMap) {
+				return
+			}
+
+			// do not inline constants
+			if object.Type.IsConcreteScalar() {
+				return
+			}
+
+			pass.objectsToInline.Set(object.SelfRef.String(), object.Type)
+		})
+	}
+
+	visitor := &Visitor{
+		OnRef: pass.processRef,
+	}
+
+	newSchemas, err := visitor.VisitSchemas(schemas)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, schema := range newSchemas {
+		newSchemas[i].Objects = schema.Objects.Filter(func(_ string, object ast.Object) bool {
+			return !pass.objectsToInline.Has(object.SelfRef.String())
+		})
+	}
+
+	return newSchemas, nil
+}
+
+func (pass *InlineScalarAliases) processRef(_ *Visitor, _ *ast.Schema, def ast.Type) (ast.Type, error) {
+	if !pass.objectsToInline.Has(def.Ref.String()) {
+		return def, nil
+	}
+
+	typeDef := pass.objectsToInline.Get(def.Ref.String()).DeepCopy()
+	typeDef.AddToPassesTrail(fmt.Sprintf("InlineScalarAliases[original=%s]", def.Ref.String()))
+
+	return typeDef, nil
+}

--- a/internal/ast/compiler/inline_scalar_aliases_test.go
+++ b/internal/ast/compiler/inline_scalar_aliases_test.go
@@ -1,0 +1,42 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestInlineScalarAliases(t *testing.T) {
+	// Prepare test input
+	schema := &ast.Schema{
+		Package: "inline_scalar_aliases",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("inline_scalar_aliases", "AliasToString", ast.String()),
+			ast.NewObject("inline_scalar_aliases", "AliasToMap", ast.NewMap(ast.String(), ast.Any())),
+			ast.NewObject("inline_scalar_aliases", "AliasToArray", ast.NewArray(ast.String())),
+			ast.NewObject("inline_scalar_aliases", "Constant", ast.String(ast.Value("foo"))),
+			ast.NewObject("inline_scalar_aliases", "SomeObject", ast.NewStruct(
+				ast.NewStructField("aliasToString", ast.NewRef("inline_scalar_aliases", "AliasToString")),
+				ast.NewStructField("aliasToMap", ast.NewRef("inline_scalar_aliases", "AliasToMap")),
+				ast.NewStructField("aliasToArray", ast.NewRef("inline_scalar_aliases", "AliasToArray")),
+			)),
+		),
+	}
+	expected := &ast.Schema{
+		Package: "inline_scalar_aliases",
+		Objects: testutils.ObjectsMap(
+			ast.NewObject("inline_scalar_aliases", "Constant", ast.String(ast.Value("foo"))),
+			ast.NewObject("inline_scalar_aliases", "SomeObject", ast.NewStruct(
+				ast.NewStructField("aliasToString", ast.String(ast.Trail("InlineScalarAliases[original=inline_scalar_aliases.AliasToString]"))),
+				ast.NewStructField("aliasToMap", ast.NewMap(ast.String(), ast.Any(), ast.Trail("InlineScalarAliases[original=inline_scalar_aliases.AliasToMap]"))),
+				ast.NewStructField("aliasToArray", ast.NewArray(ast.String(), ast.Trail("InlineScalarAliases[original=inline_scalar_aliases.AliasToArray]"))),
+			)),
+		),
+	}
+
+	pass := &InlineScalarAliases{}
+
+	// Run the compiler pass
+	runPassOnSchema(t, pass, schema, expected)
+}

--- a/internal/ast/compiler/utils_test.go
+++ b/internal/ast/compiler/utils_test.go
@@ -1,9 +1,9 @@
 package compiler
 
 import (
+	"encoding/json"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/stretchr/testify/require"
 )
@@ -35,6 +35,11 @@ func runPassOnSchemas(t *testing.T, pass Pass, input ast.Schemas, expectedOutput
 	req.NoError(err)
 	req.Len(processedSchemas, len(input))
 	for i := range input {
-		req.Empty(cmp.Diff(expectedOutput[i], processedSchemas[i]))
+		expectedJSON, err := json.MarshalIndent(expectedOutput[i], "", "  ")
+		req.NoError(err)
+		gotJSON, err := json.MarshalIndent(processedSchemas[i], "", "  ")
+		req.NoError(err)
+
+		req.JSONEq(string(expectedJSON), string(gotJSON))
 	}
 }

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -37,8 +37,9 @@
           "type": "array",
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
-        "schema_metadata": {
-          "$ref": "#/$defs/SchemaMeta"
+        "metadata": {
+          "$ref": "#/$defs/SchemaMeta",
+          "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "entrypoint": {
           "type": "string",
@@ -106,8 +107,9 @@
           "type": "array",
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
-        "schema_metadata": {
-          "$ref": "#/$defs/SchemaMeta"
+        "metadata": {
+          "$ref": "#/$defs/SchemaMeta",
+          "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
           "type": "string",
@@ -120,10 +122,6 @@
         "package": {
           "type": "string",
           "description": "Package name to use for the input schema. If empty, it will be guessed\nfrom the input file name."
-        },
-        "metadata": {
-          "$ref": "#/$defs/SchemaMeta",
-          "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         }
       },
       "additionalProperties": false,
@@ -145,8 +143,9 @@
           "type": "array",
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
-        "schema_metadata": {
-          "$ref": "#/$defs/SchemaMeta"
+        "metadata": {
+          "$ref": "#/$defs/SchemaMeta",
+          "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
           "type": "string"
@@ -174,8 +173,9 @@
           "type": "array",
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
-        "schema_metadata": {
-          "$ref": "#/$defs/SchemaMeta"
+        "metadata": {
+          "$ref": "#/$defs/SchemaMeta",
+          "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
           "type": "string",


### PR DESCRIPTION
This compiler pass will make it easier to support languages that do not allow type aliases for scalar.

Example in TS:

```typescript
type UserID = string
```