### PR TITLE
Rules: Add DefaultToConstant rule

### DIFF
--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -102,6 +102,10 @@ builders:
   - promote_options_to_constructor:
       by_object: DashboardLink
       options: [title]
+      
+  - default_to_constant:
+      by_object: Dashboard
+      options: [schemaVersion, editable]
 
 options:
   ##############

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -379,8 +379,10 @@ func AddOption(selector Selector, newOption veneers.Option) RewriteRule {
 	}
 }
 
-// DefaultToConstant sets a default value into a constant. It's useful when we omit an option in the builder
-// to avoid to lose the default value
+// DefaultToConstant sets a default value into a constant.
+// When we unfold a value, omit an option, or any other action; we can lose the default value in the Builder struct.
+// If we parse the defaults using the Builder and not the Schema, we might not have all the defaults and with this rule,
+// we set these defaults as constants inside the constructor.
 func DefaultToConstant(selector Selector, options []string) RewriteRule {
 	return func(schemas ast.Schemas, builders ast.Builders) (ast.Builders, error) {
 		for i, builder := range builders {

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -410,7 +410,6 @@ func DefaultToConstant(selector Selector, options []string) RewriteRule {
 
 				builders[i].Constructor.Assignments = append(builders[i].Constructor.Assignments, opt.Assignments...)
 			}
-
 		}
 
 		return builders, nil

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -23,6 +23,7 @@ type BuilderRule struct {
 	Initialize               *Initialize               `yaml:"initialize"`
 	PromoteOptsToConstructor *PromoteOptsToConstructor `yaml:"promote_options_to_constructor"`
 	AddOption                *AddOption                `yaml:"add_option"`
+	DefaultToConstant        *DefaultToConstant        `yaml:"default_to_constant"`
 }
 
 func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
@@ -65,6 +66,10 @@ func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 	if rule.AddOption != nil {
 		return rule.AddOption.AsRewriteRule(pkg)
+	}
+
+	if rule.DefaultToConstant != nil {
+		return rule.DefaultToConstant.AsRewriteRule(pkg)
 	}
 
 	return nil, fmt.Errorf("empty rule")
@@ -202,6 +207,20 @@ func (rule AddOption) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	}
 
 	return builder.AddOption(selector, rule.Option), nil
+}
+
+type DefaultToConstant struct {
+	BuilderSelector `yaml:",inline"`
+	Options         []string `yaml:"options"`
+}
+
+func (rule DefaultToConstant) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.DefaultToConstant(selector, rule.Options), nil
 }
 
 /******************************************************************************


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/527

It creates an action to avoid to lose defaults when we modify the options of the builders. These defaults will appear in the constructors of each language that uses Builders to parse the defaults.

We have important defaults like `schemaVersion` where we are omitting its option and loosing its value.

_Note_: Probably it could have coolest way to do it but its the cleanest way that I found to solve the issue.