### PR TITLE
Java: Add empty dataquery serializer

### DIFF
--- a/internal/jennies/java/registry.go
+++ b/internal/jennies/java/registry.go
@@ -37,10 +37,16 @@ func (jenny Registry) Generate(context languages.Context) (codejen.Files, error)
 		return nil, err
 	}
 
+	emptyDataquerySerializer, err := jenny.emptyDataquerySerializer()
+	if err != nil {
+		return nil, err
+	}
+
 	return codejen.Files{
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/PanelConfig.java"), panelRegistry, jenny),
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/Registry.java"), registry, jenny),
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/EmptyDataquery.java"), emptyDataquery, jenny),
+		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/EmptyDataquerySerializer.java"), emptyDataquerySerializer, jenny),
 	}, nil
 }
 
@@ -133,6 +139,17 @@ func (jenny Registry) formatPackage(pkg string) string {
 func (jenny Registry) emptyDataquery() ([]byte, error) {
 	buf := bytes.Buffer{}
 	if err := templates.ExecuteTemplate(&buf, "runtime/empty_dataquery.tmpl", map[string]any{
+		"Package": jenny.formatPackage("cog.variants"),
+	}); err != nil {
+		return nil, fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (jenny Registry) emptyDataquerySerializer() ([]byte, error) {
+	buf := bytes.Buffer{}
+	if err := templates.ExecuteTemplate(&buf, "runtime/empty_dataquery_serializer.tmpl", map[string]any{
 		"Package": jenny.formatPackage("cog.variants"),
 	}); err != nil {
 		return nil, fmt.Errorf("failed executing template: %w", err)

--- a/internal/jennies/java/templates/runtime/empty_dataquery.tmpl
+++ b/internal/jennies/java/templates/runtime/empty_dataquery.tmpl
@@ -1,10 +1,11 @@
-package com.grafana.foundation.cog.variants;
+package {{ .Package }};
 
-import com.grafana.foundation.elasticsearch.Dataquery;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class EmptyDataquery extends Dataquery {
+@JsonSerialize(using = EmptyDataquerySerializer.class)
+public class EmptyDataquery implements Dataquery {
     public final Map<String, Object> genericFields = new HashMap<>();
 }

--- a/internal/jennies/java/templates/runtime/empty_dataquery_serializer.tmpl
+++ b/internal/jennies/java/templates/runtime/empty_dataquery_serializer.tmpl
@@ -1,0 +1,14 @@
+package {{ .Package }};
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class EmptyDataquerySerializer extends JsonSerializer<EmptyDataquery> {
+    @Override
+    public void serialize(EmptyDataquery emptyDataquery, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeObject(emptyDataquery.genericFields);
+    }
+}


### PR DESCRIPTION
The empty dataquery (used when we receive an unknown dataquery) were mapped into an `elasticsearch` type 🤡 since a copy&paste issue.

This empty dataquery includes a generic map to save the information, but it was adding `genericFields` field into the json result.
With this change, it removes this field adding only the included values. 