### PR TITLE
Java: Fix aliases

### DIFF
--- a/internal/ast/compiler/remove_intersections.go
+++ b/internal/ast/compiler/remove_intersections.go
@@ -79,13 +79,14 @@ func (r RemoveIntersections) processObject(_ *Visitor, schema *ast.Schema, objec
 		r.arraysToFix[object.Name] = locatedObject
 	}
 
+	// TODO: Check if a reference extends from a Map if necessary
+
 	return object, nil
 }
 
 func (r RemoveIntersections) processStruct(_ *Visitor, _ *ast.Schema, def ast.Type) (ast.Type, error) {
 	str := def.AsStruct()
 	for i, field := range str.Fields {
-		// TODO: Add Map/List checks if necessary
 		if field.Type.IsRef() {
 			if obj, ok := r.objectsToRemove[field.Type.AsRef().ReferredType]; ok {
 				def.AsStruct().Fields[i] = ast.NewStructField(field.Name, ast.NewRef(obj.SelfRef.ReferredPkg, obj.SelfRef.ReferredType), ast.Comments(obj.Comments))

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -87,9 +87,7 @@ func (tf *typeFormatter) formatMap(def ast.MapType) string {
 	mapType := "unknown"
 	switch def.ValueType.Kind {
 	case ast.KindRef:
-		ref := def.ValueType.AsRef()
-		tf.packageMapper(ref.ReferredPkg, ref.ReferredType)
-		mapType = ref.ReferredType
+		mapType = tf.formatReference(def.ValueType.AsRef())
 	case ast.KindScalar:
 		mapType = formatScalarType(def.ValueType.AsScalar())
 	case ast.KindMap:


### PR DESCRIPTION
This PR fixes some issues when we a class extends from a List and, in that case, we want to use the list directly. This is was working as an alias that didn't work because extending from a list/map needs extra implementations.

Apart of this, it fixes the case when a map value is ref of an `any` scalar.