### PR TITLE
Java: Marshalling

### DIFF
--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -1,0 +1,22 @@
+package java
+
+import (
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+func genToJSONFunction(t ast.Type) string {
+	var buffer strings.Builder
+	if t.IsStructGeneratedFromDisjunction() {
+		if t.IsStruct() && (t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) || t.HasHint(ast.HintDisjunctionOfScalars)) {
+			_ = templates.ExecuteTemplate(&buffer, "marshalling/disjunctions.json_marshall.tmpl", map[string]any{
+				"Fields": t.AsStruct().Fields,
+			})
+			return buffer.String()
+		}
+	}
+
+	_ = templates.ExecuteTemplate(&buffer, "marshalling/marshalling.tmpl", map[string]any{})
+	return buffer.String()
+}

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -6,12 +6,12 @@ import (
 	"github.com/grafana/cog/internal/ast"
 )
 
-type JsonMarshaller struct {
+type JSONMarshaller struct {
 	config        Config
 	typeFormatter *typeFormatter
 }
 
-func (j JsonMarshaller) genToJSONFunction(t ast.Type) string {
+func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	if !j.config.generateBuilders || j.config.SkipRuntime || !j.config.GeneratePOM {
 		return ""
 	}
@@ -33,7 +33,7 @@ func (j JsonMarshaller) genToJSONFunction(t ast.Type) string {
 	return buffer.String()
 }
 
-func (j JsonMarshaller) annotation(t ast.Type) string {
+func (j JSONMarshaller) annotation(t ast.Type) string {
 	if !j.config.generateBuilders || j.config.SkipRuntime || !j.config.GeneratePOM {
 		return ""
 	}

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -12,7 +12,7 @@ type JsonMarshaller struct {
 }
 
 func (j JsonMarshaller) genToJSONFunction(t ast.Type) string {
-	if !j.config.GeneratePOM {
+	if !j.config.generateBuilders || j.config.SkipRuntime || !j.config.GeneratePOM {
 		return ""
 	}
 
@@ -34,7 +34,7 @@ func (j JsonMarshaller) genToJSONFunction(t ast.Type) string {
 }
 
 func (j JsonMarshaller) annotation(t ast.Type) string {
-	if !j.config.GeneratePOM {
+	if !j.config.generateBuilders || j.config.SkipRuntime || !j.config.GeneratePOM {
 		return ""
 	}
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -224,6 +224,7 @@ func (jenny RawTypes) formatStruct(pkg string, object ast.Object) ([]byte, error
 		Builders:             builders,
 		HasBuilder:           hasBuilder,
 		ShouldAddMarshalling: jenny.config.GeneratePOM,
+		ToJSONFunction:       genToJSONFunction(object.Type),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -19,7 +19,7 @@ type RawTypes struct {
 
 	typeFormatter  *typeFormatter
 	builders       Builders
-	jsonMarshaller JsonMarshaller
+	jsonMarshaller JSONMarshaller
 }
 
 func (jenny RawTypes) JennyName() string {
@@ -31,7 +31,7 @@ func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error)
 	jenny.imports = NewImportMap(jenny.config.PackagePath)
 	jenny.typeFormatter = createFormatter(context, jenny.config)
 	jenny.builders = parseBuilders(jenny.config, context, jenny.typeFormatter)
-	jenny.jsonMarshaller = JsonMarshaller{
+	jenny.jsonMarshaller = JSONMarshaller{
 		config:        jenny.config,
 		typeFormatter: jenny.typeFormatter,
 	}

--- a/internal/jennies/java/templates/marshalling/disjunctions.json_marshall.tmpl
+++ b/internal/jennies/java/templates/marshalling/disjunctions.json_marshall.tmpl
@@ -1,10 +1,11 @@
-public String ToJSON() throws JsonProcessingException {
-    {{- range .Fields }}
-    if ({{ .Name|lowerCamelCase }} != null) {
-        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
-        return ow.writeValueAsString({{ .Name|lowerCamelCase }});
+
+    public String ToJSON() throws JsonProcessingException {
+        {{- range .Fields }}
+        if ({{ .Name|lowerCamelCase }} != null) {
+            ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+            return ow.writeValueAsString({{ .Name|lowerCamelCase }});
+        }
+        {{- end }}
+        
+        return null;
     }
-    {{- end }}
-    
-    return null;
-}

--- a/internal/jennies/java/templates/marshalling/disjunctions.json_marshall.tmpl
+++ b/internal/jennies/java/templates/marshalling/disjunctions.json_marshall.tmpl
@@ -1,0 +1,10 @@
+public String ToJSON() throws JsonProcessingException {
+    {{- range .Fields }}
+    if ({{ .Name|lowerCamelCase }} != null) {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString({{ .Name|lowerCamelCase }});
+    }
+    {{- end }}
+    
+    return null;
+}

--- a/internal/jennies/java/templates/marshalling/marshalling.tmpl
+++ b/internal/jennies/java/templates/marshalling/marshalling.tmpl
@@ -1,0 +1,5 @@
+
+    public String ToJSON() throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(this);
+    }

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -10,9 +10,9 @@ package {{ .Package }};
 // {{ . }}
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements {{ .Variant }}{{ end }} {
-    {{- template "types" dict "Fields" .Fields "ShouldAddAnnotation" .ShouldAddMarshalling }}
+    {{- template "types" dict "Fields" .Fields "MarshallingConfig" .MarshallingConfig }}
 
-    {{- if and .ShouldAddMarshalling (not .Extends) }}
+    {{- if and .MarshallingConfig.ShouldAddMarshalling (not .Extends) }}
     {{ .ToJSONFunction }}
     {{- end }}
 
@@ -30,8 +30,8 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- range .Comments }}
     // {{ . }}
     {{- end }}
-    {{- if $.ShouldAddAnnotation }}
-    @JsonProperty("{{ .Name }}")
+    {{- if $.MarshallingConfig.ShouldAddMarshalling }}
+    {{ fillAnnotationPattern $.MarshallingConfig.Annotation .Name }}
     {{- end }}
     public {{ .Type }} {{ .Name | escapeVar }};
 

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -13,10 +13,7 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- template "types" dict "Fields" .Fields "ShouldAddAnnotation" .ShouldAddMarshalling }}
 
     {{- if and .ShouldAddMarshalling (not .Extends) }}
-    public String toJSON() throws JsonProcessingException {
-        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
-        return ow.writeValueAsString(this);
-    }
+    {{ .ToJSONFunction }}
     {{- end }}
 
     {{- if and .HasBuilder (not .Extends) }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -12,7 +12,7 @@ import (
 //nolint:gochecknoglobals
 var templates *template.Template
 
-//go:embed templates/runtime/*.tmpl templates/types/*.tmpl templates/veneers/*.tmpl
+//go:embed templates/runtime/*.tmpl templates/types/*.tmpl templates/veneers/*.tmpl templates/marshalling/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -94,6 +94,7 @@ type ClassTemplate struct {
 
 	Variant              string
 	ShouldAddMarshalling bool
+	ToJSONFunction       string
 }
 
 type Field struct {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -29,9 +29,10 @@ func init() {
 
 func functions() template.FuncMap {
 	return template.FuncMap{
-		"escapeVar":          escapeVarName,
-		"formatScalar":       formatScalar,
-		"lastPathIdentifier": lastPathIdentifier,
+		"escapeVar":             escapeVarName,
+		"formatScalar":          formatScalar,
+		"lastPathIdentifier":    lastPathIdentifier,
+		"fillAnnotationPattern": fillAnnotationPattern,
 		"lastItem": func(index int, values []EnumValue) bool {
 			return len(values)-1 == index
 		},
@@ -92,9 +93,9 @@ type ClassTemplate struct {
 	Builders   []Builder
 	HasBuilder bool
 
-	Variant              string
-	ShouldAddMarshalling bool
-	ToJSONFunction       string
+	Variant           string
+	MarshallingConfig MarshallingConfig
+	ToJSONFunction    string
 }
 
 type Field struct {
@@ -133,4 +134,9 @@ type OptionCall struct {
 	Initializers []string
 	OptionName   string
 	Args         []string
+}
+
+type MarshallingConfig struct {
+	ShouldAddMarshalling bool
+	Annotation           string
 }

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -90,3 +90,10 @@ func isReservedJavaKeyword(input string) bool {
 	}
 	return false
 }
+
+func fillAnnotationPattern(input string, value string) string {
+	if strings.Contains(input, "%#v") {
+		return fmt.Sprintf(input, value)
+	}
+	return input
+}


### PR DESCRIPTION
It fixes the marshalling for disjunctions (refs and scalars). For example, when you add a panel or a row inside panel's array in the dashboard, you are expecting to have the internal structure of a panel or row. In Java we were adding the whole disjunction struct adding extra values.

The expected behaviour is:
```json
{
  "panels": [{ "type": "row" }, { "type": "panel" }]
}
```

And in Java we had:
```json
"panels": [{"row": { "type": "row" }}, {"panel": { "type": "panel" }}]
```

And a Java example to see better what's the code is doing:
### Before
```java
public class StringOrMap {

    @JsonProperty("string")
    public String string;
    @JsonProperty("map")
    public Map<String, Object> map;

    public String toJSON() throws JsonProcessingException {
        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
        return ow.writeValueAsString(this);
    }
}
```

### After
```java
public class StringOrMap {

    @JsonUnwrapped
    public String string;
    @JsonUnwrapped
    public Map<String, Object> map;

    public String ToJSON() throws JsonProcessingException {
        if (string != null) {
            ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
            return ow.writeValueAsString(string);
        }
        if (map != null) {
            ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
            return ow.writeValueAsString(map);
        }

        return null;
    }
}
```