### PR TITLE
Correctly parse inline definitions in cue

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -299,6 +299,18 @@ func (g *generator) structFields(v cue.Value) ([]ast.StructField, error) {
 	for i, _ := v.Fields(cue.Optional(true), cue.Definitions(true)); i.Next(); {
 		fieldLabel := selectorLabel(i.Selector())
 
+		// inline definition
+		if i.FieldType().IsDefinition() {
+			obj, err := g.declareObject(fieldLabel, i.Value())
+			if err != nil {
+				return nil, err
+			}
+
+			g.schema.AddObject(obj)
+			continue
+		}
+
+		// "normal" field
 		node, err := g.declareNode(i.Value())
 		if err != nil {
 			return nil, err

--- a/testdata/simplecue/refs/GenerateAST/ir.json
+++ b/testdata/simplecue/refs/GenerateAST/ir.json
@@ -59,6 +59,32 @@
         "ReferredType": "IntEnum"
       }
     },
+    "SomeInlineDefinition": {
+      "Name": "SomeInlineDefinition",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "field",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "SomeInlineDefinition"
+      }
+    },
     "container": {
       "Name": "container",
       "Type": {
@@ -120,6 +146,18 @@
                 "Ref": {
                   "ReferredPkg": "grafanatest",
                   "ReferredType": "IntEnum"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "inline",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "SomeInlineDefinition"
                 }
               },
               "Required": true

--- a/testdata/simplecue/refs/schema.cue
+++ b/testdata/simplecue/refs/schema.cue
@@ -3,4 +3,10 @@
 container: {
     StringEnum: "foo" | "bar" | "baz"
     TheIntEnum: #IntEnum
+
+    #SomeInlineDefinition: {
+    	field: string
+    }
+
+    inline: #SomeInlineDefinition
 }


### PR DESCRIPTION
In cue, the following _inline_ definition is currently parsed as a field instead of an object:

```cue
container: {
    #SomeInlineDefinition: {
    	field: string
    }

    inline: #SomeInlineDefinition
}
```