### PR TITLE
Use the datasource type within queries to unmarshal them in PHP

### DIFF
--- a/.config/ci/php/phpstan.neon
+++ b/.config/ci/php/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
     - identifier: identical.alwaysFalse # not a big deal, duplicated enum values come from the schema
       paths:
         - ../../../generated/php/src/Common/ScaleDirection.php
+    - identifier: offsetAccess.nonOffsetAccessible
+      paths:
+        - ../../../generated/php/src/Cog/Runtime.php

--- a/internal/jennies/php/templates/runtime/runtime.tmpl
+++ b/internal/jennies/php/templates/runtime/runtime.tmpl
@@ -65,6 +65,11 @@ final class Runtime
      */
     public function dataqueryFromArray(array $data, string $dataqueryTypeHint): Dataquery
     {
+        // Dataqueries might reference the datasource to use, and its type. Let's use that.
+        if (empty($dataqueryTypeHint) && !empty($data['datasource']) && !empty($data['datasource']['type'])) {
+            $dataqueryTypeHint = $data['datasource']['type'];
+        }
+
         // A hint tells us the dataquery type: let's use it.
         if (!empty($dataqueryTypeHint) && isset($this->dataqueryVariants[$dataqueryTypeHint])) {
             $fromArray = $this->dataqueryVariants[$dataqueryTypeHint]->fromArray;

--- a/testdata/generated/cog/variants/variants.go
+++ b/testdata/generated/cog/variants/variants.go
@@ -33,12 +33,10 @@ type Panelcfg interface {
 type UnknownDataquery map[string]any
 
 func (unknown UnknownDataquery) DataqueryType() string {
-	return ""
+	return "unknown"
 }
 
-func (unknown UnknownDataquery) ImplementsDataqueryVariant() {
-
-}
+func (unknown UnknownDataquery) ImplementsDataqueryVariant() {}
 
 func (unknown UnknownDataquery) Equals(otherCandidate Dataquery) bool {
 	if otherCandidate == nil {


### PR DESCRIPTION
Same than #567, but for PHP