### PR TITLE
Set the `piechart.Options.displayLabels` field as optional

### DIFF
--- a/config/compiler/kind_registry.yaml
+++ b/config/compiler/kind_registry.yaml
@@ -111,6 +111,13 @@ passes:
   - fields_set_not_required:
       fields: [ common.TableFieldOptions.CellOptions ]
 
+  ##################
+  # piechart panel #
+  ##################
+
+  - fields_set_not_required:
+      fields: [ piechart.Options.displayLabels ]
+
   #####################
   # candlestick panel #
   #####################


### PR DESCRIPTION
If set to null, this field breaks the Grafana UI. Setting it as optional allows us to omit it in the JSON representation when null.