### PR TITLE
Use the datasource type within queries to unmarshal them

### DIFF
--- a/internal/jennies/golang/templates/runtime/runtime.tmpl
+++ b/internal/jennies/golang/templates/runtime/runtime.tmpl
@@ -69,6 +69,27 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 		}
 	}
 
+	// Dataqueries might reference the datasource to use, and its type. Let's use that.
+	partialDataquery := struct {
+		Datasource struct {
+			Type string `json:"type"`
+		} `json:"datasource"`
+	}{}
+	if err := json.Unmarshal(raw, &partialDataquery); err != nil {
+		return nil, err
+	}
+	if partialDataquery.Datasource.Type != "" {
+		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.DataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
 	// We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
 	dataquery := variants.UnknownDataquery{}
 	if err := json.Unmarshal(raw, &dataquery); err != nil {

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -78,6 +78,27 @@ func (runtime *Runtime) UnmarshalDataquery(raw []byte, dataqueryTypeHint string)
 		}
 	}
 
+	// Dataqueries might reference the datasource to use, and its type. Let's use that.
+	partialDataquery := struct {
+		Datasource struct {
+			Type string `json:"type"`
+		} `json:"datasource"`
+	}{}
+	if err := json.Unmarshal(raw, &partialDataquery); err != nil {
+		return nil, err
+	}
+	if partialDataquery.Datasource.Type != "" {
+		config, found := runtime.dataqueryVariants[partialDataquery.Datasource.Type]
+		if found {
+			dataquery, err := config.DataqueryUnmarshaler(raw)
+			if err != nil {
+				return nil, err
+			}
+
+			return dataquery.(variants.Dataquery), nil
+		}
+	}
+
 	// We have no idea what type the dataquery is: use our `UnknownDataquery` bag to not lose data.
 	dataquery := variants.UnknownDataquery{}
 	if err := json.Unmarshal(raw, &dataquery); err != nil {


### PR DESCRIPTION
To determine in which Go struct to unmarshal a dataquery, cog's runtime currently only looks at the datasource details contained in the panel (if it exists). To make the unmarshalling more accurate, we should also look into the query itself since it can hold a DatasourceRef.

This PR only updates the Go jenny, other languages should mimic this behavior.

Relates to #566 and #560 