### PR TITLE
Version: Adds v11.2.x kind-registry version

### DIFF
--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -15,7 +15,7 @@ normal=$(tput sgr0)
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${__dir}/libs/logs.sh"
 
-versions=("v10.1.x" "v10.2.x" "v10.3.x" "v10.4.x" "v11.0.x" "next")
+versions=("v10.1.x" "v10.2.x" "v10.3.x" "v10.4.x" "v11.0.x" "v11.2.x" "next")
 
 for version in "${versions[@]}"; do
   info "🪧 Releasing ${bold}${version}${normal}"


### PR DESCRIPTION
Adds v11.2.x version to generate its builders.

For any reason (probably a bug), v11.1.x doesn't exist in kind-registry 🤷🏼‍♀️ 