### PR TITLE
Cue: Use Selector instead of FieldType

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -300,7 +300,7 @@ func (g *generator) structFields(v cue.Value) ([]ast.StructField, error) {
 		fieldLabel := selectorLabel(i.Selector())
 
 		// inline definition
-		if i.FieldType().IsDefinition() {
+		if i.Selector().IsDefinition() {
 			obj, err := g.declareObject(fieldLabel, i.Value())
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Doing some tests, this specific function generates errors with some projects. Selector does the same and its compatible with different Cue versions.