### PR TITLE
Java: Make Panel extensible

### DIFF
--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -14,6 +14,7 @@ func TestBuilder_Generate(t *testing.T) {
 		Name:         "GoBuilder",
 		Skip: map[string]string{
 			"builder_delegation_in_disjunction": "disjunctions are eliminated with compiler passes",
+			"dashboard_panel":                   "this test if for Java generics for dashboard.Panel",
 		},
 	}
 

--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -61,6 +61,7 @@ func (b Builders) genBuilders(pkg string, name string) ([]Builder, bool) {
 			Properties:           builder.Properties,
 			Defaults:             b.genDefaults(builder.Options),
 			ImportAlias:          b.config.PackagePath,
+			IsGeneric:            builder.For.SelfRef.ReferredPkg == "dashboard" && object.Name == "Panel",
 		}
 	}), true
 }

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -1,6 +1,6 @@
 {{- define "builder" }}
-    public static class {{ .BuilderName }}Builder implements {{ if not (eq .Builder.ImportAlias "") }}{{ .Builder.ImportAlias }}.{{ end }}cog.Builder<{{ .Builder.BuilderSignatureType }}> {
-        private final {{ .Builder.ObjectName }} internal;
+    public static class {{ .BuilderName }}Builder{{ if .Builder.IsGeneric }}<T extends {{ .BuilderName }}Builder<T>>{{ end }} implements {{ if not (eq .Builder.ImportAlias "") }}{{ .Builder.ImportAlias }}.{{ end }}cog.Builder<{{ .Builder.BuilderSignatureType }}> {
+        protected final {{ .Builder.ObjectName }} internal;
         
         {{- range .Builder.Properties }}
         private {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
@@ -25,11 +25,11 @@
         }
         
     {{- range $opt := .Builder.Options }}
-    public {{ $.BuilderName }}Builder {{ .Name | lowerCamelCase | escapeVar }}({{- template "args" .Args }}) {
+    public {{ if $.Builder.IsGeneric }}T {{ else }}{{ $.BuilderName }}Builder {{ end }}{{ .Name | lowerCamelCase | escapeVar }}({{- template "args" .Args }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.Builder.BuilderName "OptionName" $opt.Name) }}
         {{- end }}
-        return this;
+        return {{ if $.Builder.IsGeneric }}(T) {{ end }}this;
     }
     {{ end -}}
         

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -129,6 +129,7 @@ type Builder struct {
 	Properties           []ast.StructField
 	Options              []ast.Option
 	Defaults             []OptionCall
+	IsGeneric            bool
 }
 
 type OptionCall struct {

--- a/internal/jennies/php/builder_test.go
+++ b/internal/jennies/php/builder_test.go
@@ -12,6 +12,9 @@ func TestBuilder_Generate(t *testing.T) {
 	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "PHPBuilder",
+		Skip: map[string]string{
+			"dashboard_panel": "this test if for Java generics for dashboard.Panel",
+		},
 	}
 
 	config := Config{

--- a/internal/jennies/python/builder_test.go
+++ b/internal/jennies/python/builder_test.go
@@ -14,6 +14,7 @@ func TestBuilder_Generate(t *testing.T) {
 		Name:         "PythonBuilder",
 		Skip: map[string]string{
 			"anonymous_struct": "Anonymous structs are not supported in Python",
+			"dashboard_panel":  "this test if for Java generics for dashboard.Panel",
 		},
 	}
 

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -12,6 +12,9 @@ func TestBuilder_Generate(t *testing.T) {
 	test := testutils.GoldenFilesTestSuite[languages.Context]{
 		TestDataRoot: "../../../testdata/jennies/builders",
 		Name:         "TypescriptBuilder",
+		Skip: map[string]string{
+			"dashboard_panel": "this test if for Java generics for dashboard.Panel",
+		},
 	}
 
 	language := New(Config{})

--- a/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
+++ b/testdata/jennies/builders/anonymous_struct/JavaBuilders/anonymous_struct/SomeStruct.java
@@ -18,7 +18,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/array_append/JavaBuilders/sandbox/SomeStruct.java
@@ -21,7 +21,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilders/basic_struct/SomeStruct.java
@@ -30,7 +30,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilders/basic_struct_defaults/SomeStruct.java
@@ -26,7 +26,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/Dashboard.java
@@ -34,7 +34,7 @@ public class Dashboard {
 
     
     public static class Builder implements cog.Builder<Dashboard> {
-        private final Dashboard internal;
+        protected final Dashboard internal;
         
         public Builder() {
             this.internal = new Dashboard();

--- a/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilders/builder_delegation/DashboardLink.java
@@ -18,7 +18,7 @@ public class DashboardLink {
 
     
     public static class Builder implements cog.Builder<DashboardLink> {
-        private final DashboardLink internal;
+        protected final DashboardLink internal;
         
         public Builder() {
             this.internal = new DashboardLink();

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/Dashboard.java
@@ -26,7 +26,7 @@ public class Dashboard {
 
     
     public static class Builder implements cog.Builder<Dashboard> {
-        private final Dashboard internal;
+        protected final Dashboard internal;
         
         public Builder() {
             this.internal = new Dashboard();

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/DashboardLink.java
@@ -18,7 +18,7 @@ public class DashboardLink {
 
     
     public static class Builder implements cog.Builder<DashboardLink> {
-        private final DashboardLink internal;
+        protected final DashboardLink internal;
         
         public Builder() {
             this.internal = new DashboardLink();

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilders/builder_delegation_in_disjunction/ExternalLink.java
@@ -16,7 +16,7 @@ public class ExternalLink {
 
     
     public static class Builder implements cog.Builder<ExternalLink> {
-        private final ExternalLink internal;
+        protected final ExternalLink internal;
         
         public Builder() {
             this.internal = new ExternalLink();

--- a/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilders/composable_slot/Dashboard.java
@@ -25,7 +25,7 @@ public class Dashboard {
 
     
     public static class Builder implements cog.Builder<Dashboard> {
-        private final Dashboard internal;
+        protected final Dashboard internal;
         
         public Builder() {
             this.internal = new Dashboard();

--- a/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constant_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -20,7 +20,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
+++ b/testdata/jennies/builders/constraints/JavaBuilders/constraints/SomeStruct.java
@@ -18,7 +18,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/constructor_argument/JavaBuilders/sandbox/SomeStruct.java
@@ -16,7 +16,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder(String title) {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilders/constructor_initializations/SomePanel.java
@@ -22,7 +22,7 @@ public class SomePanel {
 
     
     public static class Builder implements cog.Builder<SomePanel> {
-        private final SomePanel internal;
+        protected final SomePanel internal;
         
         public Builder() {
             this.internal = new SomePanel();

--- a/testdata/jennies/builders/dashboard_panel/JavaBuilders/dashboard/Panel.java
+++ b/testdata/jennies/builders/dashboard_panel/JavaBuilders/dashboard/Panel.java
@@ -1,13 +1,13 @@
-package properties;
+package dashboard;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
-public class SomeStruct {
-    @JsonProperty("id")
-    public Long id;
+public class Panel {
+    @JsonProperty("onlyFromThisDashboard")
+    public Boolean onlyFromThisDashboard;
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
@@ -15,19 +15,18 @@ public class SomeStruct {
     }
 
     
-    public static class Builder implements cog.Builder<SomeStruct> {
-        protected final SomeStruct internal;
-        private String someBuilderProperty;
+    public static class Builder<T extends Builder<T>> implements cog.Builder<Panel> {
+        protected final Panel internal;
         
         public Builder() {
-            this.internal = new SomeStruct();
-        this.someBuilderProperty = "";
+            this.internal = new Panel();
+        this.onlyFromThisDashboard(false);
         }
-    public Builder id(Long id) {
-    this.internal.id = id;
-        return this;
+    public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
+    this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
+        return (T) this;
     }
-    public SomeStruct build() {
+    public Panel build() {
             return this.internal;
         }
     }

--- a/testdata/jennies/builders/dashboard_panel/builders_context.json
+++ b/testdata/jennies/builders/dashboard_panel/builders_context.json
@@ -1,0 +1,242 @@
+{
+  "Schemas": [
+    {
+      "Package": "dashboard",
+      "Metadata": {
+        "Kind": "composable",
+        "Variant": "panelcfg",
+        "Identifier": "annolist"
+      },
+      "Objects": {
+        "Panel": {
+          "Name": "Panel",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "onlyFromThisDashboard",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Default": false,
+                    "Scalar": {
+                      "ScalarKind": "bool"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "dashboard",
+            "ReferredType": "Panel"
+          }
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "For": {
+        "Name": "Panel",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "onlyFromThisDashboard",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": false,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "onlyInTimeRange",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": false,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "tags",
+                "Type": {
+                  "Kind": "array",
+                  "Nullable": false,
+                  "Array": {
+                    "ValueType": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "limit",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": 10,
+                  "Scalar": {
+                    "ScalarKind": "uint32"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "showUser",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": true,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "showTime",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": true,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "showTags",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": true,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "navigateToPanel",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": true,
+                  "Scalar": {
+                    "ScalarKind": "bool"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "navigateBefore",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": "10m",
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "navigateAfter",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Default": "10m",
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "dashboard",
+          "ReferredType": "Panel"
+        }
+      },
+      "Package": "dashboard",
+      "Name": "Panel",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "onlyFromThisDashboard",
+          "Args": [
+            {
+              "Name": "onlyFromThisDashboard",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Default": false,
+                "Scalar": {
+                  "ScalarKind": "bool"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "onlyFromThisDashboard",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Default": false,
+                    "Scalar": {
+                      "ScalarKind": "bool"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "onlyFromThisDashboard",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Default": false,
+                    "Scalar": {
+                      "ScalarKind": "bool"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ],
+          "Default": {
+            "ArgsValues": [
+              false
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -16,7 +16,7 @@ public class Loki implements cog.variants.Dataquery {
 
     
     public static class Builder implements cog.Builder<Loki> {
-        private final Loki internal;
+        protected final Loki internal;
         
         public Builder() {
             this.internal = new Loki();

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Dashboard.java
@@ -21,7 +21,7 @@ public class Dashboard {
 
     
     public static class Builder implements cog.Builder<Dashboard> {
-        private final Dashboard internal;
+        protected final Dashboard internal;
         
         public Builder() {
             this.internal = new Dashboard();

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/SomePanel.java
@@ -20,7 +20,7 @@ public class SomePanel {
 
     
     public static class Builder implements cog.Builder<SomePanel> {
-        private final SomePanel internal;
+        protected final SomePanel internal;
         
         public Builder() {
             this.internal = new SomePanel();

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/SomeStruct.java
@@ -18,7 +18,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilders/nullable_map_assignment/SomeStruct.java
@@ -19,7 +19,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
+++ b/testdata/jennies/builders/references/JavaBuilders/some_pkg/Person.java
@@ -19,7 +19,7 @@ public class Person {
 
     
     public static class Builder implements cog.Builder<Person> {
-        private final Person internal;
+        protected final Person internal;
         
         public Builder() {
             this.internal = new Person();

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -18,7 +18,7 @@ public class SomeStruct {
 
     
     public static class Builder implements cog.Builder<SomeStruct> {
-        private final SomeStruct internal;
+        protected final SomeStruct internal;
         
         public Builder() {
             this.internal = new SomeStruct();

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/NestedStruct.java
@@ -18,7 +18,7 @@ public class NestedStruct {
 
     
     public static class Builder implements cog.Builder<NestedStruct> {
-        private final NestedStruct internal;
+        protected final NestedStruct internal;
         
         public Builder() {
             this.internal = new NestedStruct();

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilders/struct_with_defaults/Struct.java
@@ -30,7 +30,7 @@ public class Struct {
 
     
     public static class Builder implements cog.Builder<Struct> {
-        private final Struct internal;
+        protected final Struct internal;
         
         public Builder() {
             this.internal = new Struct();


### PR DESCRIPTION
Closes: https://github.com/grafana/cog/issues/559

It sets the modifier of the internal class inside builders as protected. As this way, if a class extends from it, it has access to its values.

Apart of this, `dashboard.Panel` is transformed into a generic class to be able to be able to use the methods from the extended class at any order. There are some examples to see this change better:

If we don't make panel generic:

```java
public class Builder implements cog.Builder<Panel> {
   protected final Panel internal;

  public Builder() {
    this.internal = new Panel();
  }

  public Builder title(String title) {
    this.internal.title = title;
    return this;
  }
  ...
}
```

```java
public class MyBuilder extends Builder {
  public MyBuilder() {
     super();
  }

  public MyBuilder myFunction(Integer b) {
    this.internal.aInteger = b;
    return this;
  }
  ...
}
```

With this example:
* It works: `Panel panel = new MyClass.MyBuilder().myFunction(b).title("a").build();`
* It doesn't work: `Panel panel = new MyClass.MyBuilder().title("a").myFunction(b).build();`

When it calls to `title`, it returns a `Builder` and the builder doesn't has access to `MyBuilder` functions.

So, transforming dashboard.Panel into generic one:

```java
public class Builder<T extends Builder<T>> implements cog.Builder<Panel> {
  ...

  public T title(String title) {
    this.panel.title = title;
    return (T) this;
  }
}
```

```java
public class MyBuilder extends Builder<MyBuilder> {
   // Same as before
}
```

With this, `title` method returns the builder of the `(T)` class, that in that case is `MyBuilder`, so you can access to the methods in any order.