### PR TITLE
Java: Fix enum unmarshalling

### DIFF
--- a/internal/jennies/java/templates/types/enum.tmpl
+++ b/internal/jennies/java/templates/types/enum.tmpl
@@ -1,8 +1,12 @@
 package {{ .Package }};
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 {{ range .Comments }}
 // {{ . }}
 {{- end }}
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum {{ .Name }} {
     {{- range $i, $val := .Values }}
     {{- if gt $i 0 }}, {{- end }}
@@ -10,12 +14,13 @@ public enum {{ .Name }} {
     {{- if lastItem $i $.Values }}; {{- end }}
     {{- end }}
 
-    private {{ .Type }} value;
+    private final {{ .Type }} value;
 
     private {{ .Name }}({{ .Type }} value) {
         this.value = value;
     }
 
+    @JsonValue
     public {{ .Type }} Value() {
         return value;
     }

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/CursorMode.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/CursorMode.java
@@ -1,17 +1,22 @@
 package constructor_initializations;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum CursorMode {
     OFF("off"),
     TOOLTIP("tooltip"),
     CROSSHAIR("crosshair");
 
-    private String value;
+    private final String value;
 
     private CursorMode(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/DashboardCursorSync.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/DashboardCursorSync.java
@@ -1,20 +1,25 @@
 package enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 
 // 0 for no shared crosshair or tooltip (default).
 // 1 for shared crosshair.
 // 2 for shared crosshair AND shared tooltip.
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum DashboardCursorSync {
     OFF(0),
     CROSSHAIR(1),
     TOOLTIP(2);
 
-    private Integer value;
+    private final Integer value;
 
     private DashboardCursorSync(Integer value) {
         this.value = value;
     }
 
+    @JsonValue
     public Integer Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/LogsSortOrder.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/LogsSortOrder.java
@@ -1,16 +1,21 @@
 package enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum LogsSortOrder {
     ASC("time_asc"),
     DESC("time_desc");
 
-    private String value;
+    private final String value;
 
     private LogsSortOrder(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/Operator.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/Operator.java
@@ -1,17 +1,22 @@
 package enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 
 // This is a very interesting string enum.
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum Operator {
     GREATER_THAN(">"),
     LESS_THAN("<");
 
-    private String value;
+    private final String value;
 
     private Operator(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/TableSortOrder.java
+++ b/testdata/jennies/rawtypes/enums/JavaRawTypes/enums/TableSortOrder.java
@@ -1,16 +1,21 @@
 package enums;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum TableSortOrder {
     ASC("asc"),
     DESC("desc");
 
-    private String value;
+    private final String value;
 
     private TableSortOrder(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStructOperator.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStructOperator.java
@@ -1,16 +1,21 @@
 package struct_complex_fields;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum SomeStructOperator {
     GREATER_THAN(">"),
     LESS_THAN("<");
 
-    private String value;
+    private final String value;
 
     private SomeStructOperator(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStructOperator.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStructOperator.java
@@ -1,16 +1,21 @@
 package struct_optional_fields;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum SomeStructOperator {
     GREATER_THAN(">"),
     LESS_THAN("<");
 
-    private String value;
+    private final String value;
 
     private SomeStructOperator(String value) {
         this.value = value;
     }
 
+    @JsonValue
     public String Value() {
         return value;
     }


### PR DESCRIPTION
It adds extra annotations in enums to be able to map a string/integer into a enum value. Additionally it adds the final modifier to avoid to indicate that the value is immutable.