### PR TITLE
Update the foundation-sdk maturity statement to "public preview"

### DIFF
--- a/package_templates/go/README.md
+++ b/package_templates/go/README.md
@@ -362,24 +362,12 @@ func main() {
 
 ## Maturity
 
-> [!WARNING]
-> The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue.
+The code in this repository should be considered as "public preview" and is actively developed and maintained by Engineering teams at Grafana.
 
-Grafana Labs defines experimental features as follows:
+While this repository is stable enough to be used in production environments, occasional breaking changes can be expected.
 
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
+> [!NOTE]
+> Bugs and issues are handled solely by Engineering teams. On-call support or SLAs are not available.
 
 ## License
 

--- a/package_templates/python/README.md
+++ b/package_templates/python/README.md
@@ -294,24 +294,12 @@ if __name__ == '__main__':
 
 ## Maturity
 
-> [!WARNING]
-> The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue.
+The code in this repository should be considered as "public preview" and is actively developed and maintained by Engineering teams at Grafana.
 
-Grafana Labs defines experimental features as follows:
+While this repository is stable enough to be used in production environments, occasional breaking changes can be expected.
 
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
+> [!NOTE]
+> Bugs and issues are handled solely by Engineering teams. On-call support or SLAs are not available.
 
 ## License
 

--- a/package_templates/typescript/README.md
+++ b/package_templates/typescript/README.md
@@ -185,24 +185,12 @@ console.log(JSON.stringify(builder.build(), null, 2));
 
 ## Maturity
 
-> [!WARNING]
-> The code in this repository should be considered experimental. Documentation is only
-available alongside the code. It comes with no support, but we are keen to receive
-feedback and suggestions on how to improve it, though we cannot commit
-to resolution of any particular issue.
+The code in this repository should be considered as "public preview" and is actively developed and maintained by Engineering teams at Grafana.
 
-Grafana Labs defines experimental features as follows:
+While this repository is stable enough to be used in production environments, occasional breaking changes can be expected.
 
-> Projects and features in the Experimental stage are supported only by the Engineering
-teams; on-call support is not available. Documentation is either limited or not provided
-outside of code comments. No SLA is provided.
->
-> Experimental projects or features are primarily intended for open source engineers who
-want to participate in ensuring systems stability, and to gain consensus and approval
-for open source governance projects.
->
-> Projects and features in the Experimental phase are not meant to be used in production
-environments, and the risks are unknown/high.
+> [!NOTE]
+> Bugs and issues are handled solely by Engineering teams. On-call support or SLAs are not available.
 
 ## License
 


### PR DESCRIPTION
Let's update the maturity statement displayed in the foundation-sdk to something less scary, reflecting the actual state of the sdk.