### PR TITLE
Ignore more files when calculating the diff preview in CI

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -43,7 +43,7 @@ jobs:
           echo -e "</summary>\n" >> preview.md
           echo '```patch' >> preview.md
           
-          git diff next+cog-v0.0.x..HEAD ':(exclude,glob)*/README.md' | tee -a preview.md
+          git diff next+cog-v0.0.x..HEAD ':(exclude,glob)*/README.md' ':(exclude)java/gradle.properties' ':(exclude)python/pyproject.toml' ':(exclude)typescript/package.json' | tee -a preview.md
           
           echo '```' >> preview.md
           echo -e "\n" >> preview.md


### PR DESCRIPTION
Less noise in the diffs is better.