### PR TITLE
Java: Fix veneers templates

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -51,15 +51,11 @@ func (b Builders) genBuilders(pkg string, name string) ([]template.Builder, bool
 	}
 
 	return tools.Map(builders, func(builder ast.Builder) template.Builder {
-		builderName := ""
-		if len(builders) > 1 {
-			builderName = builder.Name
-		}
 		object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
 		return template.Builder{
 			Package:     b.typeFormatter.formatPackage(pkg),
 			ObjectName:  tools.UpperCamelCase(object.Name),
-			BuilderName: builderName,
+			BuilderName: builder.Name,
 			Constructor: builder.Constructor,
 			Options:     builder.Options,
 			Properties:  builder.Properties,

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -1,32 +1,32 @@
 {{- define "builder" }}
     public static class {{ .BuilderName }}Builder {
-        private {{ .ObjectName }} internal;
+        private {{ .Builder.ObjectName }} internal;
         
-        {{- range .Properties }}
+        {{- range .Builder.Properties }}
         private {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
         {{- end }}
         
-        public {{ .BuilderName }}Builder({{- template "args" .Constructor.Args }}) {
-            this.internal = new {{ .ObjectName }}();
-        {{- range .Constructor.Assignments }}
+        public {{ .BuilderName }}Builder({{- template "args" .Builder.Constructor.Args }}) {
+            this.internal = new {{ .Builder.ObjectName }}();
+        {{- range .Builder.Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
         {{- end }}
         
-        {{- range .Defaults }}
+        {{- range .Builder.Defaults }}
         this.set{{ .OptionName }}({{ .Args|join ", " }});
         {{- end }}
         }
         
-    {{- range $opt := .Options }}
+    {{- range $opt := .Builder.Options }}
     public {{ $.BuilderName }}Builder set{{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
         {{- range .Assignments }}
-            {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" $opt.Name) }}
+            {{- template "assignment" (dict "Assignment" . "BuilderName" $.Builder.BuilderName "OptionName" $opt.Name) }}
         {{- end }}
         return this;
     }
     {{ end -}}
         
-        public {{ .ObjectName }} build() {
+        public {{ .Builder.ObjectName }} build() {
             return this.internal;
         }
     }

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -21,7 +21,8 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
 
     {{- if and .HasBuilder (not .Extends) }}
         {{- range .Builders }}
-        {{ template "builder" . }}
+        {{- $builderName := gt (len $.Builders) 1 | ternary .BuilderName  "" }}
+        {{ template "builder" (dict "Builder" . "BuilderName" $builderName) }}
         {{- end }}
     {{- end }}
 }


### PR DESCRIPTION
The current behaviour to set the builder name in the builders where they have multiple ones, breaks the template venners. We are removing the builderName to avoid to set it when we only have one builder, but it makes impossible to find the veneer template because of that. You can see [here](https://github.com/grafana/cog/blob/main/internal/jennies/java/templates/types/assigments.tmpl#L11-L12) and [here](https://github.com/grafana/cog/blob/main/internal/jennies/java/templates/types/assigments.tmpl#L16-L17).

So the PR is adding the first approach that we did pairing.