### PR TITLE
Java: Check more kinds to put the proper annotation

### DIFF
--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -10,7 +10,9 @@ import (
 )
 
 const fasterXMLPackageName = "com.fasterxml.jackson"
-const javaNullableField = "@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)"
+const javaNullableField = "@JsonInclude(JsonInclude.Include.NON_NULL)"
+const javaDefaultEmptyField = "@JsonSetter(nulls = Nulls.AS_EMPTY)"
+const javaEmptyField = "@JsonInclude(JsonInclude.Include.NON_EMPTY)"
 
 type typeFormatter struct {
 	config        Config
@@ -372,8 +374,20 @@ func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object) bool {
 
 func (tf *typeFormatter) fillNullableAnnotationPattern(t ast.Type) string {
 	if t.Nullable {
-		tf.packageMapper(fasterXMLPackageName, "databind.annotation.JsonSerialize")
+		tf.packageMapper(fasterXMLPackageName, "annotation.JsonInclude")
 		return javaNullableField
 	}
+
+	if t.IsArray() || t.IsMap() {
+		tf.packageMapper(fasterXMLPackageName, "annotation.JsonSetter")
+		tf.packageMapper(fasterXMLPackageName, "annotation.Nulls")
+		return javaDefaultEmptyField
+	}
+
+	if t.IsAny() || t.IsStruct() || t.IsRef() {
+		tf.packageMapper(fasterXMLPackageName, "annotation.JsonInclude")
+		return javaEmptyField
+	}
+
 	return ""
 }

--- a/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
+++ b/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomeStruct {
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("time")
     public Object time;
     

--- a/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 import java.util.LinkedList;
 
 public class SomeStruct {
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("tags")
     public List<String> tags;
     

--- a/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 
 // SomeStruct, to hold data.
@@ -13,6 +15,7 @@ public class SomeStruct {
     public Long id;
     @JsonProperty("uid")
     public String uid;
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("tags")
     public List<String> tags;
     // This thing could be live.

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 
 public class SomeStruct {
@@ -11,6 +13,7 @@ public class SomeStruct {
     public Long id;
     @JsonProperty("uid")
     public String uid;
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("tags")
     public List<String> tags;
     @JsonProperty("liveNow")

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class Dashboard {
     @JsonProperty("id")
@@ -12,12 +15,15 @@ public class Dashboard {
     @JsonProperty("title")
     public String title;
     // will be expanded to []cog.Builder<DashboardLink>
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("links")
     public List<DashboardLink> links;
     // will be expanded to [][]cog.Builder<DashboardLink>
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("linksOfLinks")
     public List<List<DashboardLink>> linksOfLinks;
     // will be expanded to cog.Builder<DashboardLink>
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("singleLink")
     public DashboardLink singleLink;
     

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 
 public class Dashboard {
@@ -11,6 +13,7 @@ public class Dashboard {
     @JsonProperty("singleLinkOrString")
     public unknown singleLinkOrString;
     // will be expanded to [](cog.Builder<DashboardLink> | string)
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("linksOrStrings")
     public List<unknown> linksOrStrings;
     @JsonProperty("disjunctionOfBuilders")

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -6,12 +6,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import cog.variants.Dataquery;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 
 @JsonDeserialize(using = DashboardDeserializer.class)
 public class Dashboard {
     @JsonProperty("target")
     public Dataquery target;
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("targets")
     public List<Dataquery> targets;
     

--- a/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomeStruct {
     @JsonProperty("editable")
     public unknown editable;
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("autoRefresh")
     public unknown autoRefresh;
     

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomePanel {
     @JsonProperty("type")
     public String type;
     @JsonProperty("title")
     public String title;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("cursor")
     public CursorMode cursor;
     

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 import java.util.LinkedList;
 
 public class Dashboard {
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("variables")
     public List<Variable> variables;
     

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class Options {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("legend")
     public LegendOptions legend;
     

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomePanel {
     @JsonProperty("title")
     public String title;
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("options")
     public Options options;
     

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomeStruct {
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("config")
     public Object config;
     

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Map;
 
 public class SomeStruct {
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("config")
     public Map<String, String> config;
     

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/Options.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 
 public class Options {
@@ -11,6 +13,7 @@ public class Options {
     public Boolean onlyFromThisDashboard;
     @JsonProperty("onlyInTimeRange")
     public Boolean onlyInTimeRange;
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
     @JsonProperty("tags")
     public List<String> tags;
     @JsonProperty("limit")

--- a/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilders/panelbuilder/PanelBuilder.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import java.util.List;
 import dashboard.Panel;
 

--- a/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
+++ b/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import other_pkg.Name;
 
 public class Person {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("name")
     public Name name;
     

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class SomeStruct {
-    @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("time")
     public Object time;
     

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
@@ -4,16 +4,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class Struct {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("allFields")
     public NestedStruct allFields;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("partialFields")
     public NestedStruct partialFields;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("emptyFields")
     public NestedStruct emptyFields;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("complexField")
     public Object complexField;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("partialComplexField")
     public Object partialComplexField;
     


### PR DESCRIPTION
* It adds `Nulls.AS_EMPTY` to set empty values to list and maps.
* It adds `Include.NON_EMPTY` to set these values in the Json when they have any value. It applies for generic (Objects), structs and references.
* Changes `JsonSerialize` with `JsonInclude` because its deprecated 🙃. 

If for any reason, we have problems to don't show initialise objects, we need to initialise them directly in the builder's constructor since there isn't exist an annotation or anything else to setup a non-null object.