### PR TITLE
Language/php register dataquery variants

### DIFF
--- a/internal/ast/compiler/cloudwatch.go
+++ b/internal/ast/compiler/cloudwatch.go
@@ -69,6 +69,7 @@ func (pass *Cloudwatch) processSchema(schema *ast.Schema) (*ast.Schema, error) {
 
 	schema.AddObject(entrypoint)
 	schema.EntryPoint = entrypoint.Name
+	schema.EntryPointType = entrypoint.SelfRef.AsType()
 
 	return schema, nil
 }

--- a/internal/ast/compiler/cloudwatch.go
+++ b/internal/ast/compiler/cloudwatch.go
@@ -65,7 +65,10 @@ func (pass *Cloudwatch) processSchema(schema *ast.Schema) (*ast.Schema, error) {
 		return object
 	})
 
-	schema.AddObject(pass.defineQueryDisjunction(schema))
+	entrypoint := pass.defineQueryDisjunction(schema)
+
+	schema.AddObject(entrypoint)
+	schema.EntryPoint = entrypoint.Name
 
 	return schema, nil
 }

--- a/internal/ast/compiler/dataquery_identification.go
+++ b/internal/ast/compiler/dataquery_identification.go
@@ -47,6 +47,7 @@ func (pass *DataqueryIdentification) processSchema(schema *ast.Schema, commonDat
 
 	if schema.EntryPoint == "" && len(variantObjects) == 1 {
 		schema.EntryPoint = variantObjects[0]
+		schema.EntryPointType = schema.Objects.Get(variantObjects[0]).SelfRef.AsType()
 	}
 
 	return schema

--- a/internal/ast/compiler/infer_entrypoint.go
+++ b/internal/ast/compiler/infer_entrypoint.go
@@ -18,6 +18,9 @@ func (pass *InferEntrypoint) Process(schemas []*ast.Schema) ([]*ast.Schema, erro
 		}
 
 		schema.EntryPoint = pass.inferEntrypoint(schema)
+		if schema.EntryPoint != "" {
+			schema.EntryPointType = schema.Objects.Get(schema.EntryPoint).SelfRef.AsType()
+		}
 	}
 
 	return schemas, nil

--- a/internal/ast/compiler/visitor.go
+++ b/internal/ast/compiler/visitor.go
@@ -68,6 +68,11 @@ func (visitor *Visitor) VisitSchema(schema *ast.Schema) (*ast.Schema, error) {
 	var err error
 	var obj ast.Object
 
+	newSchema.EntryPointType, err = visitor.VisitType(schema, schema.EntryPointType)
+	if err != nil {
+		return nil, fmt.Errorf("could not process entrypoint type")
+	}
+
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
 		if err != nil {
 			return

--- a/internal/ast/schema.go
+++ b/internal/ast/schema.go
@@ -1,7 +1,6 @@
 package ast
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 
@@ -99,10 +98,11 @@ func (schemas Schemas) DeepCopy() []*Schema {
 }
 
 type Schema struct { //nolint: musttag
-	Package    string
-	Metadata   SchemaMeta `json:",omitempty"`
-	EntryPoint string     `json:",omitempty"`
-	Objects    *orderedmap.Map[string, Object]
+	Package        string
+	Metadata       SchemaMeta `json:",omitempty"`
+	EntryPoint     string     `json:",omitempty"`
+	EntryPointType Type       `json:",omitempty"`
+	Objects        *orderedmap.Map[string, Object]
 }
 
 func NewSchema(pkg string, metadata SchemaMeta) *Schema {
@@ -137,7 +137,10 @@ func (schema *Schema) Merge(other *Schema) error {
 	}
 
 	if schema.EntryPoint != other.EntryPoint && (schema.EntryPoint == "" || other.EntryPoint == "") {
-		schema.EntryPoint = cmp.Or(schema.EntryPoint, other.EntryPoint)
+		if schema.EntryPoint == "" {
+			schema.EntryPoint = other.EntryPoint
+			schema.EntryPointType = other.EntryPointType
+		}
 	}
 
 	var err error
@@ -162,9 +165,10 @@ func (schema *Schema) Merge(other *Schema) error {
 
 func (schema *Schema) DeepCopy() Schema {
 	return Schema{
-		Package:    schema.Package,
-		Metadata:   schema.Metadata,
-		EntryPoint: schema.EntryPoint,
+		Package:        schema.Package,
+		Metadata:       schema.Metadata,
+		EntryPoint:     schema.EntryPoint,
+		EntryPointType: schema.EntryPointType,
 		Objects: schema.Objects.Map(func(_ string, object Object) Object {
 			return object.DeepCopy()
 		}),

--- a/internal/ast/schema.go
+++ b/internal/ast/schema.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 
@@ -135,6 +136,10 @@ func (schema *Schema) Merge(other *Schema) error {
 		return fmt.Errorf("conflicting metadata: %w", ErrCannotMergeSchemas)
 	}
 
+	if schema.EntryPoint != other.EntryPoint && (schema.EntryPoint == "" || other.EntryPoint == "") {
+		schema.EntryPoint = cmp.Or(schema.EntryPoint, other.EntryPoint)
+	}
+
 	var err error
 	other.Objects.Iterate(func(objectName string, remoteObject Object) {
 		if !schema.Objects.Has(objectName) {
@@ -157,8 +162,9 @@ func (schema *Schema) Merge(other *Schema) error {
 
 func (schema *Schema) DeepCopy() Schema {
 	return Schema{
-		Package:  schema.Package,
-		Metadata: schema.Metadata,
+		Package:    schema.Package,
+		Metadata:   schema.Metadata,
+		EntryPoint: schema.EntryPoint,
 		Objects: schema.Objects.Map(func(_ string, object Object) Object {
 			return object.DeepCopy()
 		}),

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -243,7 +243,6 @@ final class VariantConfig
 	)
 
 	return codejen.NewFile(filename, []byte(content), jenny)
-
 }
 
 func (jenny RawTypes) generateConstructor(context languages.Context, def ast.Object) string {

--- a/internal/jennies/php/templates/runtime/runtime.tmpl
+++ b/internal/jennies/php/templates/runtime/runtime.tmpl
@@ -21,6 +21,10 @@ final class Runtime
 {{- range $schema := .PanelSchemas }}
         $this->registerPanelcfgVariant(\{{ $.NamespaceRoot }}\{{ $schema.Package|formatPackageName }}\VariantConfig::get());
 {{- end }}
+
+{{- range $schema := .DataquerySchemas }}
+        $this->registerDataqueryVariant(\{{ $.NamespaceRoot }}\{{ $schema.Package|formatPackageName }}\VariantConfig::get());
+{{- end }}
     }
 
     public static function get(): self

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -78,6 +78,7 @@ func GenerateAST(schemaReader io.Reader, c Config) (*ast.Schema, error) {
 	}
 
 	g.schema.EntryPoint = rootObjectName
+	g.schema.EntryPointType = g.schema.Objects.Get(rootObjectName).SelfRef.AsType()
 
 	// To ensure a consistent output, since github.com/santhosh-tekuri/jsonschema
 	// doesn't guarantee the order of the definitions it parses.

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -153,6 +153,7 @@ func (g *generator) walkCueSchemaWithEnvelope(envelopeName string, v cue.Value) 
 	})
 
 	g.schema.EntryPoint = envelopeName
+	g.schema.EntryPointType = g.schema.Objects.Get(envelopeName).SelfRef.AsType()
 
 	return nil
 }

--- a/testdata/jsonschema/allof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/allof_object/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "Entry",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "Entry"
+    }
+  },
   "Objects": {
     "AllOf": {
       "Name": "AllOf",

--- a/testdata/jsonschema/anyof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_object/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "AnyOf",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "AnyOf"
+    }
+  },
   "Objects": {
     "AnyOf": {
       "Name": "AnyOf",

--- a/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/anyof_struct_field/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "AnyOfField",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "AnyOfField"
+    }
+  },
   "Objects": {
     "AnyOfField": {
       "Name": "AnyOfField",

--- a/testdata/jsonschema/array_any/GenerateAST/ir.json
+++ b/testdata/jsonschema/array_any/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/basic_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/basic_object/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/consts/GenerateAST/ir.json
+++ b/testdata/jsonschema/consts/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/defaults/GenerateAST/ir.json
+++ b/testdata/jsonschema/defaults/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/enum/GenerateAST/ir.json
+++ b/testdata/jsonschema/enum/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
+++ b/testdata/jsonschema/influxdbquery/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "InfluxQuery",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "InfluxQuery"
+    }
+  },
   "Objects": {
     "AdHocVariableFilter": {
       "Name": "AdHocVariableFilter",

--- a/testdata/jsonschema/number_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/number_constraints/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
+++ b/testdata/jsonschema/object_no_properties/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "Entrypoint",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "Entrypoint"
+    }
+  },
   "Objects": {
     "Entrypoint": {
       "Name": "Entrypoint",

--- a/testdata/jsonschema/oneof_object/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_object/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "Entry",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "Entry"
+    }
+  },
   "Objects": {
     "Entry": {
       "Name": "Entry",

--- a/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/oneof_struct_field/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "OneOfField",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "OneOfField"
+    }
+  },
   "Objects": {
     "OneOfField": {
       "Name": "OneOfField",

--- a/testdata/jsonschema/recursive/GenerateAST/ir.json
+++ b/testdata/jsonschema/recursive/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "Node",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "Node"
+    }
+  },
   "Objects": {
     "Node": {
       "Name": "Node",

--- a/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
+++ b/testdata/jsonschema/ref_struct_field/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "grafanatest",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "grafanatest"
+    }
+  },
   "Objects": {
     "grafanatest": {
       "Name": "grafanatest",

--- a/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
+++ b/testdata/jsonschema/string_length_constraints/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/jsonschema/time/GenerateAST/ir.json
+++ b/testdata/jsonschema/time/GenerateAST/ir.json
@@ -2,6 +2,14 @@
   "Package": "grafanatest",
   "Metadata": {},
   "EntryPoint": "SomeObject",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "SomeObject"
+    }
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/openapi/arrays/GenerateAST/ir.json
+++ b/testdata/openapi/arrays/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Arrays": {
       "Name": "Arrays",

--- a/testdata/openapi/consts/GenerateAST/ir.json
+++ b/testdata/openapi/consts/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Constants": {
       "Name": "Constants",

--- a/testdata/openapi/datatypes/GenerateAST/ir.json
+++ b/testdata/openapi/datatypes/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "DataTypes": {
       "Name": "DataTypes",

--- a/testdata/openapi/defaults/GenerateAST/ir.json
+++ b/testdata/openapi/defaults/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Array": {
       "Name": "Array",

--- a/testdata/openapi/discriminator/GenerateAST/ir.json
+++ b/testdata/openapi/discriminator/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Discriminator": {
       "Name": "Discriminator",

--- a/testdata/openapi/enums/GenerateAST/ir.json
+++ b/testdata/openapi/enums/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Enums": {
       "Name": "Enums",

--- a/testdata/openapi/external_refs/GenerateAST/ir.json
+++ b/testdata/openapi/external_refs/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "WithOneRef": {
       "Name": "WithOneRef",

--- a/testdata/openapi/intersections/GenerateAST/ir.json
+++ b/testdata/openapi/intersections/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Enum": {
       "Name": "Enum",

--- a/testdata/openapi/nested_structs/GenerateAST/ir.json
+++ b/testdata/openapi/nested_structs/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Nested": {
       "Name": "Nested",

--- a/testdata/openapi/object_no_properties/GenerateAST/ir.json
+++ b/testdata/openapi/object_no_properties/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "ObjectAdditionalPropertiesWithSchema": {
       "Name": "ObjectAdditionalPropertiesWithSchema",

--- a/testdata/openapi/refs/GenerateAST/ir.json
+++ b/testdata/openapi/refs/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Refs": {
       "Name": "Refs",

--- a/testdata/openapi/split_schema/GenerateAST/ir.json
+++ b/testdata/openapi/split_schema/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Array": {
       "Name": "Array",

--- a/testdata/openapi/time/GenerateAST/ir.json
+++ b/testdata/openapi/time/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "SomeObject": {
       "Name": "SomeObject",

--- a/testdata/simplecue/arrays/GenerateAST/ir.json
+++ b/testdata/simplecue/arrays/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "refStruct": {
       "Name": "refStruct",

--- a/testdata/simplecue/common_timezone_disjunction/GenerateAST/ir.json
+++ b/testdata/simplecue/common_timezone_disjunction/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "TimeZoneUtc": {
       "Name": "TimeZoneUtc",

--- a/testdata/simplecue/defaults/GenerateAST/ir.json
+++ b/testdata/simplecue/defaults/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "StringEnum": {
       "Name": "StringEnum",

--- a/testdata/simplecue/defaults_on_struct/GenerateAST/ir.json
+++ b/testdata/simplecue/defaults_on_struct/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "Enum": {
       "Name": "Enum",

--- a/testdata/simplecue/disjunctions/GenerateAST/ir.json
+++ b/testdata/simplecue/disjunctions/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "container": {
       "Name": "container",

--- a/testdata/simplecue/enums/GenerateAST/ir.json
+++ b/testdata/simplecue/enums/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "IntEnum": {
       "Name": "IntEnum",

--- a/testdata/simplecue/maps/GenerateAST/ir.json
+++ b/testdata/simplecue/maps/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "intStringMap": {
       "Name": "intStringMap",

--- a/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
+++ b/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "HelloMsg": {
       "Name": "HelloMsg",

--- a/testdata/simplecue/numbers_constraints/GenerateAST/ir.json
+++ b/testdata/simplecue/numbers_constraints/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "container": {
       "Name": "container",

--- a/testdata/simplecue/refs/GenerateAST/ir.json
+++ b/testdata/simplecue/refs/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "IntEnum": {
       "Name": "IntEnum",

--- a/testdata/simplecue/scalars/GenerateAST/ir.json
+++ b/testdata/simplecue/scalars/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "container": {
       "Name": "container",

--- a/testdata/simplecue/strings_constraints/GenerateAST/ir.json
+++ b/testdata/simplecue/strings_constraints/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "container": {
       "Name": "container",

--- a/testdata/simplecue/time/GenerateAST/ir.json
+++ b/testdata/simplecue/time/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "User": {
       "Name": "User",

--- a/testdata/simplecue/unifications/GenerateAST/ir.json
+++ b/testdata/simplecue/unifications/GenerateAST/ir.json
@@ -1,6 +1,10 @@
 {
   "Package": "grafanatest",
   "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
   "Objects": {
     "InlineScript": {
       "Name": "InlineScript",


### PR DESCRIPTION
Generate a variantconfig for dataqueries, and automatically register it into the runtime.

Contributes to #470 