### PR TITLE
Java: Missing VariableModel builders

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -31,7 +31,7 @@ func parseBuilders(config Config, context languages.Context, formatter *typeForm
 			b[builder.Package] = map[string]ast.Builder{}
 		}
 
-		// This is a big u
+		// This should be better 🤮
 		if builder.For.SelfRef.ReferredType == "VariableModel" || (builder.Name == "Panel" && builder.Package != "dashboard") {
 			if _, ok := externalBuilders[builder.Package]; !ok {
 				externalBuilders[builder.Package] = map[string]bool{}

--- a/internal/jennies/java/templates/types/external_builder.tmpl
+++ b/internal/jennies/java/templates/types/external_builder.tmpl
@@ -7,11 +7,11 @@ package {{ .Package }};
 {{- $panelBuilder }}
 
 {{- define "panelBuilder" }}
-public class PanelBuilder {
-    private Panel internal;
+public class {{ .BuilderName }}Builder {
+    private {{ .ObjectName }} internal;
 
-    public PanelBuilder({{- template "args" .Constructor.Args }}) {
-        this.internal = new Panel();
+    public {{ .BuilderName }}Builder({{- template "args" .Constructor.Args }}) {
+        this.internal = new {{ .ObjectName }}();
         {{- range .Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
         {{- end }}
@@ -22,7 +22,7 @@ public class PanelBuilder {
     }
     
     {{- range .Options }}
-    public PanelBuilder set{{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
+    public {{ $.BuilderName }}Builder set{{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" "PanelBuilder" "OptionName" "Panel") }}
         {{- end }}
@@ -30,7 +30,7 @@ public class PanelBuilder {
     }
     {{- end }}
     
-    public Panel build() {
+    public {{ .ObjectName }} build() {
         return this.internal;
     }
 }

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
@@ -1,13 +1,12 @@
 package panelbuilder;
 
 import java.util.List;
-import dashboard.Panel;
 
 public class PanelBuilder {
-    private Panel internal;
+    private Options internal;
 
     public PanelBuilder() {
-        this.internal = new Panel();
+        this.internal = new Options();
         this.setOnlyFromThisDashboard(false);
         this.setOnlyInTimeRange(false);
         this.setLimit(10);
@@ -59,7 +58,7 @@ public class PanelBuilder {
         return this;
     }
     
-    public Panel build() {
+    public Options build() {
         return this.internal;
     }
 }


### PR DESCRIPTION
`VariableModel` contains several implementations that are only exists in builders but there isn't a schema for any of them.

Because the builders are inside the schemas in Java, we cannot find this relationship, so, in those cases, we need to create the builder independent from the Schema.

The builders are the same than `PanelBuilder` so it refactor this part of the code to use the same in any builder that has this problem.