### PR TITLE
Bootstrap JSON → code conversion in Go

### DIFF
--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -196,12 +196,15 @@ type PathItem struct {
 	// useful mostly for composability purposes, when a field Type is "any"
 	// and we're trying to "compose in" something of a known type.
 	TypeHint *Type `json:",omitempty"`
+	// Is this element of the path the root? (ie: a variable, not a member of a struct)
+	Root bool
 }
 
 func (item PathItem) DeepCopy() PathItem {
 	clone := PathItem{
 		Identifier: item.Identifier,
 		Type:       item.Type.DeepCopy(),
+		Root:       item.Root,
 	}
 
 	if item.TypeHint != nil {
@@ -239,6 +242,10 @@ func (path Path) Append(suffix Path) Path {
 	newPath = append(newPath, suffix...)
 
 	return newPath
+}
+
+func (path Path) AppendStructField(field StructField) Path {
+	return path.Append(PathFromStructField(field))
 }
 
 func (path Path) Last() PathItem {

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -514,6 +514,10 @@ func NewObject(pkg string, name string, objectType Type, passesTrail ...string) 
 	}
 }
 
+func (object *Object) AsRef() Type {
+	return object.SelfRef.AsType()
+}
+
 func (object *Object) AddToPassesTrail(trail string) {
 	object.PassesTrail = append(object.PassesTrail, trail)
 }

--- a/internal/codegen/output.go
+++ b/internal/codegen/output.go
@@ -14,8 +14,9 @@ import (
 type Output struct {
 	Directory string `yaml:"directory"`
 
-	Types    bool `yaml:"types"`
-	Builders bool `yaml:"builders"`
+	Types      bool `yaml:"types"`
+	Builders   bool `yaml:"builders"`
+	Converters bool `yaml:"converters"`
 
 	Languages []*OutputLanguage `yaml:"languages"`
 

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -124,9 +124,10 @@ func (pipeline *Pipeline) interpolate(input string) string {
 
 func (pipeline *Pipeline) jenniesConfig() languages.Config {
 	return languages.Config{
-		Debug:    pipeline.Debug,
-		Types:    pipeline.Output.Types,
-		Builders: pipeline.Output.Builders,
+		Debug:      pipeline.Debug,
+		Types:      pipeline.Output.Types,
+		Builders:   pipeline.Output.Builders,
+		Converters: pipeline.Output.Converters,
 	}
 }
 

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -1,0 +1,77 @@
+package golang
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+type Converter struct {
+	Config         Config
+	NullableConfig languages.NullableConfig
+	Tmpl           *template.Template
+}
+
+func (jenny *Converter) JennyName() string {
+	return "GoConverter"
+}
+
+func (jenny *Converter) Generate(context languages.Context) (codejen.Files, error) {
+	files := codejen.Files{}
+
+	for _, builder := range context.Builders {
+		output, err := jenny.generateConverter(context, builder)
+		if err != nil {
+			return nil, err
+		}
+
+		filename := filepath.Join(
+			formatPackageName(builder.Package),
+			fmt.Sprintf("%s_converter_gen.go", strings.ToLower(builder.Name)),
+		)
+
+		files = append(files, *codejen.NewFile(filename, output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
+	converter := languages.NewConverterGenerator(jenny.NullableConfig).FromBuilder(context, builder)
+
+	imports := NewImportMap()
+	typeImportMapper := func(pkg string) string {
+		if imports.IsIdentical(pkg, builder.Package) {
+			return ""
+		}
+
+		return imports.Add(pkg, jenny.Config.importPath(pkg))
+	}
+	typeImportMapper("cog")
+	formatter := builderTypeFormatter(jenny.Config, context, typeImportMapper)
+
+	dummyImports := NewImportMap()
+	dummyImportMapper := func(pkg string) string {
+		return dummyImports.Add(pkg, jenny.Config.importPath(pkg))
+	}
+
+	formatRawRef := func(pkg string, ref string) string {
+		return formatter.formatRef(ast.NewRef(pkg, ref), false)
+	}
+
+	return jenny.Tmpl.
+		Funcs(map[string]any{
+			"formatType":   builderTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
+			"formatPath":   makePathFormatter(formatter),
+			"formatRawRef": formatRawRef,
+		}).
+		RenderAsBytes("converters/converter.tmpl", map[string]any{
+			"Imports":   imports,
+			"Converter": converter,
+		})
+}

--- a/internal/jennies/golang/equality_test.go
+++ b/internal/jennies/golang/equality_test.go
@@ -117,25 +117,6 @@ func TestEquality_Struct_WithArrays(t *testing.T) {
 	req.True(equality.Arrays{Refs: []equality.Variable{}}.Equals(equality.Arrays{Refs: []equality.Variable{}}))
 	req.True(equality.Arrays{Refs: []equality.Variable{{Name: "foo"}}}.Equals(equality.Arrays{Refs: []equality.Variable{{Name: "foo"}}}))
 
-	req.True(equality.Arrays{AnonymousStructs: []struct {
-		Inner string `json:"inner"`
-	}{}}.Equals(equality.Arrays{
-		AnonymousStructs: []struct {
-			Inner string `json:"inner"`
-		}{},
-	}))
-	req.True(equality.Arrays{AnonymousStructs: []struct {
-		Inner string `json:"inner"`
-	}{
-		{Inner: "foo"},
-	}}.Equals(equality.Arrays{
-		AnonymousStructs: []struct {
-			Inner string `json:"inner"`
-		}{
-			{Inner: "foo"},
-		},
-	}))
-
 	req.True(equality.Arrays{ArrayOfAny: []any{}}.Equals(equality.Arrays{ArrayOfAny: []any{}}))
 	req.True(equality.Arrays{ArrayOfAny: []any{"foo", 1}}.Equals(equality.Arrays{ArrayOfAny: []any{"foo", 1}}))
 
@@ -145,30 +126,6 @@ func TestEquality_Struct_WithArrays(t *testing.T) {
 	req.False(equality.Arrays{ArrayOfArray: [][]string{{"foo", "bar"}}}.Equals(equality.Arrays{ArrayOfArray: [][]string{{"foo"}}}))
 	req.False(equality.Arrays{ArrayOfArray: [][]string{{"foo"}, {"bar"}}}.Equals(equality.Arrays{ArrayOfArray: [][]string{{"foo"}}}))
 	req.False(equality.Arrays{ArrayOfArray: [][]string{{"foo"}, {"bar"}}}.Equals(equality.Arrays{ArrayOfArray: [][]string{{"foo"}, {"other"}}}))
-
-	req.False(equality.Arrays{AnonymousStructs: []struct {
-		Inner string `json:"inner"`
-	}{
-		{Inner: "foo"},
-	}}.Equals(equality.Arrays{
-		AnonymousStructs: []struct {
-			Inner string `json:"inner"`
-		}{
-			{Inner: "bar"},
-		},
-	}))
-	req.False(equality.Arrays{AnonymousStructs: []struct {
-		Inner string `json:"inner"`
-	}{
-		{Inner: "foo"},
-	}}.Equals(equality.Arrays{
-		AnonymousStructs: []struct {
-			Inner string `json:"inner"`
-		}{
-			{Inner: "foo"},
-			{Inner: "bar"},
-		},
-	}))
 
 	req.False(equality.Arrays{ArrayOfAny: []any{"foo", 1}}.Equals(equality.Arrays{ArrayOfAny: []any{"foo"}}))
 	req.False(equality.Arrays{ArrayOfAny: []any{"bar"}}.Equals(equality.Arrays{ArrayOfAny: []any{"foo"}}))
@@ -198,19 +155,6 @@ func TestEquality_Struct_WithMaps(t *testing.T) {
 	}.Equals(equality.Maps{
 		Refs: map[string]equality.Variable{
 			"foo": {Name: "foo"},
-		},
-	}))
-	req.True(equality.Maps{
-		AnonymousStructs: map[string]struct {
-			Inner string `json:"inner"`
-		}{
-			"foo": {Inner: "foo"},
-		},
-	}.Equals(equality.Maps{
-		AnonymousStructs: map[string]struct {
-			Inner string `json:"inner"`
-		}{
-			"foo": {Inner: "foo"},
 		},
 	}))
 	req.True(equality.Maps{

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -56,7 +56,7 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
 	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, packageMapper)
-	unmarshallerGenerator := NewJSONMarshalling(jenny.Tmpl, packageMapper, jenny.typeFormatter)
+	unmarshallerGenerator := NewJSONMarshalling(jenny.Config, jenny.Tmpl, packageMapper, jenny.typeFormatter)
 	equalityMethodsGenerator := newEqualityMethods(jenny.Tmpl)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {

--- a/internal/jennies/golang/runtime.go
+++ b/internal/jennies/golang/runtime.go
@@ -106,6 +106,14 @@ func MakeBuildErrors(rootPath string, err error) BuildErrors {
 	}}
 }
 
+func Unptr[T any](v *T) T {
+	var val T
+	if v == nil {
+		return val
+	}
+	return *v
+}
+
 `)
 }
 

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -1,0 +1,107 @@
+package {{ .Converter.Package | formatPackageName }}
+
+{{ $converter := include "converter" . }}
+
+{{ .Imports }}
+
+{{ $converter }}
+
+{{- define "guard" }}
+    {{- if and (eq .Op "!=") (eq .Value nil) -}}
+        {{ .Path | formatPath }} != nil
+    {{- else -}}
+        {{- $leftOperand := print (.Path.Last.Type | maybeDereference) (.Path | formatPath) -}}
+        {{- $operator := .Op -}}
+        {{- if eq .Op "minLength" -}}
+            {{- $leftOperand = print "len(" $leftOperand ")" -}}
+            {{- $operator = ">=" -}}
+        {{- end -}}
+        {{- if eq .Op "maxLength" -}}
+            {{- $leftOperand = print "len(" $leftOperand ")" -}}
+            {{- $operator = "<=" -}}
+        {{- end -}}
+        {{- $leftOperand }} {{ $operator}} {{ .Value | formatScalar -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "value_formatter" -}}
+    {{- if .Type.IsAny -}}
+        cog.Dump({{ .Path | formatPath }})
+    {{- else if .Type.IsScalar -}}
+        fmt.Sprintf("%#v", {{ .Type | maybeDereference }}{{ .Path | formatPath }})
+    {{- else -}}
+        cog.Dump({{ .Type | maybeDereference }}{{ .Path | formatPath }})
+    {{- end -}}
+{{- end }}
+
+{{- define "guards" }}
+    {{- $guardsCount := sub1 (len .) -}}
+    {{- range $i, $guard := . }}{{- template "guard" $guard }}{{ if ne $i $guardsCount }} && {{ end }}{{ end }}
+{{- end }}
+
+{{- define "prepare_arg" -}}
+    {{- with .Arg.Builder -}}
+        {{ $.IntoVar }} := {{ formatRawRef .BuilderPkg (print .BuilderName "Converter") }}({{- if not .ValueType.Nullable}}&{{ end }}{{ .ValuePath | formatPath }})
+    {{- end -}}
+    {{- with .Arg.Array -}}
+        tmp{{ $.IntoVar }} := []string{}
+        for _, {{ .ValueAs | formatPath }} := range {{ .For | formatPath }} {
+        {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
+        {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" .ForArg) }}
+        tmp{{ $.IntoVar }} = append(tmp{{ $.IntoVar }}, {{ $subIntoVar }})
+        }
+        {{ $.IntoVar }} := "{{ .ForType | formatType }}{" + strings.Join(tmp{{ $.IntoVar }}, ",\n") + "}"
+    {{- end -}}
+    {{- with .Arg.Runtime -}}
+        {{ $.IntoVar }} := cog.{{ .FuncName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}{{ $runtimeArg.ValuePath | formatPath }}{{ else }}{{ maybeUnptr ($runtimeArg.ValuePath | formatPath) $runtimeArg.ValueType }}{{ end }}, {{ end }})
+    {{- end -}}
+    {{- with .Arg.Direct -}}
+        {{ $.IntoVar }} := {{- template "value_formatter" (dict "Type" .ValueType "Path" .ValuePath) -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "option_mapping" -}}
+    {{- $argsCount := sub1 (len .Args) -}}
+    {{- with .ArgumentGuards -}}if {{ template "guards" . }} { {{- end }}
+    {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} { {{- end }}
+    buffer.WriteString(`{{ .Option.Name | upperCamelCase }}(`)
+    {{- range $i, $arg := .Args }}
+        {{- $intoVar := print "arg" $i }}
+        {{ template "prepare_arg" (dict "IntoVar" $intoVar "Arg" $arg) }}
+        buffer.WriteString({{ $intoVar }})
+        {{ if ne $i $argsCount }}buffer.WriteString(", "){{- end }}
+    {{- end }}
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    {{ with .ArgumentGuards -}} } {{- end }}
+    {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} } {{- end }}
+{{- end }}
+
+{{- define "conversion_mapping" -}}
+    {{- $firstOpt := .Options | first }}
+    {{- with $firstOpt.Guards -}}if {{ template "guards" . }} { {{- end }}
+    {{- if ne .RepeatFor nil -}}for _, {{ .RepeatAs }} := range {{ .RepeatFor | formatPath }} { {{- end }}
+    {{- range $optMapping := .Options }}
+        {{ template "option_mapping" $optMapping }}
+    {{- end }}
+    {{ if ne .RepeatFor nil -}} } {{- end }}
+    {{- with $firstOpt.Guards -}} } {{- end }}
+{{- end }}
+
+{{- define "converter" -}}
+    func {{ .Converter.BuilderName | upperCamelCase }}Converter(input *{{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType  }}) string {
+    {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
+    calls := []string{
+    `{{ .Converter.Package | formatPackageName }}.New{{ .Converter.BuilderName | upperCamelCase }}Builder({{ with .Converter.ConstructorArgs}}`+{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} + ", " +{{ end }}{{ end }}+`{{ end }})`,
+    }
+    var buffer strings.Builder
+
+    {{- range .Converter.Mappings }}
+        {{ template "conversion_mapping" . }}
+    {{- end }}
+
+    return strings.Join(calls, ".\t\n")
+    }
+{{- end }}

--- a/internal/jennies/golang/templates/runtime/runtime.tmpl
+++ b/internal/jennies/golang/templates/runtime/runtime.tmpl
@@ -69,6 +69,27 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 		}
 	}
 
+	// Dataqueries might reference the datasource to use, and its type. Let's use that.
+	partialDataquery := struct {
+		Datasource struct {
+			Type string `json:"type"`
+		} `json:"datasource"`
+	}{}
+	if err := json.Unmarshal(raw, &partialDataquery); err != nil {
+		return nil, err
+	}
+	if partialDataquery.Datasource.Type != "" {
+		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.DataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
 	// We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
 	dataquery := variants.UnknownDataquery{}
 	if err := json.Unmarshal(raw, &dataquery); err != nil {

--- a/internal/jennies/golang/templates/runtime/runtime.tmpl
+++ b/internal/jennies/golang/templates/runtime/runtime.tmpl
@@ -111,7 +111,6 @@ func ConfigForPanelcfgVariant(identifier string) (variants.PanelcfgConfig, bool)
 	return NewRuntime().ConfigForPanelcfgVariant(identifier)
 }
 
-
 func (runtime *Runtime) ConvertPanelToGo(inputPanel any, panelType string) string {
 	config, found := runtime.panelcfgVariants[panelType]
 	if found && config.GoConverter != nil {
@@ -121,12 +120,10 @@ func (runtime *Runtime) ConvertPanelToGo(inputPanel any, panelType string) strin
 	return "/* could not convert panel to go */"
 }
 
-func (runtime *Runtime) ConvertDataqueryToGo(inputPanel any, dataqueryTypeHints ...string) string {
-	for _, dataqueryTypeHint := range dataqueryTypeHints {
-		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
-		if found && config.GoConverter != nil {
-			return config.GoConverter(inputPanel)
-		}
+func (runtime *Runtime) ConvertDataqueryToGo(dataquery variants.Dataquery) string {
+	config, found := runtime.dataqueryVariants[dataquery.DataqueryType()]
+	if found && config.GoConverter != nil {
+		return config.GoConverter(dataquery)
 	}
 
 	return "/* could not convert dataquery to go */"
@@ -136,8 +133,8 @@ func ConvertPanelToCode(inputPanel any, panelType string) string {
 	return NewRuntime().ConvertPanelToGo(inputPanel, panelType)
 }
 
-func ConvertDataqueryToCode(inputPanel any, dataqueryTypeHints ...string) string {
-	return NewRuntime().ConvertDataqueryToGo(inputPanel, dataqueryTypeHints...)
+func ConvertDataqueryToCode(dataquery variants.Dataquery) string {
+	return NewRuntime().ConvertDataqueryToGo(dataquery)
 }
 
 func Dump(root any) string {

--- a/internal/jennies/golang/templates/runtime/runtime.tmpl
+++ b/internal/jennies/golang/templates/runtime/runtime.tmpl
@@ -110,3 +110,128 @@ func UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquer
 func ConfigForPanelcfgVariant(identifier string) (variants.PanelcfgConfig, bool) {
 	return NewRuntime().ConfigForPanelcfgVariant(identifier)
 }
+
+
+func (runtime *Runtime) ConvertPanelToGo(inputPanel any, panelType string) string {
+	config, found := runtime.panelcfgVariants[panelType]
+	if found && config.GoConverter != nil {
+		return config.GoConverter(inputPanel)
+	}
+
+	return "/* could not convert panel to go */"
+}
+
+func (runtime *Runtime) ConvertDataqueryToGo(inputPanel any, dataqueryTypeHints ...string) string {
+	for _, dataqueryTypeHint := range dataqueryTypeHints {
+		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
+		if found && config.GoConverter != nil {
+			return config.GoConverter(inputPanel)
+		}
+	}
+
+	return "/* could not convert dataquery to go */"
+}
+
+func ConvertPanelToCode(inputPanel any, panelType string) string {
+	return NewRuntime().ConvertPanelToGo(inputPanel, panelType)
+}
+
+func ConvertDataqueryToCode(inputPanel any, dataqueryTypeHints ...string) string {
+	return NewRuntime().ConvertDataqueryToGo(inputPanel, dataqueryTypeHints...)
+}
+
+func Dump(root any) string {
+	return dumpValue(reflect.ValueOf(root))
+}
+
+func dumpValue(value reflect.Value) string {
+	if !value.IsValid() {
+		return "<invalid>"
+	}
+
+	switch value.Kind() {
+	case reflect.Bool:
+		return fmt.Sprintf("%#v", value.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d", value.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d", value.Uint())
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%#v", value.Float())
+	case reflect.String:
+		return fmt.Sprintf("%#v", value.String())
+	case reflect.Array, reflect.Slice:
+		return dumpArray(value)
+	case reflect.Map:
+		return dumpMap(value)
+	case reflect.Struct:
+		return dumpStruct(value)
+	case reflect.Interface:
+		if !value.CanInterface() {
+			return "<interface: can't interface>"
+		}
+
+		return Dump(value.Interface())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return "nil"
+		}
+
+		pointed := value.Elem()
+
+		return fmt.Sprintf("cog.ToPtr[%s](%s)", pointed.Type().String(), dumpValue(pointed))
+	default:
+		return fmt.Sprintf("<unknown: type=%s, kind=%s>", value.Type(), value.Kind().String())
+	}
+}
+
+func dumpArray(value reflect.Value) string {
+	if value.IsNil() {
+		return "nil"
+	}
+
+	parts := make([]string, 0, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		parts = append(parts, dumpValue(value.Index(i)))
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
+}
+
+func dumpMap(value reflect.Value) string {
+	if value.IsNil() {
+		return "nil"
+	}
+
+	parts := make([]string, 0, value.Len())
+	iter := value.MapRange()
+	for iter.Next() {
+		line := fmt.Sprintf("%s: %s", dumpValue(iter.Key()), dumpValue(iter.Value()))
+		parts = append(parts, line)
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
+}
+
+func dumpStruct(value reflect.Value) string {
+	parts := make([]string, 0, value.NumField())
+	structType := value.Type()
+
+	for i := 0; i < value.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		fieldValue := value.Field(i)
+		fieldValueKind := fieldValue.Kind()
+		if (fieldValueKind == reflect.Pointer || fieldValueKind == reflect.Interface || fieldValueKind == reflect.Array || fieldValueKind == reflect.Slice || fieldValueKind == reflect.Map) && fieldValue.IsNil() {
+			continue
+		}
+
+		line := fmt.Sprintf("%s: %s", field.Name, dumpValue(fieldValue))
+		parts = append(parts, line)
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
+}

--- a/internal/jennies/golang/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_models.tmpl
@@ -4,11 +4,13 @@ type PanelcfgConfig struct {
 	Identifier             string
 	OptionsUnmarshaler     func(raw []byte) (any, error)
 	FieldConfigUnmarshaler func(raw []byte) (any, error)
+	GoConverter func(inputPanel any) string
 }
 
 type DataqueryConfig struct {
 	Identifier           string
 	DataqueryUnmarshaler func(raw []byte) (Dataquery, error)
+	GoConverter func(inputPanel any) string
 }
 
 type Dataquery interface {

--- a/internal/jennies/golang/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_models.tmpl
@@ -16,6 +16,7 @@ type DataqueryConfig struct {
 type Dataquery interface {
 	ImplementsDataqueryVariant()
 	Equals(other Dataquery) bool
+	DataqueryType() string
 }
 
 type Panelcfg interface {
@@ -24,9 +25,11 @@ type Panelcfg interface {
 
 type UnknownDataquery map[string]any
 
-func (unknown UnknownDataquery) ImplementsDataqueryVariant() {
-
+func (unknown UnknownDataquery) DataqueryType() string {
+	return "unknown"
 }
+
+func (unknown UnknownDataquery) ImplementsDataqueryVariant() { }
 
 func (unknown UnknownDataquery) Equals(otherCandidate Dataquery) bool {
 	if otherCandidate == nil {

--- a/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
@@ -2,14 +2,30 @@ func VariantConfig() variants.DataqueryConfig {
 	return variants.DataqueryConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",
 	    DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
-            dataquery := {{ .object.Name|upperCamelCase }}{}
+            dataquery := &{{ .object.Name|upperCamelCase }}{}
 
-            if err := json.Unmarshal(raw, &dataquery); err != nil {
+            if err := json.Unmarshal(raw, dataquery); err != nil {
                 return nil, err
             }
 
             return dataquery, nil
        },
+        {{- if .hasConverter }}
+        GoConverter: func(inputPanel any) string {
+            panel := inputPanel.(*{{ .object.Name | upperCamelCase }})
+            {{ if ne .disjunctionStruct nil -}}
+                {{- range $field := .disjunctionStruct.Fields }}
+                    if panel.{{ $field.Name | upperCamelCase }} != nil {
+                        return {{ $field.Type.Ref.ReferredType | upperCamelCase }}Converter(panel.{{ $field.Name | upperCamelCase }})
+                    }
+                {{- end }}
+
+                return ""
+            {{- else -}}
+                return {{ .object.Name | upperCamelCase }}Converter(panel)
+            {{- end }}
+        },
+        {{- end }}
 	}
 }
 

--- a/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
@@ -3,9 +3,9 @@ func VariantConfig() variants.PanelcfgConfig {
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",
 		{{- if .hasOptions }}
 		OptionsUnmarshaler: func (raw []byte) (any, error) {
-			options := Options{}
+			options := &Options{}
 
-			if err := json.Unmarshal(raw, &options); err != nil {
+			if err := json.Unmarshal(raw, options); err != nil {
 				return nil, err
 			}
 
@@ -14,13 +14,18 @@ func VariantConfig() variants.PanelcfgConfig {
 		{{- end }}
 		{{- if .hasFieldConfig }}
 		FieldConfigUnmarshaler: func (raw []byte) (any, error) {
-			fieldConfig := FieldConfig{}
+			fieldConfig := &FieldConfig{}
 
-			if err := json.Unmarshal(raw, &fieldConfig); err != nil {
+			if err := json.Unmarshal(raw, fieldConfig); err != nil {
 				return nil, err
 			}
 
 			return fieldConfig, nil
+		},
+		{{- end }}
+		{{- if .hasConverter }}
+		GoConverter: func(inputPanel any) string {
+			return PanelConverter(inputPanel.(*dashboard.Panel))
 		},
 		{{- end }}
 	}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/template"
 )
 
-//go:embed templates/runtime/*.tmpl templates/builders/*.tmpl templates/types/*.tmpl
+//go:embed templates/runtime/*.tmpl templates/builders/*.tmpl templates/converters/*.tmpl templates/types/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -26,6 +26,9 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			},
 			"formatTypeNoBuilder": func(_ ast.Type) string {
 				panic("formatType() needs to be overridden by a jenny")
+			},
+			"formatRawRef": func(_ ast.Type) string {
+				panic("formatRawRef() needs to be overridden by a jenny")
 			},
 			"emptyValueForGuard": func(_ ast.Type) string {
 				panic("emptyValueForGuard() needs to be overridden by a jenny")
@@ -65,6 +68,20 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 				}
 
 				return variableName
+			},
+			"maybeUnptr": func(variableName string, intoType ast.Type) string {
+				if !intoType.Nullable || intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot() {
+					return variableName
+				}
+
+				return "cog.Unptr(" + variableName + ")"
+			},
+			"maybeDereference": func(typeDef ast.Type) string {
+				if typeDef.Nullable && !typeDef.IsAnyOf(ast.KindArray, ast.KindMap) {
+					return "*"
+				}
+
+				return ""
 			},
 			"isNullableNonArray": func(typeDef ast.Type) bool {
 				return typeDef.Nullable && !typeDef.IsArray()

--- a/internal/jennies/template/template.go
+++ b/internal/jennies/template/template.go
@@ -180,6 +180,7 @@ func (template *Template) builtins() FuncMap {
 
 	return gotemplate.FuncMap{
 		"add1": func(i int) int { return i + 1 },
+		"sub1": func(i int) int { return i - 1 },
 		// https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/dict.go#L76
 		"dict": func(v ...any) map[string]any {
 			dict := map[string]any{}
@@ -206,6 +207,16 @@ func (template *Template) builtins() FuncMap {
 				return d
 			}
 			return given[0]
+		},
+		"first": func(list any) any {
+			tp := reflect.TypeOf(list).Kind()
+			switch tp {
+			case reflect.Slice, reflect.Array:
+				l2 := reflect.ValueOf(list)
+				return l2.Index(0).Interface() // this will *willingly* panic if the list is empty
+			default:
+				panic(fmt.Sprintf("Cannot find first on type %s", tp))
+			}
 		},
 
 		// ------- \\

--- a/internal/languages/config.go
+++ b/internal/languages/config.go
@@ -10,4 +10,7 @@ type Config struct {
 
 	// Builders indicates whether builders should be generated or not.
 	Builders bool
+
+	// Converters indicates whether converters should be generated or not.
+	Converters bool
 }

--- a/internal/languages/context.go
+++ b/internal/languages/context.go
@@ -19,28 +19,32 @@ func (context *Context) LocateObjectByRef(ref ast.RefType) (ast.Object, bool) {
 }
 
 func (context *Context) ResolveToBuilder(def ast.Type) bool {
+	_, ok := context.ResolveAsBuilder(def)
+
+	return ok
+}
+
+func (context *Context) ResolveAsBuilder(def ast.Type) (ast.Builder, bool) {
 	if def.IsArray() {
-		return context.ResolveToBuilder(def.AsArray().ValueType)
+		return context.ResolveAsBuilder(def.AsArray().ValueType)
 	}
 
 	if def.IsDisjunction() {
 		for _, branch := range def.AsDisjunction().Branches {
-			if context.ResolveToBuilder(branch) {
-				return true
+			if builder, found := context.ResolveAsBuilder(branch); found {
+				return builder, true
 			}
 		}
 
-		return false
+		return ast.Builder{}, false
 	}
 
 	if !def.IsRef() {
-		return false
+		return ast.Builder{}, false
 	}
 
 	ref := def.AsRef()
-	_, found := context.Builders.LocateByObject(ref.ReferredPkg, ref.ReferredType)
-
-	return found
+	return context.Builders.LocateByObject(ref.ReferredPkg, ref.ReferredType)
 }
 
 func (context *Context) IsDisjunctionOfBuilders(def ast.Type) bool {

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -421,6 +421,16 @@ func (generator *ConverterGenerator) optionGuards(converter Converter, option as
 			guards.Set(guard.String(), guard)
 		}
 
+		// For scalar values, add a guard against assignments equal to the default value for that path
+		if assignmentType.IsScalar() && assignmentType.Default != nil {
+			guard := MappingGuard{
+				Path:  converter.inputRootPath().Append(assignment.Path),
+				Op:    ast.NotEqualOp,
+				Value: assignmentType.Default,
+			}
+			guards.Set(guard.String(), guard)
+		}
+
 		// TODO: is that correct/needed?
 		if assignment.Method != ast.AppendAssignment && assignment.Value.Envelope != nil {
 			for _, envelopePath := range assignment.Value.Envelope.Values {

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -284,42 +284,13 @@ func (generator *ConverterGenerator) argumentsForEnvelope(context Context, conve
 
 func (generator *ConverterGenerator) argumentForType(context Context, converter Converter, argName string, valuePath ast.Path, typeDef ast.Type) ArgumentMapping {
 	if typeDef.IsComposableSlot() {
-		var slotTypeHintsArgs []*DirectArgMapping
-		var guards []MappingGuard
-		converterRootType := context.ResolveRefs(converter.inputRootPath().Last().Type)
-
-		if converterRootType.IsStruct() {
-			for _, field := range converterRootType.Struct.Fields {
-				if !field.Type.IsRef() || field.Type.AsRef().ReferredType != "DataSourceRef" {
-					continue
-				}
-
-				refPath := ast.PathFromStructField(field)
-				datasourceRefType := context.ResolveRefs(field.Type)
-
-				typeField, found := datasourceRefType.Struct.FieldByName("type")
-				if !found {
-					continue
-				}
-
-				typePath := refPath.AppendStructField(typeField)
-				guards = append(guards, generator.pathNotNullGuards(converter, typePath)...)
-
-				slotTypeHintsArgs = append(slotTypeHintsArgs, &DirectArgMapping{
-					ValuePath: converter.inputRootPath().Append(typePath),
-					ValueType: typeField.Type,
-				})
-			}
-		}
-
 		return ArgumentMapping{
 			Runtime: &RuntimeArgMapping{
 				FuncName: fmt.Sprintf("Convert%sToCode", tools.UpperCamelCase(string(typeDef.AsComposableSlot().Variant))),
-				Args: append([]*DirectArgMapping{
+				Args: []*DirectArgMapping{
 					{ValuePath: valuePath, ValueType: typeDef},
-				}, slotTypeHintsArgs...),
+				},
 			},
-			Guards: guards,
 		}
 	}
 

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -1,0 +1,507 @@
+package languages
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/orderedmap"
+	"github.com/grafana/cog/internal/tools"
+)
+
+type MappingGuard struct {
+	Path  ast.Path
+	Op    ast.Op
+	Value any
+}
+
+func (guard MappingGuard) String() string {
+	return fmt.Sprintf("%s %s %v", guard.Path, guard.Op, guard.Value)
+}
+
+type DirectArgMapping struct {
+	ValuePath ast.Path // direct mapping between a JSON value and an argument
+	ValueType ast.Type
+}
+
+// mapping between a JSON value and an argument delegated to a builder
+type BuilderArgMapping struct {
+	ValuePath   ast.Path
+	ValueType   ast.Type
+	BuilderPkg  string
+	BuilderName string
+}
+
+type ArrayArgMapping struct {
+	For       ast.Path
+	ForType   ast.Type
+	ForArg    *ArgumentMapping
+	ValueAs   ast.Path
+	ValueType ast.Type
+}
+
+type RuntimeArgMapping struct {
+	FuncName string
+	Args     []*DirectArgMapping
+}
+
+type ArgumentMapping struct {
+	Direct  *DirectArgMapping
+	Runtime *RuntimeArgMapping
+	Builder *BuilderArgMapping
+	Array   *ArrayArgMapping
+
+	Guards []MappingGuard
+}
+
+type ConversionMapping struct {
+	// for _, panel := range input.Panels { WithPanel(panel) }
+	RepeatFor ast.Path // `input.Panels`
+	RepeatAs  string   // `panel`
+
+	Options []OptionMapping
+}
+
+type OptionMapping struct {
+	Option ast.Option // option in the builder
+
+	Guards []MappingGuard
+	Args   []ArgumentMapping
+}
+
+func (optMapping OptionMapping) ArgumentGuards() []MappingGuard {
+	var guards []MappingGuard
+
+	for _, arg := range optMapping.Args {
+		guards = append(guards, arg.Guards...)
+	}
+
+	return guards
+}
+
+type ConverterInput struct {
+	ArgName string
+	TypeRef ast.RefType
+}
+
+type Converter struct {
+	Package string
+
+	BuilderName string
+	Input       ConverterInput
+
+	// FIXME: assuming we only have direct mappings here is... *optimistic*.
+	ConstructorArgs []DirectArgMapping
+
+	Mappings []ConversionMapping
+}
+
+func (converter Converter) inputRootPath() ast.Path {
+	return ast.Path{
+		{
+			Identifier: converter.Input.ArgName,
+			Type:       converter.Input.TypeRef.AsType(),
+			Root:       true,
+		},
+	}
+}
+
+type ConverterGenerator struct {
+	nullableTypes NullableConfig
+
+	// generatedPaths lets us keep track of the paths in the input that we generated option mappings for.
+	// Since several options can represent with a single path, it allows us to not have "duplicates".
+	generatedPaths map[string]struct{}
+
+	listOfDisjunctionOptions map[string][]ast.Option
+}
+
+func NewConverterGenerator(nullableTypes NullableConfig) *ConverterGenerator {
+	return &ConverterGenerator{
+		nullableTypes:            nullableTypes,
+		generatedPaths:           make(map[string]struct{}),
+		listOfDisjunctionOptions: make(map[string][]ast.Option),
+	}
+}
+
+func (generator *ConverterGenerator) FromBuilder(context Context, builder ast.Builder) Converter {
+	converter := Converter{
+		Package:     builder.Package,
+		BuilderName: builder.Name,
+
+		Input: ConverterInput{
+			ArgName: "input",
+			TypeRef: builder.For.SelfRef,
+		},
+	}
+
+	converter.ConstructorArgs = generator.constructorArgs(converter, builder)
+
+	converter.Mappings = tools.Map(builder.Options, func(option ast.Option) ConversionMapping {
+		return generator.convertOption(context, converter, option)
+	})
+
+	for _, opts := range generator.listOfDisjunctionOptions {
+		converter.Mappings = append(converter.Mappings, generator.convertListOfDisjunctionOptions(context, converter, opts))
+	}
+
+	converter.Mappings = tools.Filter(converter.Mappings, func(mapping ConversionMapping) bool {
+		return len(mapping.Options) != 0
+	})
+
+	return converter
+}
+
+func (generator *ConverterGenerator) constructorArgs(converter Converter, builder ast.Builder) []DirectArgMapping {
+	// we're only interested in assignments made from a constructor argument
+	// (as opposed to constant initializations for example)
+	argAssignments := tools.Filter(builder.Constructor.Assignments, func(assignment ast.Assignment) bool {
+		return assignment.Value.Argument != nil
+	})
+
+	return tools.Map(argAssignments, func(assignment ast.Assignment) DirectArgMapping {
+		return DirectArgMapping{
+			ValuePath: converter.inputRootPath().Append(assignment.Path),
+			ValueType: assignment.Path.Last().Type,
+		}
+	})
+}
+
+func (generator *ConverterGenerator) convertListOfDisjunctionOptions(context Context, converter Converter, options []ast.Option) ConversionMapping {
+	mapping := ConversionMapping{
+		RepeatFor: converter.inputRootPath().Append(options[0].Assignments[0].Path),
+		RepeatAs:  "item",
+	}
+
+	mapping.Options = tools.Map(options, func(option ast.Option) OptionMapping {
+		return generator.mappingForOption(context, converter, mapping, option)
+	})
+	mapping.Options = tools.Filter(mapping.Options, func(optMapping OptionMapping) bool {
+		return optMapping.Option.Name != ""
+	})
+
+	return mapping
+}
+
+func (generator *ConverterGenerator) convertOption(context Context, converter Converter, option ast.Option) ConversionMapping {
+	assignments := tools.Filter(option.Assignments, func(assignment ast.Assignment) bool {
+		key := generator.assignmentKey(assignment)
+		if _, ok := generator.generatedPaths[key]; ok {
+			return false
+		}
+
+		return assignment.Value.Constant == nil
+	})
+	if len(assignments) == 0 {
+		return ConversionMapping{}
+	}
+
+	mapping := ConversionMapping{}
+
+	if len(assignments) == 1 && assignments[0].Method == ast.AppendAssignment {
+		mapping.RepeatFor = converter.inputRootPath().Append(assignments[0].Path)
+		mapping.RepeatAs = "item"
+	}
+
+	// if the option appends one possible branch of a disjunction to a list,
+	// we need to treat it differently
+	if mapping.RepeatFor != nil && generator.isAssignmentFromDisjunctionStruct(context, assignments[0]) {
+		path := assignments[0].Path.String()
+		generator.listOfDisjunctionOptions[path] = append(generator.listOfDisjunctionOptions[path], option)
+		return ConversionMapping{}
+	}
+
+	optMapping := generator.mappingForOption(context, converter, mapping, option)
+	if optMapping.Option.Name == "" {
+		return ConversionMapping{}
+	}
+
+	mapping.Options = []OptionMapping{optMapping}
+
+	return mapping
+}
+
+func (generator *ConverterGenerator) mappingForOption(context Context, converter Converter, mapping ConversionMapping, option ast.Option) OptionMapping {
+	optMapping := OptionMapping{
+		Option: option,
+		Guards: generator.optionGuards(converter, option),
+	}
+
+	assignments := tools.Filter(option.Assignments, func(assignment ast.Assignment) bool {
+		key := generator.assignmentKey(assignment)
+		if _, ok := generator.generatedPaths[key]; ok {
+			return false
+		}
+
+		return assignment.Value.Constant == nil
+	})
+	if len(assignments) == 0 {
+		return OptionMapping{}
+	}
+
+	i := 0
+	for _, assignment := range assignments {
+		i++
+
+		generator.generatedPaths[generator.assignmentKey(assignment)] = struct{}{}
+
+		argName := fmt.Sprintf("arg%d", i)
+		valueType := assignment.Path.Last().Type
+		valuePath := converter.inputRootPath().Append(assignment.Path)
+		if mapping.RepeatFor != nil {
+			valueType = valueType.AsArray().ValueType
+			valuePath = ast.Path{
+				{Identifier: mapping.RepeatAs, Type: valueType, Root: true},
+			}
+		}
+
+		if argument, ok := generator.argumentFromDisjunctionStruct(context, converter, argName, valuePath, assignment); ok {
+			optMapping.Args = append(optMapping.Args, argument)
+			continue
+		}
+
+		if assignment.Value.Envelope != nil {
+			arguments := generator.argumentsForEnvelope(context, converter, argName, valuePath, assignment)
+			optMapping.Args = append(optMapping.Args, arguments...)
+			continue
+		}
+
+		argument := generator.argumentForType(context, converter, argName, valuePath, valueType)
+		optMapping.Args = append(optMapping.Args, argument)
+	}
+
+	return optMapping
+}
+
+func (generator *ConverterGenerator) argumentsForEnvelope(context Context, converter Converter, argName string, valuePath ast.Path, assignment ast.Assignment) []ArgumentMapping {
+	var mappings []ArgumentMapping
+	for _, envelopeField := range assignment.Value.Envelope.Values {
+		fieldValuePath := valuePath.Append(envelopeField.Path)
+		mappings = append(mappings, generator.argumentForType(context, converter, argName, fieldValuePath, fieldValuePath.Last().Type))
+	}
+	return mappings
+}
+
+func (generator *ConverterGenerator) argumentForType(context Context, converter Converter, argName string, valuePath ast.Path, typeDef ast.Type) ArgumentMapping {
+	if typeDef.IsComposableSlot() {
+		var slotTypeHintsArgs []*DirectArgMapping
+		var guards []MappingGuard
+		converterRootType := context.ResolveRefs(converter.inputRootPath().Last().Type)
+
+		if converterRootType.IsStruct() {
+			for _, field := range converterRootType.Struct.Fields {
+				if !field.Type.IsRef() || field.Type.AsRef().ReferredType != "DataSourceRef" {
+					continue
+				}
+
+				refPath := ast.PathFromStructField(field)
+				datasourceRefType := context.ResolveRefs(field.Type)
+
+				typeField, found := datasourceRefType.Struct.FieldByName("type")
+				if !found {
+					continue
+				}
+
+				typePath := refPath.AppendStructField(typeField)
+				guards = append(guards, generator.pathNotNullGuards(converter, typePath)...)
+
+				slotTypeHintsArgs = append(slotTypeHintsArgs, &DirectArgMapping{
+					ValuePath: converter.inputRootPath().Append(typePath),
+					ValueType: typeField.Type,
+				})
+			}
+		}
+
+		return ArgumentMapping{
+			Runtime: &RuntimeArgMapping{
+				FuncName: fmt.Sprintf("Convert%sToCode", tools.UpperCamelCase(string(typeDef.AsComposableSlot().Variant))),
+				Args: append([]*DirectArgMapping{
+					{ValuePath: valuePath, ValueType: typeDef},
+				}, slotTypeHintsArgs...),
+			},
+			Guards: guards,
+		}
+	}
+
+	if typeDef.IsArray() {
+		valueAs := ast.Path{
+			{Identifier: argName, Type: typeDef.Array.ValueType, Root: true},
+		}
+
+		forArg := generator.argumentForType(context, converter, argName+"Value", valueAs, typeDef.Array.ValueType)
+
+		return ArgumentMapping{
+			Array: &ArrayArgMapping{
+				For:       valuePath,
+				ForType:   typeDef,
+				ForArg:    &forArg,
+				ValueAs:   valueAs,
+				ValueType: typeDef.Array.ValueType,
+			},
+		}
+	}
+
+	builder, found := context.ResolveAsBuilder(typeDef)
+	if found && strings.EqualFold(builder.Package, "dashboard") && strings.EqualFold("panel", builder.For.Name) {
+		typeField, _ := builder.For.Type.Struct.FieldByName("type")
+
+		return ArgumentMapping{
+			Runtime: &RuntimeArgMapping{
+				FuncName: "ConvertPanelToCode",
+				Args: []*DirectArgMapping{
+					{ValuePath: valuePath, ValueType: typeDef},
+					{ValuePath: valuePath.AppendStructField(typeField), ValueType: typeField.Type},
+				},
+			},
+		}
+	}
+	if found {
+		return ArgumentMapping{
+			Builder: &BuilderArgMapping{
+				ValuePath:   valuePath,
+				ValueType:   typeDef,
+				BuilderPkg:  builder.Package,
+				BuilderName: builder.Name,
+			},
+		}
+	}
+
+	return ArgumentMapping{
+		Direct: &DirectArgMapping{
+			ValuePath: valuePath,
+			ValueType: typeDef,
+		},
+	}
+}
+
+func (generator *ConverterGenerator) isAssignmentFromDisjunctionStruct(context Context, assignment ast.Assignment) bool {
+	if assignment.Value.Envelope == nil {
+		return false
+	}
+
+	envelopedType := assignment.Value.Envelope.Type
+	if envelopedType.IsRef() {
+		referredObject, _ := context.LocateObject(envelopedType.Ref.ReferredPkg, envelopedType.Ref.ReferredType)
+		envelopedType = referredObject.Type
+	}
+
+	return envelopedType.IsStructGeneratedFromDisjunction()
+}
+
+func (generator *ConverterGenerator) argumentFromDisjunctionStruct(context Context, converter Converter, argName string, valuePath ast.Path, assignment ast.Assignment) (ArgumentMapping, bool) {
+	if !generator.isAssignmentFromDisjunctionStruct(context, assignment) {
+		return ArgumentMapping{}, false
+	}
+
+	envelopeValues := assignment.Value.Envelope.Values
+
+	arg := generator.argumentForType(context, converter, argName, valuePath.Append(envelopeValues[0].Path), envelopeValues[0].Path.Last().Type)
+	arg.Guards = tools.Map(envelopeValues, func(envelopedField ast.EnvelopeFieldValue) MappingGuard {
+		return MappingGuard{
+			Path:  valuePath.Append(envelopedField.Path),
+			Op:    ast.NotEqualOp,
+			Value: nil,
+		}
+	})
+
+	return arg, true
+}
+
+func (generator *ConverterGenerator) optionGuards(converter Converter, option ast.Option) []MappingGuard {
+	// conditions safeguarding the conversion of the current option
+	guards := orderedmap.New[string, MappingGuard]()
+
+	// TODO: define guards other than "not null" checks? (0, "", ...)
+	// TODO: builders + array of builders (and array of array of builders, ...)
+	// TODO: envelopes?
+	for _, assignment := range option.Assignments {
+		nullPathChunksGuards := generator.pathNotNullGuards(converter, assignment.Path)
+		for _, guard := range nullPathChunksGuards {
+			guards.Set(guard.String(), guard)
+		}
+
+		if assignment.Value.Constant != nil {
+			guard := MappingGuard{
+				Path:  converter.inputRootPath().Append(assignment.Path),
+				Op:    ast.EqualOp,
+				Value: assignment.Value.Constant,
+			}
+			guards.Set(guard.String(), guard)
+			continue
+		}
+
+		assignmentType := assignment.Path.Last().Type
+
+		// For arrays: ensure they're not empty
+		if assignmentType.IsArray() {
+			guard := MappingGuard{
+				Path:  converter.inputRootPath().Append(assignment.Path),
+				Op:    ast.MinLengthOp,
+				Value: 1,
+			}
+			guards.Set(guard.String(), guard)
+		}
+
+		// For strings: ensure they're not empty
+		// TODO: deal with datetime strings
+		if assignmentType.IsScalar() && assignmentType.AsScalar().ScalarKind == ast.KindString && !assignmentType.HasHint(ast.HintStringFormatDateTime) {
+			guard := MappingGuard{
+				Path:  converter.inputRootPath().Append(assignment.Path),
+				Op:    ast.NotEqualOp,
+				Value: "",
+			}
+			guards.Set(guard.String(), guard)
+		}
+
+		// TODO: is that correct/needed?
+		if assignment.Method != ast.AppendAssignment && assignment.Value.Envelope != nil {
+			for _, envelopePath := range assignment.Value.Envelope.Values {
+				guard := MappingGuard{
+					Path:  converter.inputRootPath().Append(assignment.Path.Append(envelopePath.Path)),
+					Op:    ast.NotEqualOp,
+					Value: nil,
+				}
+				guards.Set(guard.String(), guard)
+			}
+			continue
+		}
+	}
+
+	return guards.Values()
+}
+
+func (generator *ConverterGenerator) pathNotNullGuards(converter Converter, path ast.Path) []MappingGuard {
+	var guards []MappingGuard
+
+	for i, chunk := range path {
+		chunkType := chunk.Type
+		if chunk.TypeHint != nil {
+			chunkType = *chunk.TypeHint
+		}
+
+		if !generator.nullableTypes.TypeIsNullable(chunkType) {
+			continue
+		}
+
+		guards = append(guards, MappingGuard{
+			Path:  converter.inputRootPath().Append(path[:i+1]),
+			Op:    ast.NotEqualOp,
+			Value: nil,
+		})
+	}
+
+	return guards
+}
+
+func (generator *ConverterGenerator) assignmentKey(assignment ast.Assignment) string {
+	path := assignment.Path.String()
+
+	if assignment.Value.Envelope != nil {
+		// TODO: envelope of envelope?
+		for _, envelopeAssignment := range assignment.Value.Envelope.Values {
+			path += "," + envelopeAssignment.Path.String()
+		}
+	}
+
+	return path
+}

--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -22,6 +22,12 @@ type NullableKindsProvider interface {
 	NullableKinds() NullableConfig
 }
 
+func (nullableConfig NullableConfig) TypeIsNullable(typeDef ast.Type) bool {
+	return typeDef.Nullable ||
+		(typeDef.IsAny() && nullableConfig.AnyIsNullable) ||
+		typeDef.IsAnyOf(nullableConfig.Kinds...)
+}
+
 type Languages map[string]Language
 
 func (languages Languages) AsLanguageRefs() []string {

--- a/internal/languages/nilchecks.go
+++ b/internal/languages/nilchecks.go
@@ -38,10 +38,7 @@ func GenerateBuilderNilChecks(language Language, context Context) (Context, erro
 					continue
 				}
 
-				nullable := chunk.Type.Nullable ||
-					(chunk.Type.IsAny() && nullableKinds.AnyIsNullable) ||
-					chunk.Type.IsAnyOf(nullableKinds.Kinds...)
-				if nullable {
+				if nullableKinds.TypeIsNullable(chunk.Type) {
 					subPath := assignment.Path[:i+1]
 					valueType := subPath.Last().Type
 					if subPath.Last().TypeHint != nil {

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -205,6 +205,9 @@
         "builders": {
           "type": "boolean"
         },
+        "converters": {
+          "type": "boolean"
+        },
         "languages": {
           "items": {
             "$ref": "#/$defs/CodegenOutputLanguage"

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -167,6 +167,10 @@
         "typehint": {
           "$ref": "#/$defs/AstType",
           "description": "useful mostly for composability purposes, when a field Type is \"any\"\nand we're trying to \"compose in\" something of a known type."
+        },
+        "root": {
+          "type": "boolean",
+          "description": "Is this element of the path the root? (ie: a variable, not a member of a struct)"
         }
       },
       "additionalProperties": false,

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -78,6 +78,27 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 		}
 	}
 
+	// Dataqueries might reference the datasource to use, and its type. Let's use that.
+	partialDataquery := struct {
+		Datasource struct {
+			Type string `json:"type"`
+		} `json:"datasource"`
+	}{}
+	if err := json.Unmarshal(raw, &partialDataquery); err != nil {
+		return nil, err
+	}
+	if partialDataquery.Datasource.Type != "" {
+		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.DataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
 	// We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
 	dataquery := variants.UnknownDataquery{}
 	if err := json.Unmarshal(raw, &dataquery); err != nil {

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -132,12 +132,10 @@ func (runtime *Runtime) ConvertPanelToGo(inputPanel any, panelType string) strin
 	return "/* could not convert panel to go */"
 }
 
-func (runtime *Runtime) ConvertDataqueryToGo(inputPanel any, dataqueryTypeHints ...string) string {
-	for _, dataqueryTypeHint := range dataqueryTypeHints {
-		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
-		if found && config.GoConverter != nil {
-			return config.GoConverter(inputPanel)
-		}
+func (runtime *Runtime) ConvertDataqueryToGo(dataquery variants.Dataquery) string {
+	config, found := runtime.dataqueryVariants[dataquery.DataqueryType()]
+	if found && config.GoConverter != nil {
+		return config.GoConverter(dataquery)
 	}
 
 	return "/* could not convert dataquery to go */"
@@ -147,8 +145,8 @@ func ConvertPanelToCode(inputPanel any, panelType string) string {
 	return NewRuntime().ConvertPanelToGo(inputPanel, panelType)
 }
 
-func ConvertDataqueryToCode(inputPanel any, dataqueryTypeHints ...string) string {
-	return NewRuntime().ConvertDataqueryToGo(inputPanel, dataqueryTypeHints...)
+func ConvertDataqueryToCode(dataquery variants.Dataquery) string {
+	return NewRuntime().ConvertDataqueryToGo(dataquery)
 }
 
 func Dump(root any) string {

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -7,6 +7,9 @@ package cog
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/grafana/cog/testdata/generated/cog/variants"
 )
@@ -118,4 +121,128 @@ func UnmarshalDataquery(raw []byte, dataqueryTypeHint string) (variants.Dataquer
 
 func ConfigForPanelcfgVariant(identifier string) (variants.PanelcfgConfig, bool) {
 	return NewRuntime().ConfigForPanelcfgVariant(identifier)
+}
+
+func (runtime *Runtime) ConvertPanelToGo(inputPanel any, panelType string) string {
+	config, found := runtime.panelcfgVariants[panelType]
+	if found && config.GoConverter != nil {
+		return config.GoConverter(inputPanel)
+	}
+
+	return "/* could not convert panel to go */"
+}
+
+func (runtime *Runtime) ConvertDataqueryToGo(inputPanel any, dataqueryTypeHints ...string) string {
+	for _, dataqueryTypeHint := range dataqueryTypeHints {
+		config, found := runtime.dataqueryVariants[dataqueryTypeHint]
+		if found && config.GoConverter != nil {
+			return config.GoConverter(inputPanel)
+		}
+	}
+
+	return "/* could not convert dataquery to go */"
+}
+
+func ConvertPanelToCode(inputPanel any, panelType string) string {
+	return NewRuntime().ConvertPanelToGo(inputPanel, panelType)
+}
+
+func ConvertDataqueryToCode(inputPanel any, dataqueryTypeHints ...string) string {
+	return NewRuntime().ConvertDataqueryToGo(inputPanel, dataqueryTypeHints...)
+}
+
+func Dump(root any) string {
+	return dumpValue(reflect.ValueOf(root))
+}
+
+func dumpValue(value reflect.Value) string {
+	if !value.IsValid() {
+		return "<invalid>"
+	}
+
+	switch value.Kind() {
+	case reflect.Bool:
+		return fmt.Sprintf("%#v", value.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprintf("%d", value.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprintf("%d", value.Uint())
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprintf("%#v", value.Float())
+	case reflect.String:
+		return fmt.Sprintf("%#v", value.String())
+	case reflect.Array, reflect.Slice:
+		return dumpArray(value)
+	case reflect.Map:
+		return dumpMap(value)
+	case reflect.Struct:
+		return dumpStruct(value)
+	case reflect.Interface:
+		if !value.CanInterface() {
+			return "<interface: can't interface>"
+		}
+
+		return Dump(value.Interface())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return "nil"
+		}
+
+		pointed := value.Elem()
+
+		return fmt.Sprintf("cog.ToPtr[%s](%s)", pointed.Type().String(), dumpValue(pointed))
+	default:
+		return fmt.Sprintf("<unknown: type=%s, kind=%s>", value.Type(), value.Kind().String())
+	}
+}
+
+func dumpArray(value reflect.Value) string {
+	if value.IsNil() {
+		return "nil"
+	}
+
+	parts := make([]string, 0, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		parts = append(parts, dumpValue(value.Index(i)))
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
+}
+
+func dumpMap(value reflect.Value) string {
+	if value.IsNil() {
+		return "nil"
+	}
+
+	parts := make([]string, 0, value.Len())
+	iter := value.MapRange()
+	for iter.Next() {
+		line := fmt.Sprintf("%s: %s", dumpValue(iter.Key()), dumpValue(iter.Value()))
+		parts = append(parts, line)
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
+}
+
+func dumpStruct(value reflect.Value) string {
+	parts := make([]string, 0, value.NumField())
+	structType := value.Type()
+
+	for i := 0; i < value.NumField(); i++ {
+		field := structType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		fieldValue := value.Field(i)
+		fieldValueKind := fieldValue.Kind()
+		if (fieldValueKind == reflect.Pointer || fieldValueKind == reflect.Interface || fieldValueKind == reflect.Array || fieldValueKind == reflect.Slice || fieldValueKind == reflect.Map) && fieldValue.IsNil() {
+			continue
+		}
+
+		line := fmt.Sprintf("%s: %s", field.Name, dumpValue(fieldValue))
+		parts = append(parts, line)
+	}
+
+	return fmt.Sprintf("%s{%s}", value.Type().String(), strings.Join(parts, ", "))
 }

--- a/testdata/generated/cog/variants/variants.go
+++ b/testdata/generated/cog/variants/variants.go
@@ -11,11 +11,13 @@ type PanelcfgConfig struct {
 	Identifier             string
 	OptionsUnmarshaler     func(raw []byte) (any, error)
 	FieldConfigUnmarshaler func(raw []byte) (any, error)
+	GoConverter            func(inputPanel any) string
 }
 
 type DataqueryConfig struct {
 	Identifier           string
 	DataqueryUnmarshaler func(raw []byte) (Dataquery, error)
+	GoConverter          func(inputPanel any) string
 }
 
 type Dataquery interface {

--- a/testdata/generated/cog/variants/variants.go
+++ b/testdata/generated/cog/variants/variants.go
@@ -23,6 +23,7 @@ type DataqueryConfig struct {
 type Dataquery interface {
 	ImplementsDataqueryVariant()
 	Equals(other Dataquery) bool
+	DataqueryType() string
 }
 
 type Panelcfg interface {
@@ -30,6 +31,10 @@ type Panelcfg interface {
 }
 
 type UnknownDataquery map[string]any
+
+func (unknown UnknownDataquery) DataqueryType() string {
+	return ""
+}
 
 func (unknown UnknownDataquery) ImplementsDataqueryVariant() {
 

--- a/testdata/generated/equality/types_gen.go
+++ b/testdata/generated/equality/types_gen.go
@@ -95,14 +95,12 @@ func (resource Optionals) Equals(other Optionals) bool {
 }
 
 type Arrays struct {
-	Ints             []int64    `json:"ints"`
-	Strings          []string   `json:"strings"`
-	ArrayOfArray     [][]string `json:"arrayOfArray"`
-	Refs             []Variable `json:"refs"`
-	AnonymousStructs []struct {
-		Inner string `json:"inner"`
-	} `json:"anonymousStructs"`
-	ArrayOfAny []any `json:"arrayOfAny"`
+	Ints             []int64                          `json:"ints"`
+	Strings          []string                         `json:"strings"`
+	ArrayOfArray     [][]string                       `json:"arrayOfArray"`
+	Refs             []Variable                       `json:"refs"`
+	AnonymousStructs []EqualityArraysAnonymousStructs `json:"anonymousStructs"`
+	ArrayOfAny       []any                            `json:"arrayOfAny"`
 }
 
 func (resource Arrays) Equals(other Arrays) bool {
@@ -159,7 +157,7 @@ func (resource Arrays) Equals(other Arrays) bool {
 	}
 
 	for i1 := range resource.AnonymousStructs {
-		if resource.AnonymousStructs[i1].Inner != other.AnonymousStructs[i1].Inner {
+		if !resource.AnonymousStructs[i1].Equals(other.AnonymousStructs[i1]) {
 			return false
 		}
 	}
@@ -179,13 +177,11 @@ func (resource Arrays) Equals(other Arrays) bool {
 }
 
 type Maps struct {
-	Ints             map[string]int64    `json:"ints"`
-	Strings          map[string]string   `json:"strings"`
-	Refs             map[string]Variable `json:"refs"`
-	AnonymousStructs map[string]struct {
-		Inner string `json:"inner"`
-	} `json:"anonymousStructs"`
-	StringToAny map[string]any `json:"stringToAny"`
+	Ints             map[string]int64                        `json:"ints"`
+	Strings          map[string]string                       `json:"strings"`
+	Refs             map[string]Variable                     `json:"refs"`
+	AnonymousStructs map[string]EqualityMapsAnonymousStructs `json:"anonymousStructs"`
+	StringToAny      map[string]any                          `json:"stringToAny"`
 }
 
 func (resource Maps) Equals(other Maps) bool {
@@ -225,7 +221,7 @@ func (resource Maps) Equals(other Maps) bool {
 	}
 
 	for key1 := range resource.AnonymousStructs {
-		if resource.AnonymousStructs[key1].Inner != other.AnonymousStructs[key1].Inner {
+		if !resource.AnonymousStructs[key1].Equals(other.AnonymousStructs[key1]) {
 			return false
 		}
 	}
@@ -239,6 +235,32 @@ func (resource Maps) Equals(other Maps) bool {
 		if !reflect.DeepEqual(resource.StringToAny[key1], other.StringToAny[key1]) {
 			return false
 		}
+	}
+
+	return true
+}
+
+// Modified by compiler pass 'AnonymousStructsToNamed'
+type EqualityArraysAnonymousStructs struct {
+	Inner string `json:"inner"`
+}
+
+func (resource EqualityArraysAnonymousStructs) Equals(other EqualityArraysAnonymousStructs) bool {
+	if resource.Inner != other.Inner {
+		return false
+	}
+
+	return true
+}
+
+// Modified by compiler pass 'AnonymousStructsToNamed'
+type EqualityMapsAnonymousStructs struct {
+	Inner string `json:"inner"`
+}
+
+func (resource EqualityMapsAnonymousStructs) Equals(other EqualityMapsAnonymousStructs) bool {
+	if resource.Inner != other.Inner {
+		return false
 	}
 
 	return true

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -21,17 +21,8 @@ type Struct struct {
 	AllFields NestedStruct `json:"allFields"`
 	PartialFields NestedStruct `json:"partialFields"`
 	EmptyFields NestedStruct `json:"emptyFields"`
-	ComplexField struct {
-	Uid string `json:"uid"`
-	Nested struct {
-	NestedVal string `json:"nestedVal"`
-} `json:"nested"`
-	Array []string `json:"array"`
-} `json:"complexField"`
-	PartialComplexField struct {
-	Uid string `json:"uid"`
-	IntVal int64 `json:"intVal"`
-} `json:"partialComplexField"`
+	ComplexField DefaultsStructComplexField `json:"complexField"`
+	PartialComplexField DefaultsStructPartialComplexField `json:"partialComplexField"`
 }
 
 func (resource Struct) Equals(other Struct) bool {
@@ -44,26 +35,68 @@ func (resource Struct) Equals(other Struct) bool {
 		if !resource.EmptyFields.Equals(other.EmptyFields) {
 			return false
 		}
-		if resource.ComplexField.Uid != other.ComplexField.Uid {
+		if !resource.ComplexField.Equals(other.ComplexField) {
 			return false
 		}
-		if resource.ComplexField.Nested.NestedVal != other.ComplexField.Nested.NestedVal {
-			return false
-		}
-
-		if len(resource.ComplexField.Array) != len(other.ComplexField.Array) {
+		if !resource.PartialComplexField.Equals(other.PartialComplexField) {
 			return false
 		}
 
-		for i1 := range resource.ComplexField.Array {
-		if resource.ComplexField.Array[i1] != other.ComplexField.Array[i1] {
+	return true
+}
+
+
+type DefaultsStructComplexFieldNested struct {
+	NestedVal string `json:"nestedVal"`
+}
+
+func (resource DefaultsStructComplexFieldNested) Equals(other DefaultsStructComplexFieldNested) bool {
+		if resource.NestedVal != other.NestedVal {
+			return false
+		}
+
+	return true
+}
+
+
+type DefaultsStructComplexField struct {
+	Uid string `json:"uid"`
+	Nested DefaultsStructComplexFieldNested `json:"nested"`
+	Array []string `json:"array"`
+}
+
+func (resource DefaultsStructComplexField) Equals(other DefaultsStructComplexField) bool {
+		if resource.Uid != other.Uid {
+			return false
+		}
+		if !resource.Nested.Equals(other.Nested) {
+			return false
+		}
+
+		if len(resource.Array) != len(other.Array) {
+			return false
+		}
+
+		for i1 := range resource.Array {
+		if resource.Array[i1] != other.Array[i1] {
 			return false
 		}
 		}
-		if resource.PartialComplexField.Uid != other.PartialComplexField.Uid {
+
+	return true
+}
+
+
+type DefaultsStructPartialComplexField struct {
+	Uid string `json:"uid"`
+	IntVal int64 `json:"intVal"`
+}
+
+func (resource DefaultsStructPartialComplexField) Equals(other DefaultsStructPartialComplexField) bool {
+		if resource.Uid != other.Uid {
 			return false
 		}
-		if resource.PartialComplexField.IntVal != other.PartialComplexField.IntVal {
+		if resource.IntVal != other.IntVal {
 			return false
 		}
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -9,9 +9,7 @@ type SomeStruct struct {
 	Operator SomeStructOperator `json:"Operator"`
 	FieldArrayOfStrings []string `json:"FieldArrayOfStrings"`
 	FieldMapOfStringToString map[string]string `json:"FieldMapOfStringToString"`
-	FieldAnonymousStruct struct {
-	FieldAny any `json:"FieldAny"`
-} `json:"FieldAnonymousStruct"`
+	FieldAnonymousStruct StructComplexFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct"`
 	FieldRefToConstant string `json:"fieldRefToConstant"`
 }
 
@@ -57,8 +55,7 @@ func (resource SomeStruct) Equals(other SomeStruct) bool {
 			return false
 		}
 		}
-		// is DeepEqual good enough here?
-		if !reflect.DeepEqual(resource.FieldAnonymousStruct.FieldAny, other.FieldAnonymousStruct.FieldAny) {
+		if !resource.FieldAnonymousStruct.Equals(other.FieldAnonymousStruct) {
 			return false
 		}
 		if resource.FieldRefToConstant != other.FieldRefToConstant {
@@ -90,6 +87,20 @@ const (
 	SomeStructOperatorGreaterThan SomeStructOperator = ">"
 	SomeStructOperatorLessThan SomeStructOperator = "<"
 )
+
+
+type StructComplexFieldsSomeStructFieldAnonymousStruct struct {
+	FieldAny any `json:"FieldAny"`
+}
+
+func (resource StructComplexFieldsSomeStructFieldAnonymousStruct) Equals(other StructComplexFieldsSomeStructFieldAnonymousStruct) bool {
+		// is DeepEqual good enough here?
+		if !reflect.DeepEqual(resource.FieldAny, other.FieldAny) {
+			return false
+		}
+
+	return true
+}
 
 
 type StringOrBool struct {

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
@@ -5,9 +5,7 @@ type SomeStruct struct {
 	FieldString *string `json:"FieldString,omitempty"`
 	Operator *SomeStructOperator `json:"Operator,omitempty"`
 	FieldArrayOfStrings []string `json:"FieldArrayOfStrings,omitempty"`
-	FieldAnonymousStruct *struct {
-	FieldAny any `json:"FieldAny"`
-} `json:"FieldAnonymousStruct,omitempty"`
+	FieldAnonymousStruct *StructOptionalFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct,omitempty"`
 }
 
 func (resource SomeStruct) Equals(other SomeStruct) bool {
@@ -53,8 +51,7 @@ func (resource SomeStruct) Equals(other SomeStruct) bool {
 		}
 
 		if resource.FieldAnonymousStruct != nil {
-		// is DeepEqual good enough here?
-		if !reflect.DeepEqual(resource.FieldAnonymousStruct.FieldAny, other.FieldAnonymousStruct.FieldAny) {
+		if !resource.FieldAnonymousStruct.Equals(*other.FieldAnonymousStruct) {
 			return false
 		}
 		}
@@ -82,5 +79,19 @@ const (
 	SomeStructOperatorGreaterThan SomeStructOperator = ">"
 	SomeStructOperatorLessThan SomeStructOperator = "<"
 )
+
+
+type StructOptionalFieldsSomeStructFieldAnonymousStruct struct {
+	FieldAny any `json:"FieldAny"`
+}
+
+func (resource StructOptionalFieldsSomeStructFieldAnonymousStruct) Equals(other StructOptionalFieldsSomeStructFieldAnonymousStruct) bool {
+		// is DeepEqual good enough here?
+		if !reflect.DeepEqual(resource.FieldAny, other.FieldAny) {
+			return false
+		}
+
+	return true
+}
 
 

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -10,6 +10,9 @@ type Query struct {
 }
 func (resource Query) ImplementsDataqueryVariant() {}
 
+func (resource Query) DataqueryType() string {
+	return "prometheus"
+}
 
 func VariantConfig() variants.DataqueryConfig {
 	return variants.DataqueryConfig{

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -15,9 +15,9 @@ func VariantConfig() variants.DataqueryConfig {
 	return variants.DataqueryConfig{
 		Identifier: "prometheus",
 	    DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
-            dataquery := Query{}
+            dataquery := &Query{}
 
-            if err := json.Unmarshal(raw, &dataquery); err != nil {
+            if err := json.Unmarshal(raw, dataquery); err != nil {
                 return nil, err
             }
 

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -34,18 +34,18 @@ func VariantConfig() variants.PanelcfgConfig {
 	return variants.PanelcfgConfig{
 		Identifier: "timeseries",
 		OptionsUnmarshaler: func (raw []byte) (any, error) {
-			options := Options{}
+			options := &Options{}
 
-			if err := json.Unmarshal(raw, &options); err != nil {
+			if err := json.Unmarshal(raw, options); err != nil {
 				return nil, err
 			}
 
 			return options, nil
 		},
 		FieldConfigUnmarshaler: func (raw []byte) (any, error) {
-			fieldConfig := FieldConfig{}
+			fieldConfig := &FieldConfig{}
 
-			if err := json.Unmarshal(raw, &fieldConfig); err != nil {
+			if err := json.Unmarshal(raw, fieldConfig); err != nil {
 				return nil, err
 			}
 

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -21,9 +21,9 @@ func VariantConfig() variants.PanelcfgConfig {
 	return variants.PanelcfgConfig{
 		Identifier: "text",
 		OptionsUnmarshaler: func (raw []byte) (any, error) {
-			options := Options{}
+			options := &Options{}
 
-			if err := json.Unmarshal(raw, &options); err != nil {
+			if err := json.Unmarshal(raw, options); err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
Contributes to #314 

This PR lays the foundation to convert JSON to code, starting with an implementation in Go.
There are still more things to do:

* [ ] tests
* [x] take advantage of #560 to more efficiently unmarshal (and convert) dataqueries
* [ ] implement for other languages (the current conversion process works for Go, but it will most likely need some tweaks to fully support other languages... disjunctions, I'm especially looking at you)
* [x] Options with no arguments aren't converted?
	* `Editable()` on dashboard
	* `Instant()` on prometheus queries
	* ...
* [x] skip options whose value is the default one: kinda done → for scalars only (simplest case to detect)