### PR TITLE
Java: Remove set prefixes

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -130,7 +130,7 @@ func (b Builders) formatInitializers(args []ast.Argument) []string {
 		}
 		if b.typeFormatter.typeHasBuilder(arg.Type) {
 			constructorFormat = "%s.Builder %sResource = new %s.Builder();"
-			setterFormat = "%sResource.set%s(%s);"
+			setterFormat = "%sResource.%s(%s);"
 			fieldNameFunc = tools.UpperCamelCase
 		}
 
@@ -189,7 +189,7 @@ func (b Builders) formatDefaultReference(ref ast.RefType, defValue any) string {
 			defValues := defValue.(map[string]interface{})
 			for _, field := range structType.Fields {
 				if f, ok := defValues[field.Name]; ok {
-					builder = fmt.Sprintf("%s.set%s(%#v)", builder, tools.UpperCamelCase(field.Name), f)
+					builder = fmt.Sprintf("%s.%s(%#v)", builder, tools.UpperCamelCase(field.Name), f)
 				}
 			}
 			return builder + ".build()"

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -16,12 +16,12 @@
         {{- range .Initializers }}
         {{ . }}
         {{- end }}
-        this.set{{ .OptionName }}({{ .Args|join ", " }});
+        this.{{ .OptionName }}({{ .Args|join ", " }});
         {{- end }}
         }
         
     {{- range $opt := .Builder.Options }}
-    public {{ $.BuilderName }}Builder set{{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
+    public {{ $.BuilderName }}Builder {{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.Builder.BuilderName "OptionName" $opt.Name) }}
         {{- end }}

--- a/internal/jennies/java/templates/types/enum.tmpl
+++ b/internal/jennies/java/templates/types/enum.tmpl
@@ -16,7 +16,7 @@ public enum {{ .Name }} {
         this.value = value;
     }
 
-    public {{ .Type }} getValue() {
+    public {{ .Type }} Value() {
         return value;
     }
 }

--- a/internal/jennies/java/templates/types/panel_builder.tmpl
+++ b/internal/jennies/java/templates/types/panel_builder.tmpl
@@ -20,12 +20,12 @@ public class PanelBuilder implements {{ if not (eq .ImportAlias "") }}{{ .Import
         {{- range .Initializers }}
         {{ . }}
         {{- end }}
-        this.set{{ .OptionName }}({{ .Args|join ", " }});
+        this.{{ .OptionName }}({{ .Args|join ", " }});
         {{- end }}
     }
     
     {{- range .Options }}
-    public PanelBuilder set{{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
+    public PanelBuilder {{ .Name | upperCamelCase }}({{- template "args" .Args }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" "PanelBuilder" "OptionName" "Panel") }}
         {{- end }}

--- a/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
+++ b/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
@@ -10,7 +10,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setTime(Object time) {
+    public Builder Time(Object time) {
     this.internal.time = time;
         return this;
     }

--- a/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
@@ -12,7 +12,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setTags(String tags) {
+    public Builder Tags(String tags) {
 		if (this.internal.tags == null) {
 			this.internal.tags = new LinkedList<>();
 		}

--- a/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
@@ -18,22 +18,22 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setId(Long id) {
+    public Builder Id(Long id) {
     this.internal.id = id;
         return this;
     }
     
-    public Builder setUid(String uid) {
+    public Builder Uid(String uid) {
     this.internal.uid = uid;
         return this;
     }
     
-    public Builder setTags(List<String> tags) {
+    public Builder Tags(List<String> tags) {
     this.internal.tags = tags;
         return this;
     }
     
-    public Builder setLiveNow(Boolean liveNow) {
+    public Builder LiveNow(Boolean liveNow) {
     this.internal.liveNow = liveNow;
         return this;
     }

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -13,27 +13,27 @@ public class SomeStruct {
         
         public Builder() {
             this.internal = new SomeStruct();
-        this.setId(42L);
-        this.setUid("default-uid");
-        this.setTags(List.of("generated", "cog"));
-        this.setLiveNow(true);
+        this.Id(42L);
+        this.Uid("default-uid");
+        this.Tags(List.of("generated", "cog"));
+        this.LiveNow(true);
         }
-    public Builder setId(Long id) {
+    public Builder Id(Long id) {
     this.internal.id = id;
         return this;
     }
     
-    public Builder setUid(String uid) {
+    public Builder Uid(String uid) {
     this.internal.uid = uid;
         return this;
     }
     
-    public Builder setTags(List<String> tags) {
+    public Builder Tags(List<String> tags) {
     this.internal.tags = tags;
         return this;
     }
     
-    public Builder setLiveNow(Boolean liveNow) {
+    public Builder LiveNow(Boolean liveNow) {
     this.internal.liveNow = liveNow;
         return this;
     }

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
@@ -18,27 +18,27 @@ public class Dashboard {
         public Builder() {
             this.internal = new Dashboard();
         }
-    public Builder setId(Long id) {
+    public Builder Id(Long id) {
     this.internal.id = id;
         return this;
     }
     
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }
     
-    public Builder setLinks(cog.Builder<List<DashboardLink>> links) {
+    public Builder Links(cog.Builder<List<DashboardLink>> links) {
     this.internal.links = links.build();
         return this;
     }
     
-    public Builder setLinksOfLinks(cog.Builder<List<List<DashboardLink>>> linksOfLinks) {
+    public Builder LinksOfLinks(cog.Builder<List<List<DashboardLink>>> linksOfLinks) {
     this.internal.linksOfLinks = linksOfLinks.build();
         return this;
     }
     
-    public Builder setSingleLink(cog.Builder<DashboardLink> singleLink) {
+    public Builder SingleLink(cog.Builder<DashboardLink> singleLink) {
     this.internal.singleLink = singleLink.build();
         return this;
     }

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
@@ -11,12 +11,12 @@ public class DashboardLink {
         public Builder() {
             this.internal = new DashboardLink();
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }
     
-    public Builder setUrl(String url) {
+    public Builder Url(String url) {
     this.internal.url = url;
         return this;
     }

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
@@ -15,17 +15,17 @@ public class Dashboard {
         public Builder() {
             this.internal = new Dashboard();
         }
-    public Builder setSingleLinkOrString(cog.Builder<unknown> singleLinkOrString) {
+    public Builder SingleLinkOrString(cog.Builder<unknown> singleLinkOrString) {
     this.internal.singleLinkOrString = singleLinkOrString.build();
         return this;
     }
     
-    public Builder setLinksOrStrings(cog.Builder<List<unknown>> linksOrStrings) {
+    public Builder LinksOrStrings(cog.Builder<List<unknown>> linksOrStrings) {
     this.internal.linksOrStrings = linksOrStrings.build();
         return this;
     }
     
-    public Builder setDisjunctionOfBuilders(cog.Builder<unknown> disjunctionOfBuilders) {
+    public Builder DisjunctionOfBuilders(cog.Builder<unknown> disjunctionOfBuilders) {
     this.internal.disjunctionOfBuilders = disjunctionOfBuilders.build();
         return this;
     }

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
@@ -11,12 +11,12 @@ public class DashboardLink {
         public Builder() {
             this.internal = new DashboardLink();
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }
     
-    public Builder setUrl(String url) {
+    public Builder Url(String url) {
     this.internal.url = url;
         return this;
     }

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
@@ -10,7 +10,7 @@ public class ExternalLink {
         public Builder() {
             this.internal = new ExternalLink();
         }
-    public Builder setUrl(String url) {
+    public Builder Url(String url) {
     this.internal.url = url;
         return this;
     }

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -13,12 +13,12 @@ public class Dashboard {
         public Builder() {
             this.internal = new Dashboard();
         }
-    public Builder setTarget(cog.Builder<Dataquery> target) {
+    public Builder Target(cog.Builder<Dataquery> target) {
     this.internal.target = target.build();
         return this;
     }
     
-    public Builder setTargets(cog.Builder<List<Dataquery>> targets) {
+    public Builder Targets(cog.Builder<List<Dataquery>> targets) {
     this.internal.targets = targets.build();
         return this;
     }

--- a/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -11,22 +11,22 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setEditable() {
+    public Builder Editable() {
     this.internal.editable = true;
         return this;
     }
     
-    public Builder setReadonly() {
+    public Builder Readonly() {
     this.internal.editable = false;
         return this;
     }
     
-    public Builder setAutoRefresh() {
+    public Builder AutoRefresh() {
     this.internal.autoRefresh = true;
         return this;
     }
     
-    public Builder setNoAutoRefresh() {
+    public Builder NoAutoRefresh() {
     this.internal.autoRefresh = false;
         return this;
     }

--- a/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
+++ b/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
@@ -11,7 +11,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setId(Long id) {
+    public Builder Id(Long id) {
         if (!(id >= 5)) {
             throw new IllegalArgumentException("id must be >= 5");
         }
@@ -22,7 +22,7 @@ public class SomeStruct {
         return this;
     }
     
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
         if (!(title.length() >= 1)) {
             throw new IllegalArgumentException("title.length() must be >= 1");
         }

--- a/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
@@ -11,7 +11,7 @@ public class SomeStruct {
             this.internal = new SomeStruct();
     this.internal.title = title;
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/CursorMode.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/CursorMode.java
@@ -12,7 +12,7 @@ public enum CursorMode {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
@@ -14,7 +14,7 @@ public class SomePanel {
     this.internal.type = "panel_type";
     this.internal.cursor = CursorMode.TOOLTIP;
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -10,7 +10,7 @@ public class Loki implements cog.variants.Dataquery {
         public Builder() {
             this.internal = new Loki();
         }
-    public Builder setExpr(String expr) {
+    public Builder Expr(String expr) {
     this.internal.expr = expr;
         return this;
     }

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
@@ -12,7 +12,7 @@ public class Dashboard {
         public Builder() {
             this.internal = new Dashboard();
         }
-    public Builder setWithVariable(String name,String value) {
+    public Builder WithVariable(String name,String value) {
 		if (this.internal.variables == null) {
 			this.internal.variables = new LinkedList<>();
 		}

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
@@ -11,12 +11,12 @@ public class SomePanel {
         public Builder() {
             this.internal = new SomePanel();
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
     this.internal.title = title;
         return this;
     }
     
-    public Builder setShowLegend(Boolean show) {
+    public Builder ShowLegend(Boolean show) {
 		if (this.internal.options == null) {
 			this.internal.options = new initialization_safeguards.Options();
 		}

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
@@ -10,7 +10,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setTitle(String title) {
+    public Builder Title(String title) {
 		if (this.internal.config == null) {
 			this.internal.config = new known_any.Config();
 		}

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -11,7 +11,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setConfig(Map<String, String> config) {
+    public Builder Config(Map<String, String> config) {
     this.internal.config = config;
         return this;
     }

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
@@ -8,53 +8,53 @@ public class PanelBuilder implements cog.Builder<Panel> {
 
     public PanelBuilder() {
         this.internal = new Panel();
-        this.setOnlyFromThisDashboard(false);
-        this.setOnlyInTimeRange(false);
-        this.setLimit(10);
-        this.setShowUser(true);
-        this.setShowTime(true);
-        this.setShowTags(true);
-        this.setNavigateToPanel(true);
-        this.setNavigateBefore("10m");
-        this.setNavigateAfter("10m");
+        this.OnlyFromThisDashboard(false);
+        this.OnlyInTimeRange(false);
+        this.Limit(10);
+        this.ShowUser(true);
+        this.ShowTime(true);
+        this.ShowTags(true);
+        this.NavigateToPanel(true);
+        this.NavigateBefore("10m");
+        this.NavigateAfter("10m");
     }
-    public PanelBuilder setOnlyFromThisDashboard(Boolean onlyFromThisDashboard) {
+    public PanelBuilder OnlyFromThisDashboard(Boolean onlyFromThisDashboard) {
     this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
         return this;
     }
-    public PanelBuilder setOnlyInTimeRange(Boolean onlyInTimeRange) {
+    public PanelBuilder OnlyInTimeRange(Boolean onlyInTimeRange) {
     this.internal.onlyInTimeRange = onlyInTimeRange;
         return this;
     }
-    public PanelBuilder setTags(List<String> tags) {
+    public PanelBuilder Tags(List<String> tags) {
     this.internal.tags = tags;
         return this;
     }
-    public PanelBuilder setLimit(Integer limit) {
+    public PanelBuilder Limit(Integer limit) {
     this.internal.limit = limit;
         return this;
     }
-    public PanelBuilder setShowUser(Boolean showUser) {
+    public PanelBuilder ShowUser(Boolean showUser) {
     this.internal.showUser = showUser;
         return this;
     }
-    public PanelBuilder setShowTime(Boolean showTime) {
+    public PanelBuilder ShowTime(Boolean showTime) {
     this.internal.showTime = showTime;
         return this;
     }
-    public PanelBuilder setShowTags(Boolean showTags) {
+    public PanelBuilder ShowTags(Boolean showTags) {
     this.internal.showTags = showTags;
         return this;
     }
-    public PanelBuilder setNavigateToPanel(Boolean navigateToPanel) {
+    public PanelBuilder NavigateToPanel(Boolean navigateToPanel) {
     this.internal.navigateToPanel = navigateToPanel;
         return this;
     }
-    public PanelBuilder setNavigateBefore(String navigateBefore) {
+    public PanelBuilder NavigateBefore(String navigateBefore) {
     this.internal.navigateBefore = navigateBefore;
         return this;
     }
-    public PanelBuilder setNavigateAfter(String navigateAfter) {
+    public PanelBuilder NavigateAfter(String navigateAfter) {
     this.internal.navigateAfter = navigateAfter;
         return this;
     }

--- a/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
+++ b/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
@@ -11,7 +11,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setId(Long id) {
+    public Builder Id(Long id) {
     this.internal.id = id;
         return this;
     }

--- a/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
+++ b/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
@@ -11,7 +11,7 @@ public class Person {
         public Builder() {
             this.internal = new Person();
         }
-    public Builder setName(Name name) {
+    public Builder Name(Name name) {
     this.internal.name = name;
         return this;
     }

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -10,7 +10,7 @@ public class SomeStruct {
         public Builder() {
             this.internal = new SomeStruct();
         }
-    public Builder setTime(String from,String to) {
+    public Builder Time(String from,String to) {
 		if (this.internal.time == null) {
 			this.internal.time = new Object();
 		}

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
@@ -11,12 +11,12 @@ public class NestedStruct {
         public Builder() {
             this.internal = new NestedStruct();
         }
-    public Builder setStringVal(String stringVal) {
+    public Builder StringVal(String stringVal) {
     this.internal.stringVal = stringVal;
         return this;
     }
     
-    public Builder setIntVal(Long intVal) {
+    public Builder IntVal(Long intVal) {
     this.internal.intVal = intVal;
         return this;
     }

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
@@ -14,36 +14,36 @@ public class Struct {
         public Builder() {
             this.internal = new Struct();
         NestedStruct.Builder nestedStructResource = new NestedStruct.Builder();
-        nestedStructResource.setStringVal("hello");
-        nestedStructResource.setIntVal(3L);
-        this.setAllFields(nestedStructResource);
+        nestedStructResource.StringVal("hello");
+        nestedStructResource.IntVal(3L);
+        this.AllFields(nestedStructResource);
         NestedStruct.Builder nestedStructResource = new NestedStruct.Builder();
-        nestedStructResource.setIntVal(4L);
-        this.setPartialFields(nestedStructResource);
-        this.setComplexField(new Object());
-        this.setPartialComplexField(new Object());
+        nestedStructResource.IntVal(4L);
+        this.PartialFields(nestedStructResource);
+        this.ComplexField(new Object());
+        this.PartialComplexField(new Object());
         }
-    public Builder setAllFields(cog.Builder<NestedStruct> allFields) {
+    public Builder AllFields(cog.Builder<NestedStruct> allFields) {
     this.internal.allFields = allFields.build();
         return this;
     }
     
-    public Builder setPartialFields(cog.Builder<NestedStruct> partialFields) {
+    public Builder PartialFields(cog.Builder<NestedStruct> partialFields) {
     this.internal.partialFields = partialFields.build();
         return this;
     }
     
-    public Builder setEmptyFields(cog.Builder<NestedStruct> emptyFields) {
+    public Builder EmptyFields(cog.Builder<NestedStruct> emptyFields) {
     this.internal.emptyFields = emptyFields.build();
         return this;
     }
     
-    public Builder setComplexField(Object complexField) {
+    public Builder ComplexField(Object complexField) {
     this.internal.complexField = complexField;
         return this;
     }
     
-    public Builder setPartialComplexField(Object partialComplexField) {
+    public Builder PartialComplexField(Object partialComplexField) {
     this.internal.partialComplexField = partialComplexField;
         return this;
     }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/DashboardCursorSync.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/DashboardCursorSync.java
@@ -15,7 +15,7 @@ public enum DashboardCursorSync {
         this.value = value;
     }
 
-    public Integer getValue() {
+    public Integer Value() {
         return value;
     }
 }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/LogsSortOrder.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/LogsSortOrder.java
@@ -11,7 +11,7 @@ public enum LogsSortOrder {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/Operator.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/Operator.java
@@ -12,7 +12,7 @@ public enum Operator {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/TableSortOrder.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/TableSortOrder.java
@@ -11,7 +11,7 @@ public enum TableSortOrder {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStructOperator.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStructOperator.java
@@ -11,7 +11,7 @@ public enum SomeStructOperator {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStructOperator.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStructOperator.java
@@ -11,7 +11,7 @@ public enum SomeStructOperator {
         this.value = value;
     }
 
-    public String getValue() {
+    public String Value() {
         return value;
     }
 }


### PR DESCRIPTION
Since we don't have getters/setters it doesn't have sense to have the setter prefix.