### PR TITLE
Java: Initialise properties and null-checks

### DIFF
--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -11,6 +11,10 @@
         {{- range .Builder.Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
         {{- end }}
+        
+        {{- range .Builder.Properties }}
+        this.{{ .Name | escapeVar }} = {{ .Type | emptyValueForType }};
+        {{- end }}
 
         {{- range .Builder.Defaults }}
         {{- range .Initializers }}

--- a/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
+++ b/internal/jennies/java/templates/veneers/assigment_Dashboard_WithPanel.tmpl
@@ -5,7 +5,7 @@
     }
     // The panel either has no position set, or it is the first panel of the dashboard.
     // In that case, we position it on the grid
-    if (panelOrRowPanel.panel.gridPos.x == 0 && panelOrRowPanel.panel.gridPos.y == 0) {
+    if ((panelOrRowPanel.panel.gridPos.x == null || panelOrRowPanel.panel.gridPos.x == 0) && (panelOrRowPanel.panel.gridPos.y == null || panelOrRowPanel.panel.gridPos.y == 0)) {
         panelOrRowPanel.panel.gridPos.x = this.currentX;
         panelOrRowPanel.panel.gridPos.y = this.currentY;
     }

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -150,6 +150,25 @@ func (tf *typeFormatter) defaultValueFor(def ast.Type) string {
 		return fmt.Sprintf("new %s()", tf.formatPackage(refDef))
 	case ast.KindStruct:
 		return "new Object()"
+	case ast.KindScalar:
+		switch def.AsScalar().ScalarKind {
+		case ast.KindBool:
+			return "false"
+		case ast.KindFloat32:
+			return "0.0f"
+		case ast.KindFloat64:
+			return "0.0"
+		case ast.KindInt8, ast.KindUint8, ast.KindInt16, ast.KindUint16, ast.KindInt32, ast.KindUint32:
+			return "0"
+		case ast.KindInt64, ast.KindUint64:
+			return "0L"
+		case ast.KindString:
+			return ""
+		case ast.KindBytes:
+			return "(byte) 0"
+		default:
+			return "unknown"
+		}
 	default:
 		return "unknown"
 	}

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -163,7 +163,7 @@ func (tf *typeFormatter) defaultValueFor(def ast.Type) string {
 		case ast.KindInt64, ast.KindUint64:
 			return "0L"
 		case ast.KindString:
-			return ""
+			return `""`
 		case ast.KindBytes:
 			return "(byte) 0"
 		default:

--- a/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
+++ b/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
@@ -10,6 +10,7 @@ public class SomeStruct {
         
         public Builder() {
             this.internal = new SomeStruct();
+        this.someBuilderProperty = "";
         }
     public Builder Id(Long id) {
     this.internal.id = id;


### PR DESCRIPTION
There are some NPE with properties because aren't initialised and veneer template needs some null-checks.