### PR TITLE
Java: Factory methods for disjunctions

### DIFF
--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -17,7 +17,18 @@ package {{ .Package }};
 @JsonSerialize(using = {{ .Name }}Serializer.class)
 {{- end }}
 public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}{{ if gt $i 0 }}, {{ end }}{{ $e }}{{ end }}{{ end }}{{ if .Variant }} implements {{ .Variant }}{{ end }} {
-    {{- template "types" dict "Fields" .Fields "Annotation" .Annotation }}
+    {{- template "types" dict "Fields" .Fields "Annotation" .Annotation "HasFactoryMethods" .ShouldAddFactoryMethods }}
+    
+    {{- if .ShouldAddFactoryMethods }}
+    protected {{ .Name }}() {}
+    {{- range .Fields }}
+    public static {{ $.Name }} create{{ .Name }}({{ .Type | formatBuilderFieldType }} {{ .Name | lowerCamelCase | escapeVar }}) {
+        {{ $.Name }} {{ $.Name | lowerCamelCase }} = new {{ $.Name }}();
+        {{ $.Name | lowerCamelCase }}.{{ .Name | lowerCamelCase | escapeVar }} = {{ .Name | lowerCamelCase | escapeVar }}{{ if .Type | typeHasBuilder }}.build(){{ end }};
+        return {{ $.Name | lowerCamelCase }};
+    }
+    {{- end }}
+    {{- end }}
 
     {{- if and (ne .ToJSONFunction "") (not .Extends) }}
     {{ .ToJSONFunction }}
@@ -40,6 +51,6 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- if ne $.Annotation "" }} 
     {{ fillAnnotationPattern $.Annotation .Name }}
     {{- end }}
-    public {{ .Type }} {{ .Name | lowerCamelCase | escapeVar }};
+    {{ if $.HasFactoryMethods }}protected{{ else }}public{{ end }} {{ .Type | formatType }} {{ .Name | lowerCamelCase | escapeVar }};
     {{- end }}
 {{- end }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -91,21 +91,16 @@ type ClassTemplate struct {
 	Extends  []string
 	Comments []string
 
-	Fields     []Field
+	Fields     []ast.StructField
 	Builders   []Builder
 	HasBuilder bool
 
-	Variant               string
-	Annotation            string
-	ToJSONFunction        string
-	ShouldAddSerializer   bool
-	ShouldAddDeserializer bool
-}
-
-type Field struct {
-	Name     string
-	Type     string
-	Comments []string
+	Variant                 string
+	Annotation              string
+	ToJSONFunction          string
+	ShouldAddSerializer     bool
+	ShouldAddDeserializer   bool
+	ShouldAddFactoryMethods bool
 }
 
 type ConstantTemplate struct {

--- a/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
@@ -1,10 +1,10 @@
 package sandbox;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 import java.util.LinkedList;
 
 public class SomeStruct { 

--- a/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
@@ -1,10 +1,10 @@
 package basic_struct;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 
 // SomeStruct, to hold data.
 public class SomeStruct {

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -1,10 +1,10 @@
 package basic_struct_defaults;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 
 public class SomeStruct { 
     @JsonProperty("id")

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
@@ -1,10 +1,10 @@
 package builder_delegation;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 
 public class Dashboard { 
     @JsonProperty("id")

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
@@ -1,10 +1,10 @@
 package builder_delegation_in_disjunction;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 
 public class Dashboard {
     // will be expanded to cog.Builder<DashboardLink> | string 

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -1,12 +1,12 @@
 package composable_slot;
 
-import cog.variants.Dataquery;
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import cog.variants.Dataquery;
+import java.util.List;
 
 @JsonDeserialize(using = DashboardDeserializer.class)
 public class Dashboard { 

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
@@ -1,10 +1,10 @@
 package sandbox;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 import java.util.LinkedList;
 
 public class Dashboard { 

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -1,10 +1,10 @@
 package nullable_map_assignment;
 
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.Map;
 
 public class SomeStruct { 
     @JsonProperty("config")

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
@@ -1,10 +1,10 @@
 package panelbuilder;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 
 public class Options { 
     @JsonProperty("onlyFromThisDashboard")

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
@@ -1,10 +1,10 @@
 package panelbuilder;
 
-import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.List;
 import dashboard.Panel;
 
 public class PanelBuilder implements cog.Builder<Panel> {

--- a/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
+++ b/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
@@ -1,10 +1,10 @@
 package some_pkg;
 
-import other_pkg.Name;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import other_pkg.Name;
 
 public class Person { 
     @JsonProperty("name")

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/RefreshRate.java
@@ -3,6 +3,17 @@ package disjunctions;
 
 // Refresh rate or disabled.
 public class RefreshRate {
-    public String string;
-    public Boolean bool;
+    protected String string;
+    protected Boolean bool;
+    protected RefreshRate() {}
+    public static RefreshRate createString(String string) {
+        RefreshRate refreshRate = new RefreshRate();
+        refreshRate.string = string;
+        return refreshRate;
+    }
+    public static RefreshRate createBool(Boolean bool) {
+        RefreshRate refreshRate = new RefreshRate();
+        refreshRate.bool = bool;
+        return refreshRate;
+    }
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SeveralRefs.java
@@ -2,7 +2,23 @@ package disjunctions;
 
 
 public class SeveralRefs {
-    public SomeStruct someStruct;
-    public SomeOtherStruct someOtherStruct;
-    public YetAnotherStruct yetAnotherStruct;
+    protected SomeStruct someStruct;
+    protected SomeOtherStruct someOtherStruct;
+    protected YetAnotherStruct yetAnotherStruct;
+    protected SeveralRefs() {}
+    public static SeveralRefs createSomeStruct(SomeStruct someStruct) {
+        SeveralRefs severalRefs = new SeveralRefs();
+        severalRefs.someStruct = someStruct;
+        return severalRefs;
+    }
+    public static SeveralRefs createSomeOtherStruct(SomeOtherStruct someOtherStruct) {
+        SeveralRefs severalRefs = new SeveralRefs();
+        severalRefs.someOtherStruct = someOtherStruct;
+        return severalRefs;
+    }
+    public static SeveralRefs createYetAnotherStruct(YetAnotherStruct yetAnotherStruct) {
+        SeveralRefs severalRefs = new SeveralRefs();
+        severalRefs.yetAnotherStruct = yetAnotherStruct;
+        return severalRefs;
+    }
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/RefreshRate.java
@@ -3,6 +3,17 @@ package withdashes;
 
 // Refresh rate or disabled.
 public class RefreshRate {
-    public String string;
-    public Boolean bool;
+    protected String string;
+    protected Boolean bool;
+    protected RefreshRate() {}
+    public static RefreshRate createString(String string) {
+        RefreshRate refreshRate = new RefreshRate();
+        refreshRate.string = string;
+        return refreshRate;
+    }
+    public static RefreshRate createBool(Boolean bool) {
+        RefreshRate refreshRate = new RefreshRate();
+        refreshRate.bool = bool;
+        return refreshRate;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrBool.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrBool.java
@@ -2,6 +2,17 @@ package struct_complex_fields;
 
 
 public class StringOrBool {
-    public String string;
-    public Boolean bool;
+    protected String string;
+    protected Boolean bool;
+    protected StringOrBool() {}
+    public static StringOrBool createString(String string) {
+        StringOrBool stringOrBool = new StringOrBool();
+        stringOrBool.string = string;
+        return stringOrBool;
+    }
+    public static StringOrBool createBool(Boolean bool) {
+        StringOrBool stringOrBool = new StringOrBool();
+        stringOrBool.bool = bool;
+        return stringOrBool;
+    }
 }


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cog/issues/512

Disjunctions should admit only one value. With the current code, the way to create an object for a disjunction looks:

```java
StringOrBool value = new StringOrBool();
value.string = "abc";
value.bool = true;
```

So its able to accept more than one value, but the result is going to be the first one evaluated in the serialised process. Apart of this, this is super annoying way to create a disjunction that should only accept one option.

With this change, we only can create this object like:

```java
StringOrBool aString = StringOrBool.createString("abc");
StringOrBool aBool = StringOrBool.createBool(true);
```

The modifier of their fields and default constructor (the one without parameters) become `protected`. This modifier only allows internal package use to simplify the access to serializers and deserializers.

_Note_: The PR changes the import order because [this](https://github.com/grafana/cog/compare/main...java/factory-methods#diff-f0a7ceb33be772e3591df7fe113e5d729793d16dde0e5cd89e171c457568941cL232) was evaluating the types of the field before and now is done inside the template.