### PR TITLE
Fix constants generation in PHP

### DIFF
--- a/examples/php/index.php
+++ b/examples/php/index.php
@@ -5,6 +5,7 @@ use App\Monitoring\Disk;
 use App\Monitoring\Logs;
 use App\Monitoring\Memory;
 use App\Monitoring\Network;
+use Grafana\Foundation\Common;
 use Grafana\Foundation\Dashboard\DashboardBuilder;
 use Grafana\Foundation\Dashboard\DashboardCursorSync;
 use Grafana\Foundation\Dashboard\DataSourceRef;
@@ -24,7 +25,7 @@ $builder = (new DashboardBuilder(title: '[TEST] Node Exporter / Raspberry'))
     ->tags(['generated', 'raspberrypi-node-integration'])
     ->refresh('30s')
     ->time('now-30m', 'now')
-    //->timezone(\Grafana\Foundation\Common\TIME_ZONE_BROWSER) // TODO: const + autoloading issues?
+    ->timezone(Common\Constants::TIME_ZONE_BROWSER)
     ->timepicker(
         (new TimePickerBuilder())
             ->refreshIntervals(['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'])

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/ConnectionPath.php
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/ConnectionPath.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Grafana\Foundation\StructComplexFields;
-
-const CONNECTION_PATH = "straight";

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/Constants.php
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/Constants.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Grafana\Foundation\StructComplexFields;
+
+final class Constants
+{
+    const CONNECTION_PATH = "straight";
+}


### PR DESCRIPTION
In PHP, constants can't be autoloaded if they're not defined within a class.

Contributes to #470 