### PR TITLE
Add provenance publish config for typescript foundation-sdk package

### DIFF
--- a/package_templates/typescript/package.json
+++ b/package_templates/typescript/package.json
@@ -10,6 +10,11 @@
     "traces",
     "metrics"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
   "license": "Apache-2.0",
   "author": "Grafana Labs",
   "homepage": "https://github.com/grafana/grafana-foundation-sdk",

--- a/repository_templates/typescript/.github/workflows/typescript-release.yaml
+++ b/repository_templates/typescript/.github/workflows/typescript-release.yaml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     defaults:
       run:


### PR DESCRIPTION
Adding provenance information to the NPM package published for the foundation-sdk allows us to publicly establish where a package was built and who published it, which can increase supply-chain security.

See:
* https://docs.npmjs.com/generating-provenance-statements
* https://github.com/grafana/plugin-tools/pull/1127