### PR TITLE
Java: Avoid to show fields in json output when they aren't set and nullable

### DIFF
--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -17,9 +17,9 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	}
 
 	var buffer strings.Builder
-	j.typeFormatter.packageMapper(fasterXmlPackageName, "core.JsonProcessingException")
-	j.typeFormatter.packageMapper(fasterXmlPackageName, "databind.ObjectMapper")
-	j.typeFormatter.packageMapper(fasterXmlPackageName, "databind.ObjectWriter")
+	j.typeFormatter.packageMapper(fasterXMLPackageName, "core.JsonProcessingException")
+	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectMapper")
+	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectWriter")
 	if t.IsStructGeneratedFromDisjunction() {
 		if t.IsStruct() && (t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) || t.HasHint(ast.HintDisjunctionOfScalars)) {
 			_ = templates.ExecuteTemplate(&buffer, "marshalling/disjunctions.json_marshall.tmpl", map[string]any{
@@ -39,10 +39,10 @@ func (j JSONMarshaller) annotation(t ast.Type) string {
 	}
 
 	if t.IsStructGeneratedFromDisjunction() && t.IsStruct() {
-		j.typeFormatter.packageMapper(fasterXmlPackageName, "annotation.JsonUnwrapped")
+		j.typeFormatter.packageMapper(fasterXMLPackageName, "annotation.JsonUnwrapped")
 		return "@JsonUnwrapped"
 	}
 
-	j.typeFormatter.packageMapper(fasterXmlPackageName, "annotation.JsonProperty")
+	j.typeFormatter.packageMapper(fasterXMLPackageName, "annotation.JsonProperty")
 	return "@JsonProperty(%#v)"
 }

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -17,9 +17,9 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	}
 
 	var buffer strings.Builder
-	j.typeFormatter.packageMapper("com.fasterxml.jackson", "core.JsonProcessingException")
-	j.typeFormatter.packageMapper("com.fasterxml.jackson", "databind.ObjectMapper")
-	j.typeFormatter.packageMapper("com.fasterxml.jackson", "databind.ObjectWriter")
+	j.typeFormatter.packageMapper(fasterXmlPackageName, "core.JsonProcessingException")
+	j.typeFormatter.packageMapper(fasterXmlPackageName, "databind.ObjectMapper")
+	j.typeFormatter.packageMapper(fasterXmlPackageName, "databind.ObjectWriter")
 	if t.IsStructGeneratedFromDisjunction() {
 		if t.IsStruct() && (t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) || t.HasHint(ast.HintDisjunctionOfScalars)) {
 			_ = templates.ExecuteTemplate(&buffer, "marshalling/disjunctions.json_marshall.tmpl", map[string]any{
@@ -39,10 +39,10 @@ func (j JSONMarshaller) annotation(t ast.Type) string {
 	}
 
 	if t.IsStructGeneratedFromDisjunction() && t.IsStruct() {
-		j.typeFormatter.packageMapper("com.fasterxml.jackson", "annotation.JsonUnwrapped")
+		j.typeFormatter.packageMapper(fasterXmlPackageName, "annotation.JsonUnwrapped")
 		return "@JsonUnwrapped"
 	}
 
-	j.typeFormatter.packageMapper("com.fasterxml.jackson", "annotation.JsonProperty")
+	j.typeFormatter.packageMapper(fasterXmlPackageName, "annotation.JsonProperty")
 	return "@JsonProperty(%#v)"
 }

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -50,16 +50,17 @@ func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error)
 
 func (jenny RawTypes) getTemplate() *template.Template {
 	return templates.Funcs(map[string]any{
-		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
-		"formatType":               jenny.typeFormatter.formatFieldType,
-		"typeHasBuilder":           jenny.typeFormatter.typeHasBuilder,
-		"resolvesToComposableSlot": jenny.typeFormatter.resolvesToComposableSlot,
-		"emptyValueForType":        jenny.typeFormatter.defaultValueFor,
-		"formatCastValue":          jenny.typeFormatter.formatCastValue,
-		"formatAssignmentPath":     jenny.typeFormatter.formatAssignmentPath,
-		"formatPath":               jenny.typeFormatter.formatFieldPath,
-		"shouldCastNilCheck":       jenny.typeFormatter.shouldCastNilCheck,
-		"formatValue":              jenny.typeFormatter.formatValue,
+		"formatBuilderFieldType":        jenny.typeFormatter.formatBuilderFieldType,
+		"formatType":                    jenny.typeFormatter.formatFieldType,
+		"typeHasBuilder":                jenny.typeFormatter.typeHasBuilder,
+		"resolvesToComposableSlot":      jenny.typeFormatter.resolvesToComposableSlot,
+		"emptyValueForType":             jenny.typeFormatter.defaultValueFor,
+		"formatCastValue":               jenny.typeFormatter.formatCastValue,
+		"formatAssignmentPath":          jenny.typeFormatter.formatAssignmentPath,
+		"formatPath":                    jenny.typeFormatter.formatFieldPath,
+		"shouldCastNilCheck":            jenny.typeFormatter.shouldCastNilCheck,
+		"formatValue":                   jenny.typeFormatter.formatValue,
+		"fillNullableAnnotationPattern": jenny.typeFormatter.fillNullableAnnotationPattern,
 	})
 }
 

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -49,7 +49,9 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     // {{ . }}
     {{- end }}
     {{- if ne $.Annotation "" }}
+    {{- if fillNullableAnnotationPattern .Type }}
     {{ fillNullableAnnotationPattern .Type }}
+    {{- end }}
     {{ fillAnnotationPattern $.Annotation .Name }}
     {{- end }}
     {{ if $.HasFactoryMethods }}protected{{ else }}public{{ end }} {{ .Type | formatType }} {{ .Name | lowerCamelCase | escapeVar }};

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -48,7 +48,8 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- range .Comments }}
     // {{ . }}
     {{- end }}
-    {{- if ne $.Annotation "" }} 
+    {{- if ne $.Annotation "" }}
+    {{ fillNullableAnnotationPattern .Type }}
     {{ fillAnnotationPattern $.Annotation .Name }}
     {{- end }}
     {{ if $.HasFactoryMethods }}protected{{ else }}public{{ end }} {{ .Type | formatType }} {{ .Name | lowerCamelCase | escapeVar }};

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -35,6 +35,9 @@ func functions() template.FuncMap {
 		"fillAnnotationPattern": fillAnnotationPattern,
 		"containsValue":         containsValue,
 		"getJavaFieldTypeCheck": getJavaFieldTypeCheck,
+		"fillNullableAnnotationPattern": func(_ ast.Type) string {
+			panic("fillNullableAnnotationPattern() needs to be overridden by a jenny")
+		},
 		"lastItem": func(index int, values []EnumValue) bool {
 			return len(values)-1 == index
 		},

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -9,6 +9,9 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
+const fasterXmlPackageName = "com.fasterxml.jackson"
+const javaNullableField = "@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)"
+
 type typeFormatter struct {
 	config        Config
 	packageMapper func(pkg string, class string) string
@@ -348,7 +351,7 @@ func (tf *typeFormatter) objectNeedsCustomSerializer(obj ast.Object) bool {
 		return false
 	}
 	if obj.Type.HasHint(ast.HintDisjunctionOfScalars) {
-		tf.packageMapper("com.fasterxml.jackson", "databind.annotation.JsonSerialize")
+		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonSerialize")
 		return true
 	}
 
@@ -360,9 +363,17 @@ func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object) bool {
 		return false
 	}
 	if objectNeedsCustomDeserialiser(tf.context, obj) {
-		tf.packageMapper("com.fasterxml.jackson", "databind.annotation.JsonDeserialize")
+		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonDeserialize")
 		return true
 	}
 
 	return false
+}
+
+func (tf *typeFormatter) fillNullableAnnotationPattern(t ast.Type) string {
+	if t.Nullable {
+		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonSerialize")
+		return javaNullableField
+	}
+	return ""
 }

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
-const fasterXmlPackageName = "com.fasterxml.jackson"
+const fasterXMLPackageName = "com.fasterxml.jackson"
 const javaNullableField = "@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)"
 
 type typeFormatter struct {
@@ -351,7 +351,7 @@ func (tf *typeFormatter) objectNeedsCustomSerializer(obj ast.Object) bool {
 		return false
 	}
 	if obj.Type.HasHint(ast.HintDisjunctionOfScalars) {
-		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonSerialize")
+		tf.packageMapper(fasterXMLPackageName, "databind.annotation.JsonSerialize")
 		return true
 	}
 
@@ -363,7 +363,7 @@ func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object) bool {
 		return false
 	}
 	if objectNeedsCustomDeserialiser(tf.context, obj) {
-		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonDeserialize")
+		tf.packageMapper(fasterXMLPackageName, "databind.annotation.JsonDeserialize")
 		return true
 	}
 
@@ -372,7 +372,7 @@ func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object) bool {
 
 func (tf *typeFormatter) fillNullableAnnotationPattern(t ast.Type) string {
 	if t.Nullable {
-		tf.packageMapper(fasterXmlPackageName, "databind.annotation.JsonSerialize")
+		tf.packageMapper(fasterXMLPackageName, "databind.annotation.JsonSerialize")
 		return javaNullableField
 	}
 	return ""

--- a/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
+++ b/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-public class SomeStruct { 
+public class SomeStruct {
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("time")
     public Object time;
     

--- a/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 import java.util.LinkedList;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("tags")
     public List<String> tags;
     

--- a/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
@@ -8,15 +8,15 @@ import java.util.List;
 
 // SomeStruct, to hold data.
 public class SomeStruct {
-    // id identifies something. Weird, right? 
+    // id identifies something. Weird, right?
     @JsonProperty("id")
-    public Long id; 
+    public Long id;
     @JsonProperty("uid")
-    public String uid; 
+    public String uid;
     @JsonProperty("tags")
     public List<String> tags;
     // This thing could be live.
-    // Or maybe not. 
+    // Or maybe not.
     @JsonProperty("liveNow")
     public Boolean liveNow;
     

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -6,13 +6,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("id")
-    public Long id; 
+    public Long id;
     @JsonProperty("uid")
-    public String uid; 
+    public String uid;
     @JsonProperty("tags")
-    public List<String> tags; 
+    public List<String> tags;
     @JsonProperty("liveNow")
     public Boolean liveNow;
     

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
@@ -6,18 +6,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 
-public class Dashboard { 
+public class Dashboard {
     @JsonProperty("id")
-    public Long id; 
+    public Long id;
     @JsonProperty("title")
     public String title;
-    // will be expanded to []cog.Builder<DashboardLink> 
+    // will be expanded to []cog.Builder<DashboardLink>
     @JsonProperty("links")
     public List<DashboardLink> links;
-    // will be expanded to [][]cog.Builder<DashboardLink> 
+    // will be expanded to [][]cog.Builder<DashboardLink>
     @JsonProperty("linksOfLinks")
     public List<List<DashboardLink>> linksOfLinks;
-    // will be expanded to cog.Builder<DashboardLink> 
+    // will be expanded to cog.Builder<DashboardLink>
     @JsonProperty("singleLink")
     public DashboardLink singleLink;
     

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class DashboardLink { 
+public class DashboardLink {
     @JsonProperty("title")
-    public String title; 
+    public String title;
     @JsonProperty("url")
     public String url;
     

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
@@ -7,12 +7,12 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 
 public class Dashboard {
-    // will be expanded to cog.Builder<DashboardLink> | string 
+    // will be expanded to cog.Builder<DashboardLink> | string
     @JsonProperty("singleLinkOrString")
     public unknown singleLinkOrString;
-    // will be expanded to [](cog.Builder<DashboardLink> | string) 
+    // will be expanded to [](cog.Builder<DashboardLink> | string)
     @JsonProperty("linksOrStrings")
-    public List<unknown> linksOrStrings; 
+    public List<unknown> linksOrStrings;
     @JsonProperty("disjunctionOfBuilders")
     public unknown disjunctionOfBuilders;
     

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class DashboardLink { 
+public class DashboardLink {
     @JsonProperty("title")
-    public String title; 
+    public String title;
     @JsonProperty("url")
     public String url;
     

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class ExternalLink { 
+public class ExternalLink {
     @JsonProperty("url")
     public String url;
     

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -9,9 +9,9 @@ import cog.variants.Dataquery;
 import java.util.List;
 
 @JsonDeserialize(using = DashboardDeserializer.class)
-public class Dashboard { 
+public class Dashboard {
     @JsonProperty("target")
-    public Dataquery target; 
+    public Dataquery target;
     @JsonProperty("targets")
     public List<Dataquery> targets;
     

--- a/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("editable")
-    public unknown editable; 
+    public unknown editable;
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("autoRefresh")
     public unknown autoRefresh;
     

--- a/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
+++ b/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("id")
-    public Long id; 
+    public Long id;
     @JsonProperty("title")
     public String title;
     

--- a/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("title")
     public String title;
     

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomePanel { 
+public class SomePanel {
     @JsonProperty("type")
-    public String type; 
+    public String type;
     @JsonProperty("title")
-    public String title; 
+    public String title;
     @JsonProperty("cursor")
     public CursorMode cursor;
     

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Loki implements cog.variants.Dataquery { 
+public class Loki implements cog.variants.Dataquery {
     @JsonProperty("expr")
     public String expr;
     

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 import java.util.LinkedList;
 
-public class Dashboard { 
+public class Dashboard {
     @JsonProperty("variables")
     public List<Variable> variables;
     

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Variable.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Variable.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Variable { 
+public class Variable {
     @JsonProperty("name")
-    public String name; 
+    public String name;
     @JsonProperty("value")
     public String value;
     

--- a/testdata/jennies/builders/foreign_builder/JavaBuilders/some_pkg/SomeStruct.java
+++ b/testdata/jennies/builders/foreign_builder/JavaBuilders/some_pkg/SomeStruct.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("title")
     public String title;
     

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/LegendOptions.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/LegendOptions.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class LegendOptions { 
+public class LegendOptions {
     @JsonProperty("show")
     public Boolean show;
     

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Options { 
+public class Options {
     @JsonProperty("legend")
     public LegendOptions legend;
     

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-public class SomePanel { 
+public class SomePanel {
     @JsonProperty("title")
-    public String title; 
+    public String title;
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("options")
     public Options options;
     

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/Config.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/Config.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Config { 
+public class Config {
     @JsonProperty("title")
     public String title;
     

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-public class SomeStruct { 
+public class SomeStruct {
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("config")
     public Object config;
     

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 
-public class SomeStruct { 
+public class SomeStruct {
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("config")
     public Map<String, String> config;
     

--- a/testdata/jennies/builders/package-with-dashes/JavaBuilders/withdashes/SomeStruct.java
+++ b/testdata/jennies/builders/package-with-dashes/JavaBuilders/withdashes/SomeStruct.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("title")
     public String title;
     

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
@@ -6,25 +6,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.List;
 
-public class Options { 
+public class Options {
     @JsonProperty("onlyFromThisDashboard")
-    public Boolean onlyFromThisDashboard; 
+    public Boolean onlyFromThisDashboard;
     @JsonProperty("onlyInTimeRange")
-    public Boolean onlyInTimeRange; 
+    public Boolean onlyInTimeRange;
     @JsonProperty("tags")
-    public List<String> tags; 
+    public List<String> tags;
     @JsonProperty("limit")
-    public Integer limit; 
+    public Integer limit;
     @JsonProperty("showUser")
-    public Boolean showUser; 
+    public Boolean showUser;
     @JsonProperty("showTime")
-    public Boolean showTime; 
+    public Boolean showTime;
     @JsonProperty("showTags")
-    public Boolean showTags; 
+    public Boolean showTags;
     @JsonProperty("navigateToPanel")
-    public Boolean navigateToPanel; 
+    public Boolean navigateToPanel;
     @JsonProperty("navigateBefore")
-    public String navigateBefore; 
+    public String navigateBefore;
     @JsonProperty("navigateAfter")
     public String navigateAfter;
     

--- a/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
+++ b/testdata/jennies/builders/properties/JavaBuilders/properties/SomeStruct.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct { 
+public class SomeStruct {
     @JsonProperty("id")
     public Long id;
     

--- a/testdata/jennies/builders/references/JavaBuilders/other_pkg/Name.java
+++ b/testdata/jennies/builders/references/JavaBuilders/other_pkg/Name.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Name { 
+public class Name {
     @JsonProperty("first_name")
-    public String firstName; 
+    public String firstName;
     @JsonProperty("last_name")
     public String lastName;
     

--- a/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
+++ b/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import other_pkg.Name;
 
-public class Person { 
+public class Person {
     @JsonProperty("name")
     public Name name;
     

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-public class SomeStruct { 
+public class SomeStruct {
+    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
     @JsonProperty("time")
     public Object time;
     

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class NestedStruct { 
+public class NestedStruct {
     @JsonProperty("stringVal")
-    public String stringVal; 
+    public String stringVal;
     @JsonProperty("intVal")
     public Long intVal;
     

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
@@ -5,15 +5,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class Struct { 
+public class Struct {
     @JsonProperty("allFields")
-    public NestedStruct allFields; 
+    public NestedStruct allFields;
     @JsonProperty("partialFields")
-    public NestedStruct partialFields; 
+    public NestedStruct partialFields;
     @JsonProperty("emptyFields")
-    public NestedStruct emptyFields; 
+    public NestedStruct emptyFields;
     @JsonProperty("complexField")
-    public Object complexField; 
+    public Object complexField;
     @JsonProperty("partialComplexField")
     public Object partialComplexField;
     


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/525

Java was printing all fields even if they are nullable. The problem is that the frontend can have a weird behaviour if we show these nulls in the json.