### PR TITLE
Make targets detect and use devbox appropriately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           enable-cache: 'true'
 
       - name: Run golangci-lint
-        run: devbox run lint
+        run: make lint
 
   tests:
     name: Tests
@@ -33,7 +33,7 @@ jobs:
           enable-cache: 'true'
 
       - name: Tests
-        run: devbox run tests
+        run: make tests
 
   registry:
     name: Generate registry
@@ -103,20 +103,20 @@ jobs:
 
       - name: Run code generation
         run: |
-          devbox run gen-sdk-dev
+          make gen-sdk-dev
 
       - name: Run the Go example
         run: |
-          devbox run go-example
+          make run-go-example
 
       - name: Run the Typescript example
         run: |
-          devbox run ts-example
+          make run-ts-example
 
       - name: Run the PHP example
         run: |
-          devbox run php-example
+          make run-php-example
 
       - name: Run Java example
         run: |
-          devbox run java-example
+          make run-java-example

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,71 @@
+# Within devbox
+ifneq "$(DEVBOX_CONFIG_DIR)" ""
+    RUN_DEVBOX:=
+else # Normal shell
+    RUN_DEVBOX:=devbox run
+endif
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
 .PHONY: lint
-lint:
-	golangci-lint run -c .golangci.yaml
+lint: dev-env-check-binaries ## Lints the code base.
+	$(RUN_DEVBOX) golangci-lint run -c .golangci.yaml
 
 .PHONY: tests
-tests:
-	go test -v ./...
+tests: dev-env-check-binaries ## Runs the tests.
+	$(RUN_DEVBOX) go test -v ./...
 
 .PHONY: deps
-deps:
-	go mod vendor
+deps: dev-env-check-binaries ## Installs the dependencies.
+	$(RUN_DEVBOX) go mod vendor
 
 .PHONY: docs
-docs:
-	go run cmd/compiler-passes-docs/*
-	go run cmd/cog-config-schemas/*
+docs: dev-env-check-binaries ## Generates the documentation.
+	$(RUN_DEVBOX) go run cmd/compiler-passes-docs/*
+	$(RUN_DEVBOX) go run cmd/cog-config-schemas/*
 
 .PHONY: gen-sdk-dev
-gen-sdk-dev:
+gen-sdk-dev: dev-env-check-binaries ## Generates a dev version of the Foundation SDK.
 	rm -rf generated
-	go run cmd/cli/main.go generate \
+	$(RUN_DEVBOX) go run cmd/cli/main.go generate \
 		--config ./config/foundation_sdk.dev.yaml \
 		--parameters kind_registry_version=next,grafana_version=main
 
 .PHONY: run-go-example
-run-go-example:
-	go run ./examples/_go/*
+run-go-example: dev-env-check-binaries ## Runs the Go example.
+	$(RUN_DEVBOX) go run ./examples/_go/*
 
 .PHONY: run-java-example
-run-java-example:
-	gradle publishToMavenLocal -p generated
-	gradle run -p examples/java
+run-java-example: dev-env-check-binaries ## Runs the Java example.
+	$(RUN_DEVBOX) gradle publishToMavenLocal -p generated
+	$(RUN_DEVBOX) gradle run -p examples/java
 
 .PHONY: run-php-example
-run-php-example:
-	cd ./examples/php && \
-	composer install && \
-	php index.php
+run-php-example: dev-env-check-binaries ## Runs the PHP example.
+	$(RUN_DEVBOX) composer install -d ./examples/php && \
+	$(RUN_DEVBOX) php ./examples/php/index.php
 
 .PHONY: run-ts-example
-run-ts-example:
-	ts-node examples/typescript
+run-ts-example: dev-env-check-binaries ## Runs the Typescript example.
+	$(RUN_DEVBOX) ts-node examples/typescript
+
+.PHONY: dev-env-check-binaires
+dev-env-check-binaries: ## Check that the required binary are present.
+	@devbox version >/dev/null 2>&1 || (echo "ERROR: devbox is required. See https://www.jetify.com/devbox/docs/quickstart/"; exit 1)

--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ One-off commands can be executed within the devbox shell as well:
 $ devbox run go version
 ```
 
-Various cog-specific commands also exist:
-
-```console
-$ devbox run
-```
-
 Packages can be installed using:
 
 ```console

--- a/devbox.json
+++ b/devbox.json
@@ -16,15 +16,6 @@
   "shell": {
     "init_hook": [
       "echo 'Installing dependencies...' && make deps"
-    ],
-    "scripts": {
-      "go-example":  "make run-go-example",
-      "java-example": "make run-java-example",
-      "php-example": "make run-php-example",
-      "ts-example":  "make run-ts-example",
-      "lint":        "make lint",
-      "tests":       "make tests",
-      "gen-sdk-dev": "make gen-sdk-dev"
-    }
+    ]
   }
 }


### PR DESCRIPTION
Having both devbox and the Makefile as an entrypoint for targets/commands is confusing.
This PR simplifies that by ensuring that make targets are able to correctly run commands, possibly by decorating them with a `devbox run` if the current shell isn't a devbox one.

As a bonus, the Makefile is now self-documenting.