### PR TITLE
CI: Update golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54.2
+          version: v1.60.3
           # Done by setup-go
           skip-pkg-cache: true
           skip-build-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,8 +7,7 @@ linters:
     - wastedassign
     - varnamelen
     - forcetypeassert
-    - goerr113
-    - exhaustivestruct
+    - err113
     - ireturn
     - funlen
     - forbidigo
@@ -18,7 +17,6 @@ linters:
     - prealloc
     - dupl
     - lll
-    - maligned
     - goconst
     - depguard
     - exhaustive
@@ -34,22 +32,25 @@ linters:
     - tagliatelle
     - nlreturn
     - gocyclo
-    # deprecated
-    - deadcode
-    - scopelint
-    - nosnakecase
-    - golint
-    - interfacer
-    - structcheck
-    - ifshort
-    - varcheck
+    # added from 1.60.3
+    - revive
+    - govet
+    - intrange
+    - mnd
+    - perfsprint
+    - musttag
+    - testifylint
 
 linters-settings:
   errcheck:
-    ignore: fmt:.*
+    exclude-functions: 
+     - fmt:.*
+
+issues:
+  exclude-dirs:
+    - generated
 
 run:
   modules-download-mode: vendor
   timeout: 3m
-  skip-dirs:
-    - generated
+  go: '1.23'


### PR DESCRIPTION
Golang 1.23 is available in version 1.60.3 onwards. We need this change to make https://github.com/grafana/cog/pull/520 works.