### PR TITLE
Fix PHP CI in foundation-sdk

### DIFF
--- a/repository_templates/php/.github/workflows/php-ci.yaml
+++ b/repository_templates/php/.github/workflows/php-ci.yaml
@@ -26,9 +26,7 @@ jobs:
           ini-values: opcache.enable_cli=1
 
       - name: Install dependencies
-        run: |
-          cd php
-          composer install
+        run: composer install
 
       - name: Lint generated PHP code with phpstan
         run: phpstan analyze --memory-limit 256M -c .config/ci/php/phpstan.neon


### PR DESCRIPTION
The composer.json file moved in https://github.com/grafana/cog/pull/492

Contributes to #470