### PR TITLE
Compiler: Fix testdata datasource name

### DIFF
--- a/config/compiler/testdata_passes.yaml
+++ b/config/compiler/testdata_passes.yaml
@@ -19,7 +19,7 @@ passes:
   # TODO: should be replaced by a ref to dashboard.DatasourceRef
   - rename_object:
       from: 'testdata.TestdataTestdataTargetsDatasource'
-      to: 'datasource'
+      to: 'Datasource'
 
   - rename_object:
       from: 'testdata.TestdataTestdataTargetsNodes'


### PR DESCRIPTION
All renaming names are in upper camel case except this one. It generates wrong Java code.