### PR TITLE
Java: Fix release templates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,8 +94,6 @@ jobs:
           check-latest: true
       - name: Java setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        env:
-          CHECK_GENERATED_FILES: true
         with:
           gradle-version: '8.8'
 
@@ -170,8 +168,6 @@ jobs:
           check-latest: true
       - name: Java setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        env:
-          CHECK_GENERATED_FILES: true
         with:
           gradle-version: '8.8'
 

--- a/repository_templates/java/.github/workflows/java-ci.yaml
+++ b/repository_templates/java/.github/workflows/java-ci.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Java setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        env:
-          CHECK_GENERATED_FILES: true
         with:
           gradle-version: '8.8'
 

--- a/repository_templates/java/.github/workflows/java-ci.yaml
+++ b/repository_templates/java/.github/workflows/java-ci.yaml
@@ -16,6 +16,8 @@ jobs:
         working-directory: ./java
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Use Java SDK {{ `${{ env.JAVA_VERSION }}` }}
         uses: actions/setup-java@v4
         with:
@@ -23,10 +25,12 @@ jobs:
           distribution: 'temurin'
           check-latest: true
 
-      - name: Test and build Jar
+      - name: Java setup Gradle
         uses: gradle/actions/setup-gradle@v3
         env:
           CHECK_GENERATED_FILES: true
         with:
           gradle-version: '8.8'
+
+      - name: Java build
         run: gradle build

--- a/repository_templates/java/.github/workflows/java-release.yaml
+++ b/repository_templates/java/.github/workflows/java-release.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Java {{ `${{ env.JAVA_VERSION }}` }}
+      - name: Uses Java SDK {{ `${{ env.JAVA_VERSION }}` }}
         uses: actions/setup-java@v4
         with:
           java-version: {{ `${{ env.JAVA_VERSION }}` }}

--- a/repository_templates/java/.github/workflows/java-release.yaml
+++ b/repository_templates/java/.github/workflows/java-release.yaml
@@ -33,14 +33,17 @@ jobs:
           distribution: 'temurin'
           check-latest: true
 
-      - name: Publish package 📦
+      - name: Java setup gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: '8.8'
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+          
+      - name: Publish package 📦
         env:
           OSSRH_USERNAME: {{ `${{ secrets.OSSRH_USERNAME }}` }}
           OSSRH_PASSWORD: {{ `${{ secrets.OSSRH_PASSWORD }}` }}
           SIGNING_KEY: {{ `${{ secrets.SIGNING_KEY }}` }}
           SIGNING_PASSWORD: {{ `${{ secrets.SIGNING_PASSWORD }}` }}
+        run:
+          gradle publishToSonatype closeAndReleaseSonatypeStagingRepository
   


### PR DESCRIPTION
Missing `actions/checkout@v4` step and `gradle build` should be a different step.