### PR TITLE
Use same datasource reference to all dataqueries

### DIFF
--- a/config/compiler/common_passes.yaml
+++ b/config/compiler/common_passes.yaml
@@ -4,3 +4,4 @@ passes:
   - entrypoint_identification: {}
   - dataquery_identification: {}
   - disjunction_with_constant_to_default: {}
+  - set_datasource_to_dataquery: {}

--- a/docs/compiler_passes.md
+++ b/docs/compiler_passes.md
@@ -370,6 +370,19 @@ schema_set_identifier:
   identifier: string
 ```
 
+## `set_datasource_to_dataquery`
+
+SetDatasourceToDataquery uses dashboard.DataSourceRef reference for the datasource field in each dataquery.
+
+Depending on the type of schema, this value can be an any or an internal Datasource struct generating an inconsistency
+between them.
+
+### Usage
+
+```yaml
+set_datasource_to_dataquery: {}
+```
+
 ## `unspec`
 
 Unspec removes the Kubernetes-style envelope added by kindsys.

--- a/internal/ast/compiler/constants.go
+++ b/internal/ast/compiler/constants.go
@@ -7,6 +7,7 @@ const (
 
 	dashboardPackage                = "dashboard"
 	dashboardObject                 = "Dashboard"
+	dashboardDatasource             = "DataSourceRef"
 	dashboardPanelObject            = "Panel"
 	dashboardRowPanelObject         = "RowPanel"
 	dashboardPanelIDField           = "id"
@@ -14,4 +15,6 @@ const (
 	dashboardPanelLibraryPanelField = "libraryPanel"
 	dashboardPanelTypeField         = "type"
 	dashboardPanelsField            = "panels"
+
+	datasourceName = "Datasource"
 )

--- a/internal/ast/compiler/set_datasource_to_dataquery.go
+++ b/internal/ast/compiler/set_datasource_to_dataquery.go
@@ -1,0 +1,55 @@
+package compiler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+// SetDatasourceToDataquery uses dashboard.DataSourceRef reference for the datasource field in each dataquery.
+//
+// Depending on the type of schema, this value can be an any or an internal Datasource struct generating an inconsistency
+// between them.
+type SetDatasourceToDataquery struct {
+}
+
+func (d *SetDatasourceToDataquery) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	visitor := Visitor{
+		OnSchema:      d.processSchema,
+		OnStructField: d.processFieldStruct,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (d *SetDatasourceToDataquery) processSchema(v *Visitor, schema *ast.Schema) (*ast.Schema, error) {
+	var err error
+	schema.Objects.Iterate(func(key string, value ast.Object) {
+		if schema.Package != dashboardPackage && (key == datasourceName || key == dashboardDatasource) {
+			schema.Objects.Remove(key)
+		} else {
+			obj, objErr := v.VisitObject(schema, value)
+			if objErr != nil {
+				err = objErr
+			}
+
+			schema.Objects.Set(key, obj)
+		}
+	})
+
+	return schema, err
+}
+
+func (d *SetDatasourceToDataquery) processFieldStruct(_ *Visitor, schema *ast.Schema, field ast.StructField) (ast.StructField, error) {
+	if schema.Package == dashboardPackage || schema.Metadata.Variant != ast.SchemaVariantDataQuery {
+		return field, nil
+	}
+
+	if field.Name == strings.ToLower(datasourceName) || field.Name == dashboardDatasource {
+		field.Type = ast.NewRef(dashboardPackage, dashboardDatasource)
+		field.AddToPassesTrail(fmt.Sprintf("SetDatasourceToDataquery[%s.%s]", dashboardPackage, dashboardDatasource))
+	}
+
+	return field, nil
+}

--- a/internal/ast/compiler/set_datasource_to_dataquery_test.go
+++ b/internal/ast/compiler/set_datasource_to_dataquery_test.go
@@ -1,0 +1,66 @@
+package compiler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestSetDatasourceToDataQuery(t *testing.T) {
+	schemas := ast.Schemas{
+		&ast.Schema{
+			Package: "dashboard",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject(dashboardPackage, dashboardDatasource, ast.NewStruct(
+					ast.NewStructField("Uid", ast.NewScalar(ast.KindString, ast.Nullable())),
+					ast.NewStructField("Type", ast.NewScalar(ast.KindString, ast.Nullable())),
+				)),
+			),
+		},
+		&ast.Schema{
+			Package: "no_dataquery",
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("no_dataquery", datasourceName, ast.String()),
+				ast.NewObject("no_dataquery", dashboardDatasource, ast.String()),
+			),
+		},
+		&ast.Schema{
+			Package: "dataquery",
+			Metadata: ast.SchemaMeta{
+				Variant: ast.SchemaVariantDataQuery,
+			},
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("dataquery", datasourceName, ast.Any()),
+				ast.NewObject("dataquery", "Query", ast.NewStruct(
+					ast.NewStructField("datasource", ast.NewRef("dataquery", datasourceName)),
+					ast.NewStructField("Type", ast.NewScalar(ast.KindString, ast.Nullable())),
+				)),
+			),
+		},
+	}
+
+	expected := ast.Schemas{
+		schemas[0],
+		schemas[1],
+		&ast.Schema{
+			Package: "dataquery",
+			Metadata: ast.SchemaMeta{
+				Variant: ast.SchemaVariantDataQuery,
+			},
+			Objects: testutils.ObjectsMap(
+				ast.NewObject("dataquery", "Query", ast.NewStruct(
+					ast.NewStructField(
+						"datasource",
+						ast.NewRef(dashboardPackage, dashboardDatasource),
+						ast.PassesTrail(fmt.Sprintf("SetDatasourceToDataquery[%s.%s]", dashboardPackage, dashboardDatasource)),
+					),
+					ast.NewStructField("Type", ast.NewScalar(ast.KindString, ast.Nullable())),
+				)),
+			),
+		},
+	}
+
+	runPassOnSchemas(t, &SetDatasourceToDataquery{}, schemas, expected)
+}

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -11,6 +11,7 @@ type CompilerPass struct {
 	EntrypointIdentification *EntrypointIdentification `yaml:"entrypoint_identification"`
 	DataqueryIdentification  *DataqueryIdentification  `yaml:"dataquery_identification"`
 	Unspec                   *Unspec                   `yaml:"unspec"`
+	SetDatasourceToDataquery *SetDatasourceToDataquery `yaml:"set_datasource_to_dataquery"`
 	FieldsSetDefault         *FieldsSetDefault         `yaml:"fields_set_default"`
 	FieldsSetRequired        *FieldsSetRequired        `yaml:"fields_set_required"`
 	FieldsSetNotRequired     *FieldsSetNotRequired     `yaml:"fields_set_not_required"`
@@ -47,7 +48,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 	if pass.Unspec != nil {
 		return pass.Unspec.AsCompilerPass(), nil
 	}
-
+	if pass.SetDatasourceToDataquery != nil {
+		return pass.SetDatasourceToDataquery.AsCompilerPass(), nil
+	}
 	if pass.FieldsSetDefault != nil {
 		return pass.FieldsSetDefault.AsCompilerPass()
 	}
@@ -135,6 +138,12 @@ type Unspec struct {
 
 func (pass Unspec) AsCompilerPass() *compiler.Unspec {
 	return &compiler.Unspec{}
+}
+
+type SetDatasourceToDataquery struct{}
+
+func (pass SetDatasourceToDataquery) AsCompilerPass() *compiler.SetDatasourceToDataquery {
+	return &compiler.SetDatasourceToDataquery{}
 }
 
 type FieldsSetDefault struct {

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -282,6 +282,9 @@
         "unspec": {
           "$ref": "#/$defs/YamlUnspec"
         },
+        "set_datasource_to_dataquery": {
+          "$ref": "#/$defs/YamlSetDatasourceToDataquery"
+        },
         "fields_set_default": {
           "$ref": "#/$defs/YamlFieldsSetDefault"
         },
@@ -526,6 +529,11 @@
           "type": "string"
         }
       },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlSetDatasourceToDataquery": {
+      "properties": {},
       "additionalProperties": false,
       "type": "object"
     },


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/554

It creates a compiler pass that uses the same `dashboard.DataSourceRef` reference to all dataqueries for the `datasource` field.