### PR TITLE
Go: Use variants package for cogvariants.

### DIFF
--- a/internal/jennies/golang/runtime.go
+++ b/internal/jennies/golang/runtime.go
@@ -46,7 +46,7 @@ type Builder[ResourceT any] interface {
 
 func (jenny Runtime) Runtime() (string, error) {
 	imports := NewImportMap()
-	imports.Add("cogvariants", jenny.Config.importPath("cog/variants"))
+	imports.Add("", jenny.Config.importPath("cog/variants"))
 
 	return renderTemplate("runtime/runtime.tmpl", map[string]any{
 		"imports": imports,

--- a/internal/jennies/golang/templates/runtime/runtime.tmpl
+++ b/internal/jennies/golang/templates/runtime/runtime.tmpl
@@ -5,8 +5,8 @@ package cog
 var runtimeInstance *Runtime
 
 type Runtime struct {
-	panelcfgVariants  map[string]cogvariants.PanelcfgConfig
-	dataqueryVariants map[string]cogvariants.DataqueryConfig
+	panelcfgVariants  map[string]variants.PanelcfgConfig
+	dataqueryVariants map[string]variants.DataqueryConfig
 }
 
 func NewRuntime() *Runtime {
@@ -15,34 +15,34 @@ func NewRuntime() *Runtime {
     }
 
 	runtimeInstance = &Runtime{
-        panelcfgVariants: make(map[string]cogvariants.PanelcfgConfig),
-        dataqueryVariants: make(map[string]cogvariants.DataqueryConfig),
+        panelcfgVariants: make(map[string]variants.PanelcfgConfig),
+        dataqueryVariants: make(map[string]variants.DataqueryConfig),
 	}
 
 	return runtimeInstance
 }
 
-func (runtime *Runtime) RegisterPanelcfgVariant(config cogvariants.PanelcfgConfig) {
+func (runtime *Runtime) RegisterPanelcfgVariant(config variants.PanelcfgConfig) {
 	runtime.panelcfgVariants[config.Identifier] = config
 }
 
-func (runtime *Runtime) ConfigForPanelcfgVariant(identifier string) (cogvariants.PanelcfgConfig, bool) {
+func (runtime *Runtime) ConfigForPanelcfgVariant(identifier string) (variants.PanelcfgConfig, bool) {
 	config, found := runtime.panelcfgVariants[identifier]
 
 	return config, found
 }
 
-func (runtime *Runtime) RegisterDataqueryVariant(config cogvariants.DataqueryConfig) {
+func (runtime *Runtime) RegisterDataqueryVariant(config variants.DataqueryConfig) {
 	runtime.dataqueryVariants[config.Identifier] = config
 }
 
-func (runtime *Runtime) UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint string) ([]cogvariants.Dataquery, error) {
+func (runtime *Runtime) UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint string) ([]variants.Dataquery, error) {
 	rawDataqueries := []json.RawMessage{}
 	if err := json.Unmarshal(raw, &rawDataqueries); err != nil {
 		return nil, err
 	}
 
-	dataqueries := make([]cogvariants.Dataquery, 0, len(rawDataqueries))
+	dataqueries := make([]variants.Dataquery, 0, len(rawDataqueries))
 	for _, rawDataquery := range rawDataqueries {
 		dataquery, err := runtime.UnmarshalDataquery(rawDataquery, dataqueryTypeHint)
 		if err != nil {
@@ -55,7 +55,7 @@ func (runtime *Runtime) UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint st
 	return dataqueries, nil
 }
 
-func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (cogvariants.Dataquery, error) {
+func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquery, error) {
 	// A hint tells us the dataquery type: let's use it.
 	if dataqueryTypeHint != "" {
 		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
@@ -65,12 +65,12 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 				return nil, err
 			}
 
-			return dataquery.(cogvariants.Dataquery), nil
+			return dataquery.(variants.Dataquery), nil
 		}
 	}
 
 	// We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
-	dataquery := cogvariants.UnknownDataquery{}
+	dataquery := variants.UnknownDataquery{}
 	if err := json.Unmarshal(raw, &dataquery); err != nil {
 		return nil, err
 	}
@@ -78,14 +78,14 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 	return dataquery, nil
 }
 
-func UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint string) ([]cogvariants.Dataquery, error) {
+func UnmarshalDataqueryArray(raw []byte, dataqueryTypeHint string) ([]variants.Dataquery, error) {
 	return NewRuntime().UnmarshalDataqueryArray(raw, dataqueryTypeHint)
 }
 
-func UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (cogvariants.Dataquery, error) {
+func UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquery, error) {
 	return NewRuntime().UnmarshalDataquery(raw, dataqueryTypeHint)
 }
 
-func ConfigForPanelcfgVariant(identifier string) (cogvariants.PanelcfgConfig, bool) {
+func ConfigForPanelcfgVariant(identifier string) (variants.PanelcfgConfig, bool) {
 	return NewRuntime().ConfigForPanelcfgVariant(identifier)
 }

--- a/internal/jennies/golang/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_models.tmpl
@@ -1,4 +1,4 @@
-package cogvariants
+package variants
 
 type PanelcfgConfig struct {
 	Identifier             string

--- a/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
@@ -1,7 +1,7 @@
-func VariantConfig() cogvariants.DataqueryConfig {
-	return cogvariants.DataqueryConfig{
+func VariantConfig() variants.DataqueryConfig {
+	return variants.DataqueryConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",
-	    DataqueryUnmarshaler: func (raw []byte) (cogvariants.Dataquery, error) {
+	    DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
             dataquery := {{ .object.Name|upperCamelCase }}{}
 
             if err := json.Unmarshal(raw, &dataquery); err != nil {

--- a/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
@@ -1,5 +1,5 @@
-func VariantConfig() cogvariants.PanelcfgConfig {
-	return cogvariants.PanelcfgConfig{
+func VariantConfig() variants.PanelcfgConfig {
+	return variants.PanelcfgConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",
 		{{- if .hasOptions }}
 		OptionsUnmarshaler: func (raw []byte) (any, error) {

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -8,6 +8,10 @@ import (
 )
 
 func formatPackageName(pkg string) string {
+	splitPath := strings.Split(pkg, "/")
+	if len(splitPath) > 1 {
+		pkg = splitPath[len(splitPath)-1]
+	}
 	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
 
 	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))

--- a/package_templates/go/README.md
+++ b/package_templates/go/README.md
@@ -110,7 +110,7 @@ import (
     "encoding/json"
 
     "github.com/grafana/grafana-foundation-sdk/go/cog"
-    cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
 )
 
 type CustomQuery struct {
@@ -125,10 +125,10 @@ type CustomQuery struct {
 // Let cog know that CustomQuery is a Dataquery variant
 func (resource CustomQuery) ImplementsDataqueryVariant() {}
 
-func CustomQueryVariantConfig() cogvariants.DataqueryConfig {
-    return cogvariants.DataqueryConfig{
+func CustomQueryVariantConfig() variants.DataqueryConfig {
+    return variants.DataqueryConfig{
         Identifier: "custom", // datasource plugin ID
-        DataqueryUnmarshaler: func(raw []byte) (cogvariants.Dataquery, error) {
+        DataqueryUnmarshaler: func(raw []byte) (variants.Dataquery, error) {
             dataquery := &CustomQuery{}
 
             if err := json.Unmarshal(raw, dataquery); err != nil {
@@ -141,8 +141,8 @@ func CustomQueryVariantConfig() cogvariants.DataqueryConfig {
 }
 
 // Compile-time check to ensure that CustomQueryBuilder indeed is
-// a builder for cogvariants.Dataquery
-var _ cog.Builder[cogvariants.Dataquery] = (*CustomQueryBuilder)(nil)
+// a builder for variants.Dataquery
+var _ cog.Builder[variants.Dataquery] = (*CustomQueryBuilder)(nil)
 
 type CustomQueryBuilder struct {
     internal *CustomQuery
@@ -154,7 +154,7 @@ func NewCustomQueryBuilder(query string) *CustomQueryBuilder {
     }
 }
 
-func (builder *CustomQueryBuilder) Build() (cogvariants.Dataquery, error) {
+func (builder *CustomQueryBuilder) Build() (variants.Dataquery, error) {
     return *builder.internal, nil
 }
 
@@ -231,7 +231,7 @@ import (
     "encoding/json"
 
     "github.com/grafana/grafana-foundation-sdk/go/cog"
-    cogvariants "github.com/grafana/grafana-foundation-sdk/go/cog/variants"
+	"github.com/grafana/grafana-foundation-sdk/go/cog/variants"
     "github.com/grafana/grafana-foundation-sdk/go/dashboard"
 )
 
@@ -239,8 +239,8 @@ type CustomPanelOptions struct {
     MakeBeautiful bool `json:"makeBeautiful"`
 }
 
-func CustomPanelVariantConfig() cogvariants.PanelcfgConfig {
-    return cogvariants.PanelcfgConfig{
+func CustomPanelVariantConfig() variants.PanelcfgConfig {
+    return variants.PanelcfgConfig{
         Identifier: "custom-panel", // plugin ID
         OptionsUnmarshaler: func(raw []byte) (any, error) {
             options := CustomPanelOptions{}
@@ -292,7 +292,7 @@ func (builder *CustomPanelBuilder) Title(title string) *CustomPanelBuilder {
     return builder
 }
 
-func (builder *CustomPanelBuilder) WithTarget(targets cog.Builder[cogvariants.Dataquery]) *CustomPanelBuilder {
+func (builder *CustomPanelBuilder) WithTarget(targets cog.Builder[variants.Dataquery]) *CustomPanelBuilder {
     targetsResource, err := targets.Build()
     if err != nil {
         builder.errors["targets"] = err.(cog.BuildErrors)

--- a/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
@@ -2,7 +2,7 @@ package composable_slot
 
 import (
 	cog "github.com/grafana/cog/generated/cog"
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 )
 
 var _ cog.Builder[Dashboard] = (*LokiBuilderBuilder)(nil)
@@ -38,7 +38,7 @@ func (builder *LokiBuilderBuilder) Build() (Dashboard, error) {
 	return *builder.internal, nil
 }
 
-func (builder *LokiBuilderBuilder) Target(target cog.Builder[cogvariants.Dataquery]) *LokiBuilderBuilder {
+func (builder *LokiBuilderBuilder) Target(target cog.Builder[variants.Dataquery]) *LokiBuilderBuilder {
     targetResource, err := target.Build()
     if err != nil {
         builder.errors["target"] = err.(cog.BuildErrors)
@@ -49,8 +49,8 @@ func (builder *LokiBuilderBuilder) Target(target cog.Builder[cogvariants.Dataque
     return builder
 }
 
-func (builder *LokiBuilderBuilder) Targets(targets []cog.Builder[cogvariants.Dataquery]) *LokiBuilderBuilder {
-        targetsResources := make([]cogvariants.Dataquery, 0, len(targets))
+func (builder *LokiBuilderBuilder) Targets(targets []cog.Builder[variants.Dataquery]) *LokiBuilderBuilder {
+        targetsResources := make([]variants.Dataquery, 0, len(targets))
         for _, r1 := range targets {
                 targetsDepth1, err := r1.Build()
                 if err != nil {

--- a/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
@@ -2,10 +2,10 @@ package dataquery_variant_builder
 
 import (
 	cog "github.com/grafana/cog/generated/cog"
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 )
 
-var _ cog.Builder[cogvariants.Dataquery] = (*LokiBuilderBuilder)(nil)
+var _ cog.Builder[variants.Dataquery] = (*LokiBuilderBuilder)(nil)
 
 type LokiBuilderBuilder struct {
     internal *Loki
@@ -24,7 +24,7 @@ func NewLokiBuilderBuilder() *LokiBuilderBuilder {
 	return builder
 }
 
-func (builder *LokiBuilderBuilder) Build() (cogvariants.Dataquery, error) {
+func (builder *LokiBuilderBuilder) Build() (variants.Dataquery, error) {
 	var errs cog.BuildErrors
 
 	for _, err := range builder.errors {

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -1,7 +1,7 @@
 package dashboard
 
 import (
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 	cog "github.com/grafana/cog/generated/cog"
 )
 
@@ -29,7 +29,7 @@ type Panel struct {
 	Type string `json:"type"`
 	Datasource *DataSourceRef `json:"datasource,omitempty"`
 	Options any `json:"options,omitempty"`
-	Targets []cogvariants.Dataquery `json:"targets,omitempty"`
+	Targets []variants.Dataquery `json:"targets,omitempty"`
 	FieldConfig *FieldConfigSource `json:"fieldConfig,omitempty"`
 }
 

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -1,7 +1,7 @@
 package variant_dataquery
 
 import (
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 )
 
 type Query struct {
@@ -11,10 +11,10 @@ type Query struct {
 func (resource Query) ImplementsDataqueryVariant() {}
 
 
-func VariantConfig() cogvariants.DataqueryConfig {
-	return cogvariants.DataqueryConfig{
+func VariantConfig() variants.DataqueryConfig {
+	return variants.DataqueryConfig{
 		Identifier: "prometheus",
-	    DataqueryUnmarshaler: func (raw []byte) (cogvariants.Dataquery, error) {
+	    DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
             dataquery := Query{}
 
             if err := json.Unmarshal(raw, &dataquery); err != nil {

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -1,7 +1,7 @@
 package variant_panelcfg_full
 
 import (
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 )
 
 type Options struct {
@@ -12,8 +12,8 @@ type FieldConfig struct {
 	TimeseriesFieldConfigOption string `json:"timeseries_field_config_option"`
 }
 
-func VariantConfig() cogvariants.PanelcfgConfig {
-	return cogvariants.PanelcfgConfig{
+func VariantConfig() variants.PanelcfgConfig {
+	return variants.PanelcfgConfig{
 		Identifier: "timeseries",
 		OptionsUnmarshaler: func (raw []byte) (any, error) {
 			options := Options{}

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -1,15 +1,15 @@
 package variant_panelcfg_only_options
 
 import (
-	cogvariants "github.com/grafana/cog/generated/cog/variants"
+	variants "github.com/grafana/cog/generated/cog/variants"
 )
 
 type Options struct {
 	Content string `json:"content"`
 }
 
-func VariantConfig() cogvariants.PanelcfgConfig {
-	return cogvariants.PanelcfgConfig{
+func VariantConfig() variants.PanelcfgConfig {
+	return variants.PanelcfgConfig{
 		Identifier: "text",
 		OptionsUnmarshaler: func (raw []byte) (any, error) {
 			options := Options{}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-foundation-sdk/issues/190

We were using `cogvariants` instead of variants because the sanitiser removes all invalid characters of the aliases. When we add a variant we need to pass the cog/variants package and it's why this result.

The change is assuming that all packages fit with the directory name. The only exception that we had was cogvariants, so it should work for all of the cases.