### PR TITLE
Disambiguate name conflicts in config schemas

### DIFF
--- a/cmd/cog-config-schemas/main.go
+++ b/cmd/cog-config-schemas/main.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/cog/internal/codegen"
+	"github.com/grafana/cog/internal/tools"
 	"github.com/grafana/cog/internal/yaml"
 	"github.com/invopop/jsonschema"
 )
@@ -21,20 +23,30 @@ func main() {
 		{name: "pipeline", input: &codegen.Pipeline{}},
 	}
 
+	reflector := &jsonschema.Reflector{
+		RequiredFromJSONSchemaTags: true, // we don't have good information as to what is required :/
+		FieldNameTag:               "yaml",
+		KeyNamer: func(key string) string {
+			if strings.ToUpper(string(key[0])) == string(key[0]) {
+				return strings.ToLower(key)
+			}
+
+			return key
+		},
+		Namer: func(reflected reflect.Type) string {
+			name := reflected.Name()
+
+			if reflected.PkgPath() != "" {
+				parts := strings.Split(reflected.PkgPath(), "/")
+				name = tools.UpperCamelCase(parts[len(parts)-1]) + tools.UpperCamelCase(name)
+			}
+
+			return name
+		},
+	}
+
 	for _, t := range types {
 		fmt.Printf("Generating schema for type '%s'\n", t.name)
-
-		reflector := &jsonschema.Reflector{
-			RequiredFromJSONSchemaTags: true, // we don't have good information as to what is required :/
-			FieldNameTag:               "yaml",
-			KeyNamer: func(key string) string {
-				if strings.ToUpper(string(key[0])) == string(key[0]) {
-					return strings.ToLower(key)
-				}
-
-				return key
-			},
-		}
 
 		if err := reflector.AddGoComments("github.com/grafana/cog", "./"); err != nil {
 			panic(fmt.Errorf("could not add Go comments to reflector: %w", err))

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -1,131 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json",
-  "$ref": "#/$defs/Compiler",
+  "$ref": "#/$defs/YamlCompiler",
   "$defs": {
-    "AddFields": {
-      "properties": {
-        "to": {
-          "type": "string",
-          "description": "Expected format: [package].[object]"
-        },
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/StructField"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "AnonymousStructsToNamed": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ArrayType": {
+    "AstArrayType": {
       "properties": {
         "value_type": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "Cloudwatch": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Compiler": {
-      "properties": {
-        "passes": {
-          "items": {
-            "$ref": "#/$defs/CompilerPass"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "CompilerPass": {
-      "properties": {
-        "entrypoint_identification": {
-          "$ref": "#/$defs/EntrypointIdentification"
-        },
-        "dataquery_identification": {
-          "$ref": "#/$defs/DataqueryIdentification"
-        },
-        "unspec": {
-          "$ref": "#/$defs/Unspec"
-        },
-        "fields_set_default": {
-          "$ref": "#/$defs/FieldsSetDefault"
-        },
-        "fields_set_required": {
-          "$ref": "#/$defs/FieldsSetRequired"
-        },
-        "fields_set_not_required": {
-          "$ref": "#/$defs/FieldsSetNotRequired"
-        },
-        "omit": {
-          "$ref": "#/$defs/Omit"
-        },
-        "add_fields": {
-          "$ref": "#/$defs/AddFields"
-        },
-        "name_anonymous_struct": {
-          "$ref": "#/$defs/NameAnonymousStruct"
-        },
-        "rename_object": {
-          "$ref": "#/$defs/RenameObject"
-        },
-        "retype_object": {
-          "$ref": "#/$defs/RetypeObject"
-        },
-        "hint_object": {
-          "$ref": "#/$defs/HintObject"
-        },
-        "retype_field": {
-          "$ref": "#/$defs/RetypeField"
-        },
-        "schema_set_identifier": {
-          "$ref": "#/$defs/SchemaSetIdentifier"
-        },
-        "anonymous_structs_to_named": {
-          "$ref": "#/$defs/AnonymousStructsToNamed"
-        },
-        "disjunction_to_type": {
-          "$ref": "#/$defs/DisjunctionToType"
-        },
-        "disjunction_of_anonymous_structs_to_explicit": {
-          "$ref": "#/$defs/DisjunctionOfAnonymousStructsToExplicit"
-        },
-        "disjunction_infer_mapping": {
-          "$ref": "#/$defs/DisjunctionInferMapping"
-        },
-        "disjunction_with_constant_to_default": {
-          "$ref": "#/$defs/DisjunctionWithConstantToDefault"
-        },
-        "dashboard_panels": {
-          "$ref": "#/$defs/DashboardPanels"
-        },
-        "cloudwatch": {
-          "$ref": "#/$defs/Cloudwatch"
-        },
-        "google_cloud_monitoring": {
-          "$ref": "#/$defs/GoogleCloudMonitoring"
-        },
-        "library_panels": {
-          "$ref": "#/$defs/LibraryPanels"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ComposableSlotType": {
+    "AstComposableSlotType": {
       "properties": {
         "variant": {
           "type": "string"
@@ -134,35 +21,10 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "DashboardPanels": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DataqueryIdentification": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionInferMapping": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionOfAnonymousStructsToExplicit": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionToType": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionType": {
+    "AstDisjunctionType": {
       "properties": {
         "branches": {
-          "$ref": "#/$defs/Types"
+          "$ref": "#/$defs/AstTypes"
         },
         "discriminator": {
           "type": "string",
@@ -178,21 +40,11 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "DisjunctionWithConstantToDefault": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "EntrypointIdentification": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "EnumType": {
+    "AstEnumType": {
       "properties": {
         "values": {
           "items": {
-            "$ref": "#/$defs/EnumValue"
+            "$ref": "#/$defs/AstEnumValue"
           },
           "type": "array",
           "description": "possible values. Value types might be different"
@@ -201,10 +53,10 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "EnumValue": {
+    "AstEnumValue": {
       "properties": {
         "type": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         },
         "name": {
           "type": "string"
@@ -214,65 +66,11 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "FieldsSetDefault": {
-      "properties": {
-        "defaults": {
-          "type": "object",
-          "description": "Expected format: [package].[object].[field] → value"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "FieldsSetNotRequired": {
-      "properties": {
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Expected format: [package].[object].[field]"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "FieldsSetRequired": {
-      "properties": {
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Expected format: [package].[object].[field]"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "GoogleCloudMonitoring": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "HintObject": {
-      "properties": {
-        "object": {
-          "type": "string",
-          "description": "Expected format: [package].[object]"
-        },
-        "hints": {
-          "$ref": "#/$defs/JenniesHints"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "IntersectionType": {
+    "AstIntersectionType": {
       "properties": {
         "branches": {
           "items": {
-            "$ref": "#/$defs/Type"
+            "$ref": "#/$defs/AstType"
           },
           "type": "array"
         }
@@ -280,54 +78,23 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "JenniesHints": {
+    "AstJenniesHints": {
       "type": "object",
       "description": "meant to be used by jennies, to gain a finer control on the codegen from schemas"
     },
-    "LibraryPanels": {
-      "properties": {},
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "MapType": {
+    "AstMapType": {
       "properties": {
         "indextype": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         },
         "valuetype": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "NameAnonymousStruct": {
-      "properties": {
-        "field": {
-          "type": "string",
-          "description": "Expected format: [package].[object].[field]"
-        },
-        "as": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Omit": {
-      "properties": {
-        "objects": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Expected format: [package].[object]"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "RefType": {
+    "AstRefType": {
       "properties": {
         "referred_pkg": {
           "type": "string"
@@ -339,58 +106,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "RenameObject": {
-      "properties": {
-        "from": {
-          "type": "string",
-          "description": "Expected format: [package].[object]"
-        },
-        "to": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "RetypeField": {
-      "properties": {
-        "field": {
-          "type": "string",
-          "description": "Expected format: [package].[object].[field]"
-        },
-        "as": {
-          "$ref": "#/$defs/Type"
-        },
-        "comments": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "RetypeObject": {
-      "properties": {
-        "object": {
-          "type": "string",
-          "description": "Expected format: [package].[object]"
-        },
-        "as": {
-          "$ref": "#/$defs/Type"
-        },
-        "comments": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ScalarType": {
+    "AstScalarType": {
       "properties": {
         "scalar_kind": {
           "type": "string",
@@ -401,7 +117,7 @@
         },
         "constraints": {
           "items": {
-            "$ref": "#/$defs/TypeConstraint"
+            "$ref": "#/$defs/AstTypeConstraint"
           },
           "type": "array"
         }
@@ -409,19 +125,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "SchemaSetIdentifier": {
-      "properties": {
-        "package": {
-          "type": "string"
-        },
-        "identifier": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "StructField": {
+    "AstStructField": {
       "properties": {
         "name": {
           "type": "string"
@@ -433,7 +137,7 @@
           "type": "array"
         },
         "type": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         },
         "required": {
           "type": "boolean"
@@ -448,11 +152,11 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "StructType": {
+    "AstStructType": {
       "properties": {
         "fields": {
           "items": {
-            "$ref": "#/$defs/StructField"
+            "$ref": "#/$defs/AstStructField"
           },
           "type": "array"
         }
@@ -460,7 +164,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Type": {
+    "AstType": {
       "properties": {
         "kind": {
           "type": "string"
@@ -470,34 +174,34 @@
         },
         "default": true,
         "disjunction": {
-          "$ref": "#/$defs/DisjunctionType"
+          "$ref": "#/$defs/AstDisjunctionType"
         },
         "array": {
-          "$ref": "#/$defs/ArrayType"
+          "$ref": "#/$defs/AstArrayType"
         },
         "enum": {
-          "$ref": "#/$defs/EnumType"
+          "$ref": "#/$defs/AstEnumType"
         },
         "map": {
-          "$ref": "#/$defs/MapType"
+          "$ref": "#/$defs/AstMapType"
         },
         "struct": {
-          "$ref": "#/$defs/StructType"
+          "$ref": "#/$defs/AstStructType"
         },
         "ref": {
-          "$ref": "#/$defs/RefType"
+          "$ref": "#/$defs/AstRefType"
         },
         "scalar": {
-          "$ref": "#/$defs/ScalarType"
+          "$ref": "#/$defs/AstScalarType"
         },
         "intersection": {
-          "$ref": "#/$defs/IntersectionType"
+          "$ref": "#/$defs/AstIntersectionType"
         },
         "composable_slot": {
-          "$ref": "#/$defs/ComposableSlotType"
+          "$ref": "#/$defs/AstComposableSlotType"
         },
         "hints": {
-          "$ref": "#/$defs/JenniesHints"
+          "$ref": "#/$defs/AstJenniesHints"
         },
         "passestrail": {
           "items": {
@@ -510,7 +214,7 @@
       "type": "object",
       "description": "Struct representing every type defined by the IR."
     },
-    "TypeConstraint": {
+    "AstTypeConstraint": {
       "properties": {
         "op": {
           "type": "string"
@@ -523,13 +227,309 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Types": {
+    "AstTypes": {
       "items": {
-        "$ref": "#/$defs/Type"
+        "$ref": "#/$defs/AstType"
       },
       "type": "array"
     },
-    "Unspec": {
+    "YamlAddFields": {
+      "properties": {
+        "to": {
+          "type": "string",
+          "description": "Expected format: [package].[object]"
+        },
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/AstStructField"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlAnonymousStructsToNamed": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlCloudwatch": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlCompiler": {
+      "properties": {
+        "passes": {
+          "items": {
+            "$ref": "#/$defs/YamlCompilerPass"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlCompilerPass": {
+      "properties": {
+        "entrypoint_identification": {
+          "$ref": "#/$defs/YamlEntrypointIdentification"
+        },
+        "dataquery_identification": {
+          "$ref": "#/$defs/YamlDataqueryIdentification"
+        },
+        "unspec": {
+          "$ref": "#/$defs/YamlUnspec"
+        },
+        "fields_set_default": {
+          "$ref": "#/$defs/YamlFieldsSetDefault"
+        },
+        "fields_set_required": {
+          "$ref": "#/$defs/YamlFieldsSetRequired"
+        },
+        "fields_set_not_required": {
+          "$ref": "#/$defs/YamlFieldsSetNotRequired"
+        },
+        "omit": {
+          "$ref": "#/$defs/YamlOmit"
+        },
+        "add_fields": {
+          "$ref": "#/$defs/YamlAddFields"
+        },
+        "name_anonymous_struct": {
+          "$ref": "#/$defs/YamlNameAnonymousStruct"
+        },
+        "rename_object": {
+          "$ref": "#/$defs/YamlRenameObject"
+        },
+        "retype_object": {
+          "$ref": "#/$defs/YamlRetypeObject"
+        },
+        "hint_object": {
+          "$ref": "#/$defs/YamlHintObject"
+        },
+        "retype_field": {
+          "$ref": "#/$defs/YamlRetypeField"
+        },
+        "schema_set_identifier": {
+          "$ref": "#/$defs/YamlSchemaSetIdentifier"
+        },
+        "anonymous_structs_to_named": {
+          "$ref": "#/$defs/YamlAnonymousStructsToNamed"
+        },
+        "disjunction_to_type": {
+          "$ref": "#/$defs/YamlDisjunctionToType"
+        },
+        "disjunction_of_anonymous_structs_to_explicit": {
+          "$ref": "#/$defs/YamlDisjunctionOfAnonymousStructsToExplicit"
+        },
+        "disjunction_infer_mapping": {
+          "$ref": "#/$defs/YamlDisjunctionInferMapping"
+        },
+        "disjunction_with_constant_to_default": {
+          "$ref": "#/$defs/YamlDisjunctionWithConstantToDefault"
+        },
+        "dashboard_panels": {
+          "$ref": "#/$defs/YamlDashboardPanels"
+        },
+        "cloudwatch": {
+          "$ref": "#/$defs/YamlCloudwatch"
+        },
+        "google_cloud_monitoring": {
+          "$ref": "#/$defs/YamlGoogleCloudMonitoring"
+        },
+        "library_panels": {
+          "$ref": "#/$defs/YamlLibraryPanels"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDashboardPanels": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDataqueryIdentification": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDisjunctionInferMapping": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDisjunctionOfAnonymousStructsToExplicit": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDisjunctionToType": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDisjunctionWithConstantToDefault": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlEntrypointIdentification": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlFieldsSetDefault": {
+      "properties": {
+        "defaults": {
+          "type": "object",
+          "description": "Expected format: [package].[object].[field] → value"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlFieldsSetNotRequired": {
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Expected format: [package].[object].[field]"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlFieldsSetRequired": {
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Expected format: [package].[object].[field]"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlGoogleCloudMonitoring": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlHintObject": {
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "Expected format: [package].[object]"
+        },
+        "hints": {
+          "$ref": "#/$defs/AstJenniesHints"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlLibraryPanels": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlNameAnonymousStruct": {
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Expected format: [package].[object].[field]"
+        },
+        "as": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlOmit": {
+      "properties": {
+        "objects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Expected format: [package].[object]"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlRenameObject": {
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Expected format: [package].[object]"
+        },
+        "to": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlRetypeField": {
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Expected format: [package].[object].[field]"
+        },
+        "as": {
+          "$ref": "#/$defs/AstType"
+        },
+        "comments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlRetypeObject": {
+      "properties": {
+        "object": {
+          "type": "string",
+          "description": "Expected format: [package].[object]"
+        },
+        "as": {
+          "$ref": "#/$defs/AstType"
+        },
+        "comments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlSchemaSetIdentifier": {
+      "properties": {
+        "package": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlUnspec": {
       "properties": {},
       "additionalProperties": false,
       "type": "object"

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -1,27 +1,24 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/grafana/cog/main/schemas/pipeline.json",
-  "$ref": "#/$defs/Pipeline",
+  "$ref": "#/$defs/CodegenPipeline",
   "$defs": {
-    "Config": {
+    "AstSchemaMeta": {
       "properties": {
-        "go_mod": {
-          "type": "boolean",
-          "description": "GenerateGoMod indicates whether a go.mod file should be generated.\nIf enabled, PackageRoot is used as module path."
+        "kind": {
+          "type": "string"
         },
-        "skip_runtime": {
-          "type": "boolean",
-          "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        "variant": {
+          "type": "string"
         },
-        "package_root": {
-          "type": "string",
-          "description": "Root path for imports.\nEx: github.com/grafana/cog/generated"
+        "identifier": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "CueInput": {
+    "CodegenCueInput": {
       "properties": {
         "allowed_objects": {
           "items": {
@@ -38,7 +35,7 @@
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
         "metadata": {
-          "$ref": "#/$defs/SchemaMeta",
+          "$ref": "#/$defs/AstSchemaMeta",
           "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "entrypoint": {
@@ -64,34 +61,34 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Input": {
+    "CodegenInput": {
       "properties": {
         "if": {
           "type": "string"
         },
         "jsonschema": {
-          "$ref": "#/$defs/JSONSchemaInput"
+          "$ref": "#/$defs/CodegenJSONSchemaInput"
         },
         "openapi": {
-          "$ref": "#/$defs/OpenAPIInput"
+          "$ref": "#/$defs/CodegenOpenAPIInput"
         },
         "kind_registry": {
-          "$ref": "#/$defs/KindRegistryInput"
+          "$ref": "#/$defs/CodegenKindRegistryInput"
         },
         "kindsys_core": {
-          "$ref": "#/$defs/CueInput"
+          "$ref": "#/$defs/CodegenCueInput"
         },
         "kindsys_composable": {
-          "$ref": "#/$defs/CueInput"
+          "$ref": "#/$defs/CodegenCueInput"
         },
         "cue": {
-          "$ref": "#/$defs/CueInput"
+          "$ref": "#/$defs/CodegenCueInput"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "JSONSchemaInput": {
+    "CodegenJSONSchemaInput": {
       "properties": {
         "allowed_objects": {
           "items": {
@@ -108,7 +105,7 @@
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
         "metadata": {
-          "$ref": "#/$defs/SchemaMeta",
+          "$ref": "#/$defs/AstSchemaMeta",
           "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
@@ -127,7 +124,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "KindRegistryInput": {
+    "CodegenKindRegistryInput": {
       "properties": {
         "allowed_objects": {
           "items": {
@@ -144,7 +141,7 @@
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
         "metadata": {
-          "$ref": "#/$defs/SchemaMeta",
+          "$ref": "#/$defs/AstSchemaMeta",
           "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
@@ -157,7 +154,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "OpenAPIInput": {
+    "CodegenOpenAPIInput": {
       "properties": {
         "allowed_objects": {
           "items": {
@@ -174,7 +171,7 @@
           "description": "Transforms holds a list of paths to files containing compiler passes\nto apply to the input."
         },
         "metadata": {
-          "$ref": "#/$defs/SchemaMeta",
+          "$ref": "#/$defs/AstSchemaMeta",
           "description": "Metadata to add to the schema, this can be used to set Kind and Variant"
         },
         "path": {
@@ -197,7 +194,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Output": {
+    "CodegenOutput": {
       "properties": {
         "directory": {
           "type": "string"
@@ -210,7 +207,7 @@
         },
         "languages": {
           "items": {
-            "$ref": "#/$defs/OutputLanguage"
+            "$ref": "#/$defs/CodegenOutputLanguage"
           },
           "type": "array"
         },
@@ -233,46 +230,46 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "OutputLanguage": {
+    "CodegenOutputLanguage": {
       "properties": {
         "go": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/GolangConfig"
         },
         "java": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/JavaConfig"
         },
         "jsonschema": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/JsonschemaConfig"
         },
         "openapi": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/OpenapiConfig"
         },
         "python": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/PythonConfig"
         },
         "typescript": {
-          "$ref": "#/$defs/Config"
+          "$ref": "#/$defs/TypescriptConfig"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "Pipeline": {
+    "CodegenPipeline": {
       "properties": {
         "debug": {
           "type": "boolean"
         },
         "inputs": {
           "items": {
-            "$ref": "#/$defs/Input"
+            "$ref": "#/$defs/CodegenInput"
           },
           "type": "array"
         },
         "transformations": {
-          "$ref": "#/$defs/Transforms"
+          "$ref": "#/$defs/CodegenTransforms"
         },
         "output": {
-          "$ref": "#/$defs/Output"
+          "$ref": "#/$defs/CodegenOutput"
         },
         "parameters": {
           "additionalProperties": {
@@ -284,22 +281,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "SchemaMeta": {
-      "properties": {
-        "kind": {
-          "type": "string"
-        },
-        "variant": {
-          "type": "string"
-        },
-        "identifier": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Transforms": {
+    "CodegenTransforms": {
       "properties": {
         "schemas": {
           "items": {
@@ -314,6 +296,91 @@
           },
           "type": "array",
           "description": "VeneersDirectories holds a list of paths to directories containing\nveneers to apply to all the builders."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "GolangConfig": {
+      "properties": {
+        "go_mod": {
+          "type": "boolean",
+          "description": "GenerateGoMod indicates whether a go.mod file should be generated.\nIf enabled, PackageRoot is used as module path."
+        },
+        "skip_runtime": {
+          "type": "boolean",
+          "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        },
+        "package_root": {
+          "type": "string",
+          "description": "Root path for imports.\nEx: github.com/grafana/cog/generated"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JavaConfig": {
+      "properties": {
+        "gen_pom": {
+          "type": "boolean"
+        },
+        "maven_version": {
+          "type": "string"
+        },
+        "package_path": {
+          "type": "string"
+        },
+        "skip_runtime": {
+          "type": "boolean",
+          "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JsonschemaConfig": {
+      "properties": {
+        "compact": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "OpenapiConfig": {
+      "properties": {
+        "compact": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PythonConfig": {
+      "properties": {
+        "path_prefix": {
+          "type": "string"
+        },
+        "skip_runtime": {
+          "type": "boolean",
+          "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TypescriptConfig": {
+      "properties": {
+        "path_prefix": {
+          "type": "string"
+        },
+        "skip_runtime": {
+          "type": "boolean",
+          "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        },
+        "skip_index": {
+          "type": "boolean",
+          "description": "SkipIndex disables the generation of `index.ts` files."
         }
       },
       "additionalProperties": false,

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -1,109 +1,38 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/grafana/cog/main/schemas/veneers.json",
-  "$ref": "#/$defs/Veneers",
+  "$ref": "#/$defs/YamlVeneers",
   "$defs": {
-    "AddAssignment": {
-      "properties": {
-        "by_name": {
-          "type": "string",
-          "description": "objectName.optionName"
-        },
-        "by_builder": {
-          "type": "string",
-          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
-        },
-        "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
-        },
-        "assignment": {
-          "$ref": "#/$defs/Assignment"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "AddOption": {
-      "properties": {
-        "by_object": {
-          "type": "string"
-        },
-        "by_name": {
-          "type": "string"
-        },
-        "generated_from_disjunction": {
-          "type": "boolean",
-          "description": "noop?"
-        },
-        "option": {
-          "$ref": "#/$defs/Option"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Argument": {
+    "AstArgument": {
       "properties": {
         "name": {
           "type": "string"
         },
         "type": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "ArrayToAppend": {
-      "properties": {
-        "by_name": {
-          "type": "string",
-          "description": "objectName.optionName"
-        },
-        "by_builder": {
-          "type": "string",
-          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
-        },
-        "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ArrayType": {
+    "AstArrayType": {
       "properties": {
         "value_type": {
-          "$ref": "#/$defs/Type"
+          "$ref": "#/$defs/AstType"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "Assignment": {
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "method": {
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/AssignmentValue"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "AssignmentEnvelope": {
+    "AstAssignmentEnvelope": {
       "properties": {
         "type": {
-          "$ref": "#/$defs/Type",
+          "$ref": "#/$defs/AstType",
           "description": "Should be a ref or a struct only"
         },
         "values": {
           "items": {
-            "$ref": "#/$defs/EnvelopeFieldValue"
+            "$ref": "#/$defs/AstEnvelopeFieldValue"
           },
           "type": "array"
         }
@@ -111,84 +40,20 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "AssignmentValue": {
+    "AstAssignmentValue": {
       "properties": {
         "argument": {
-          "$ref": "#/$defs/Argument"
+          "$ref": "#/$defs/AstArgument"
         },
         "constant": true,
         "envelope": {
-          "$ref": "#/$defs/AssignmentEnvelope"
+          "$ref": "#/$defs/AstAssignmentEnvelope"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "BuilderRule": {
-      "properties": {
-        "omit": {
-          "$ref": "#/$defs/BuilderSelector"
-        },
-        "rename": {
-          "$ref": "#/$defs/RenameBuilder"
-        },
-        "merge_into": {
-          "$ref": "#/$defs/MergeInto"
-        },
-        "compose_dashboard_panel": {
-          "$ref": "#/$defs/ComposeDashboardPanel"
-        },
-        "properties": {
-          "$ref": "#/$defs/Properties"
-        },
-        "duplicate": {
-          "$ref": "#/$defs/Duplicate"
-        },
-        "initialize": {
-          "$ref": "#/$defs/Initialize"
-        },
-        "promote_options_to_constructor": {
-          "$ref": "#/$defs/PromoteOptsToConstructor"
-        },
-        "add_option": {
-          "$ref": "#/$defs/AddOption"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "BuilderSelector": {
-      "properties": {
-        "by_object": {
-          "type": "string"
-        },
-        "by_name": {
-          "type": "string"
-        },
-        "generated_from_disjunction": {
-          "type": "boolean",
-          "description": "noop?"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ByNamesSelector": {
-      "properties": {
-        "object": {
-          "type": "string"
-        },
-        "options": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "ComposableSlotType": {
+    "AstComposableSlotType": {
       "properties": {
         "variant": {
           "type": "string"
@@ -197,42 +62,10 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "ComposeDashboardPanel": {
-      "properties": {
-        "panel_builder_name": {
-          "type": "string"
-        },
-        "exclude_panel_options": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionAsOptions": {
-      "properties": {
-        "by_name": {
-          "type": "string",
-          "description": "objectName.optionName"
-        },
-        "by_builder": {
-          "type": "string",
-          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
-        },
-        "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "DisjunctionType": {
+    "AstDisjunctionType": {
       "properties": {
         "branches": {
-          "$ref": "#/$defs/Types"
+          "$ref": "#/$defs/AstTypes"
         },
         "discriminator": {
           "type": "string",
@@ -248,7 +81,419 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Duplicate": {
+    "AstEnumType": {
+      "properties": {
+        "values": {
+          "items": {
+            "$ref": "#/$defs/AstEnumValue"
+          },
+          "type": "array",
+          "description": "possible values. Value types might be different"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstEnumValue": {
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/AstType"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": true
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstEnvelopeFieldValue": {
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/AstPath",
+          "description": "where to assign within the struct/ref"
+        },
+        "value": {
+          "$ref": "#/$defs/AstAssignmentValue",
+          "description": "what to assign"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstIntersectionType": {
+      "properties": {
+        "branches": {
+          "items": {
+            "$ref": "#/$defs/AstType"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstJenniesHints": {
+      "type": "object",
+      "description": "meant to be used by jennies, to gain a finer control on the codegen from schemas"
+    },
+    "AstMapType": {
+      "properties": {
+        "indextype": {
+          "$ref": "#/$defs/AstType"
+        },
+        "valuetype": {
+          "$ref": "#/$defs/AstType"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstPath": {
+      "items": {
+        "$ref": "#/$defs/AstPathItem"
+      },
+      "type": "array"
+    },
+    "AstPathItem": {
+      "properties": {
+        "identifier": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/AstType",
+          "description": "any"
+        },
+        "typehint": {
+          "$ref": "#/$defs/AstType",
+          "description": "useful mostly for composability purposes, when a field Type is \"any\"\nand we're trying to \"compose in\" something of a known type."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstRefType": {
+      "properties": {
+        "referred_pkg": {
+          "type": "string"
+        },
+        "referred_type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstScalarType": {
+      "properties": {
+        "scalar_kind": {
+          "type": "string",
+          "description": "bool, bytes, string, int, float, ..."
+        },
+        "value": {
+          "description": "if value isn't nil, we're representing a constant scalar"
+        },
+        "constraints": {
+          "items": {
+            "$ref": "#/$defs/AstTypeConstraint"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstStructField": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "comments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "type": {
+          "$ref": "#/$defs/AstType"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "passestrail": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstStructType": {
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/AstStructField"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstType": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "nullable": {
+          "type": "boolean"
+        },
+        "default": true,
+        "disjunction": {
+          "$ref": "#/$defs/AstDisjunctionType"
+        },
+        "array": {
+          "$ref": "#/$defs/AstArrayType"
+        },
+        "enum": {
+          "$ref": "#/$defs/AstEnumType"
+        },
+        "map": {
+          "$ref": "#/$defs/AstMapType"
+        },
+        "struct": {
+          "$ref": "#/$defs/AstStructType"
+        },
+        "ref": {
+          "$ref": "#/$defs/AstRefType"
+        },
+        "scalar": {
+          "$ref": "#/$defs/AstScalarType"
+        },
+        "intersection": {
+          "$ref": "#/$defs/AstIntersectionType"
+        },
+        "composable_slot": {
+          "$ref": "#/$defs/AstComposableSlotType"
+        },
+        "hints": {
+          "$ref": "#/$defs/AstJenniesHints"
+        },
+        "passestrail": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Struct representing every type defined by the IR."
+    },
+    "AstTypeConstraint": {
+      "properties": {
+        "op": {
+          "type": "string"
+        },
+        "args": {
+          "items": true,
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "AstTypes": {
+      "items": {
+        "$ref": "#/$defs/AstType"
+      },
+      "type": "array"
+    },
+    "VeneersAssignment": {
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/AstAssignmentValue"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VeneersOption": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "assignments": {
+          "items": {
+            "$ref": "#/$defs/VeneersAssignment"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlAddAssignment": {
+      "properties": {
+        "by_name": {
+          "type": "string",
+          "description": "objectName.optionName"
+        },
+        "by_builder": {
+          "type": "string",
+          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
+        },
+        "by_names": {
+          "$ref": "#/$defs/YamlByNamesSelector"
+        },
+        "assignment": {
+          "$ref": "#/$defs/VeneersAssignment"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlAddOption": {
+      "properties": {
+        "by_object": {
+          "type": "string"
+        },
+        "by_name": {
+          "type": "string"
+        },
+        "generated_from_disjunction": {
+          "type": "boolean",
+          "description": "noop?"
+        },
+        "option": {
+          "$ref": "#/$defs/VeneersOption"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlArrayToAppend": {
+      "properties": {
+        "by_name": {
+          "type": "string",
+          "description": "objectName.optionName"
+        },
+        "by_builder": {
+          "type": "string",
+          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
+        },
+        "by_names": {
+          "$ref": "#/$defs/YamlByNamesSelector"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlBuilderRule": {
+      "properties": {
+        "omit": {
+          "$ref": "#/$defs/YamlBuilderSelector"
+        },
+        "rename": {
+          "$ref": "#/$defs/YamlRenameBuilder"
+        },
+        "merge_into": {
+          "$ref": "#/$defs/YamlMergeInto"
+        },
+        "compose_dashboard_panel": {
+          "$ref": "#/$defs/YamlComposeDashboardPanel"
+        },
+        "properties": {
+          "$ref": "#/$defs/YamlProperties"
+        },
+        "duplicate": {
+          "$ref": "#/$defs/YamlDuplicate"
+        },
+        "initialize": {
+          "$ref": "#/$defs/YamlInitialize"
+        },
+        "promote_options_to_constructor": {
+          "$ref": "#/$defs/YamlPromoteOptsToConstructor"
+        },
+        "add_option": {
+          "$ref": "#/$defs/YamlAddOption"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlBuilderSelector": {
+      "properties": {
+        "by_object": {
+          "type": "string"
+        },
+        "by_name": {
+          "type": "string"
+        },
+        "generated_from_disjunction": {
+          "type": "boolean",
+          "description": "noop?"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlByNamesSelector": {
+      "properties": {
+        "object": {
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlComposeDashboardPanel": {
+      "properties": {
+        "panel_builder_name": {
+          "type": "string"
+        },
+        "exclude_panel_options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDisjunctionAsOptions": {
+      "properties": {
+        "by_name": {
+          "type": "string",
+          "description": "objectName.optionName"
+        },
+        "by_builder": {
+          "type": "string",
+          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
+        },
+        "by_names": {
+          "$ref": "#/$defs/YamlByNamesSelector"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlDuplicate": {
       "properties": {
         "by_object": {
           "type": "string"
@@ -273,7 +518,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "DuplicateOption": {
+    "YamlDuplicateOption": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -284,7 +529,7 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         },
         "as": {
           "type": "string"
@@ -293,47 +538,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "EnumType": {
-      "properties": {
-        "values": {
-          "items": {
-            "$ref": "#/$defs/EnumValue"
-          },
-          "type": "array",
-          "description": "possible values. Value types might be different"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "EnumValue": {
-      "properties": {
-        "type": {
-          "$ref": "#/$defs/Type"
-        },
-        "name": {
-          "type": "string"
-        },
-        "value": true
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "EnvelopeFieldValue": {
-      "properties": {
-        "path": {
-          "$ref": "#/$defs/Path",
-          "description": "where to assign within the struct/ref"
-        },
-        "value": {
-          "$ref": "#/$defs/AssignmentValue",
-          "description": "what to assign"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Initialization": {
+    "YamlInitialization": {
       "properties": {
         "property": {
           "type": "string"
@@ -343,7 +548,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Initialize": {
+    "YamlInitialize": {
       "properties": {
         "by_object": {
           "type": "string"
@@ -357,7 +562,7 @@
         },
         "set": {
           "items": {
-            "$ref": "#/$defs/Initialization"
+            "$ref": "#/$defs/YamlInitialization"
           },
           "type": "array"
         }
@@ -365,35 +570,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "IntersectionType": {
-      "properties": {
-        "branches": {
-          "items": {
-            "$ref": "#/$defs/Type"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "JenniesHints": {
-      "type": "object",
-      "description": "meant to be used by jennies, to gain a finer control on the codegen from schemas"
-    },
-    "MapType": {
-      "properties": {
-        "indextype": {
-          "$ref": "#/$defs/Type"
-        },
-        "valuetype": {
-          "$ref": "#/$defs/Type"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "MergeInto": {
+    "YamlMergeInto": {
       "properties": {
         "destination": {
           "type": "string"
@@ -420,55 +597,40 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Option": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "assignments": {
-          "items": {
-            "$ref": "#/$defs/Assignment"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "OptionRule": {
+    "YamlOptionRule": {
       "properties": {
         "omit": {
-          "$ref": "#/$defs/OptionSelector"
+          "$ref": "#/$defs/YamlOptionSelector"
         },
         "rename": {
-          "$ref": "#/$defs/RenameOption"
+          "$ref": "#/$defs/YamlRenameOption"
         },
         "unfold_boolean": {
-          "$ref": "#/$defs/UnfoldBoolean"
+          "$ref": "#/$defs/YamlUnfoldBoolean"
         },
         "struct_fields_as_arguments": {
-          "$ref": "#/$defs/StructFieldsAsArguments"
+          "$ref": "#/$defs/YamlStructFieldsAsArguments"
         },
         "struct_fields_as_options": {
-          "$ref": "#/$defs/StructFieldsAsOptions"
+          "$ref": "#/$defs/YamlStructFieldsAsOptions"
         },
         "array_to_append": {
-          "$ref": "#/$defs/ArrayToAppend"
+          "$ref": "#/$defs/YamlArrayToAppend"
         },
         "disjunction_as_options": {
-          "$ref": "#/$defs/DisjunctionAsOptions"
+          "$ref": "#/$defs/YamlDisjunctionAsOptions"
         },
         "duplicate": {
-          "$ref": "#/$defs/DuplicateOption"
+          "$ref": "#/$defs/YamlDuplicateOption"
         },
         "add_assignment": {
-          "$ref": "#/$defs/AddAssignment"
+          "$ref": "#/$defs/YamlAddAssignment"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "OptionSelector": {
+    "YamlOptionSelector": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -479,36 +641,13 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         }
       },
       "additionalProperties": false,
       "type": "object"
     },
-    "Path": {
-      "items": {
-        "$ref": "#/$defs/PathItem"
-      },
-      "type": "array"
-    },
-    "PathItem": {
-      "properties": {
-        "identifier": {
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/$defs/Type",
-          "description": "any"
-        },
-        "typehint": {
-          "$ref": "#/$defs/Type",
-          "description": "useful mostly for composability purposes, when a field Type is \"any\"\nand we're trying to \"compose in\" something of a known type."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "PromoteOptsToConstructor": {
+    "YamlPromoteOptsToConstructor": {
       "properties": {
         "by_object": {
           "type": "string"
@@ -530,7 +669,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Properties": {
+    "YamlProperties": {
       "properties": {
         "by_object": {
           "type": "string"
@@ -544,7 +683,7 @@
         },
         "set": {
           "items": {
-            "$ref": "#/$defs/StructField"
+            "$ref": "#/$defs/AstStructField"
           },
           "type": "array"
         }
@@ -552,19 +691,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "RefType": {
-      "properties": {
-        "referred_pkg": {
-          "type": "string"
-        },
-        "referred_type": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "RenameBuilder": {
+    "YamlRenameBuilder": {
       "properties": {
         "by_object": {
           "type": "string"
@@ -583,7 +710,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "RenameOption": {
+    "YamlRenameOption": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -594,7 +721,7 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         },
         "as": {
           "type": "string"
@@ -603,53 +730,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "ScalarType": {
-      "properties": {
-        "scalar_kind": {
-          "type": "string",
-          "description": "bool, bytes, string, int, float, ..."
-        },
-        "value": {
-          "description": "if value isn't nil, we're representing a constant scalar"
-        },
-        "constraints": {
-          "items": {
-            "$ref": "#/$defs/TypeConstraint"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "StructField": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "comments": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "type": {
-          "$ref": "#/$defs/Type"
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "passestrail": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "StructFieldsAsArguments": {
+    "YamlStructFieldsAsArguments": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -660,7 +741,7 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         },
         "fields": {
           "items": {
@@ -672,7 +753,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "StructFieldsAsOptions": {
+    "YamlStructFieldsAsOptions": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -683,7 +764,7 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         },
         "fields": {
           "items": {
@@ -695,88 +776,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "StructType": {
-      "properties": {
-        "fields": {
-          "items": {
-            "$ref": "#/$defs/StructField"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Type": {
-      "properties": {
-        "kind": {
-          "type": "string"
-        },
-        "nullable": {
-          "type": "boolean"
-        },
-        "default": true,
-        "disjunction": {
-          "$ref": "#/$defs/DisjunctionType"
-        },
-        "array": {
-          "$ref": "#/$defs/ArrayType"
-        },
-        "enum": {
-          "$ref": "#/$defs/EnumType"
-        },
-        "map": {
-          "$ref": "#/$defs/MapType"
-        },
-        "struct": {
-          "$ref": "#/$defs/StructType"
-        },
-        "ref": {
-          "$ref": "#/$defs/RefType"
-        },
-        "scalar": {
-          "$ref": "#/$defs/ScalarType"
-        },
-        "intersection": {
-          "$ref": "#/$defs/IntersectionType"
-        },
-        "composable_slot": {
-          "$ref": "#/$defs/ComposableSlotType"
-        },
-        "hints": {
-          "$ref": "#/$defs/JenniesHints"
-        },
-        "passestrail": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "Struct representing every type defined by the IR."
-    },
-    "TypeConstraint": {
-      "properties": {
-        "op": {
-          "type": "string"
-        },
-        "args": {
-          "items": true,
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "Types": {
-      "items": {
-        "$ref": "#/$defs/Type"
-      },
-      "type": "array"
-    },
-    "UnfoldBoolean": {
+    "YamlUnfoldBoolean": {
       "properties": {
         "by_name": {
           "type": "string",
@@ -787,7 +787,7 @@
           "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
         },
         "by_names": {
-          "$ref": "#/$defs/ByNamesSelector"
+          "$ref": "#/$defs/YamlByNamesSelector"
         },
         "true_as": {
           "type": "string"
@@ -799,7 +799,7 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "Veneers": {
+    "YamlVeneers": {
       "properties": {
         "language": {
           "type": "string"
@@ -809,13 +809,13 @@
         },
         "builders": {
           "items": {
-            "$ref": "#/$defs/BuilderRule"
+            "$ref": "#/$defs/YamlBuilderRule"
           },
           "type": "array"
         },
         "options": {
           "items": {
-            "$ref": "#/$defs/OptionRule"
+            "$ref": "#/$defs/YamlOptionRule"
           },
           "type": "array"
         }


### PR DESCRIPTION
Some definitions conflicted with each others in our config schemas due to identical names.

To lift this kind of ambiguity, I tweaked the schema-generator to use both the package name and the object name when generating a definition.