### PR TITLE
Java: Fix dataquery implementations

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -52,14 +52,15 @@ func (b Builders) genBuilders(pkg string, name string) ([]Builder, bool) {
 	return tools.Map(builders, func(builder ast.Builder) Builder {
 		object, _ := b.context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
 		return Builder{
-			Package:     b.typeFormatter.formatPackage(pkg),
-			ObjectName:  tools.UpperCamelCase(object.Name),
-			BuilderName: builder.Name,
-			Constructor: builder.Constructor,
-			Options:     builder.Options,
-			Properties:  builder.Properties,
-			Defaults:    b.genDefaults(builder.Options),
-			ImportAlias: b.config.PackagePath,
+			Package:              b.typeFormatter.formatPackage(pkg),
+			ObjectName:           tools.UpperCamelCase(object.Name),
+			BuilderName:          builder.Name,
+			BuilderSignatureType: b.getBuilderSignature(builder, object),
+			Constructor:          builder.Constructor,
+			Options:              builder.Options,
+			Properties:           builder.Properties,
+			Defaults:             b.genDefaults(builder.Options),
+			ImportAlias:          b.config.PackagePath,
 		}
 	}), true
 }
@@ -85,6 +86,14 @@ func (b Builders) getBuilders(pkg string, name string) ast.Builders {
 	}
 
 	return builderMap[name]
+}
+
+func (b Builders) getBuilderSignature(builder ast.Builder, obj ast.Object) string {
+	if builder.Name != obj.Type.ImplementedVariant() {
+		return builder.Name
+	}
+
+	return fmt.Sprintf("%s.%s", b.typeFormatter.formatPackage("cog.variants"), tools.UpperCamelCase(obj.Name))
 }
 
 func (b Builders) genDefaults(options []ast.Option) []OptionCall {

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -90,7 +90,7 @@ func (b Builders) getBuilders(pkg string, name string) ast.Builders {
 
 func (b Builders) getBuilderSignature(builder ast.Builder, obj ast.Object) string {
 	if builder.Name != obj.Type.ImplementedVariant() {
-		return builder.Name
+		return obj.Name
 	}
 
 	return fmt.Sprintf("%s.%s", b.typeFormatter.formatPackage("cog.variants"), tools.UpperCamelCase(obj.Name))

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -1,5 +1,5 @@
 {{- define "builder" }}
-    public static class {{ .BuilderName }}Builder implements {{ if not (eq .Builder.ImportAlias "") }}{{ .Builder.ImportAlias }}.{{ end }}cog.Builder<{{ .Builder.ObjectName }}> {
+    public static class {{ .BuilderName }}Builder implements {{ if not (eq .Builder.ImportAlias "") }}{{ .Builder.ImportAlias }}.{{ end }}cog.Builder<{{ .Builder.BuilderSignatureType }}> {
         private {{ .Builder.ObjectName }} internal;
         
         {{- range .Builder.Properties }}


### PR DESCRIPTION
It adds the package prefix to Dataquery builders implementations when it's the same name than the class name, to point to the variant's Dataquery.