### PR TITLE
Use the datasource type within queries to unmarshal them in Python

### DIFF
--- a/internal/jennies/python/templates/runtime/runtime.tmpl
+++ b/internal/jennies/python/templates/runtime/runtime.tmpl
@@ -36,6 +36,9 @@ class Runtime:
         self.panelcfg_variants[variant.identifier] = variant
 
     def dataquery_from_json(self, data: dict[str, Any], dataquery_type_hint: str) -> cogvariants.Dataquery:
+        if dataquery_type_hint == "" and "datasource" in data and "type" in data["datasource"]:
+            dataquery_type_hint = data["datasource"]["type"]
+
         if dataquery_type_hint != "" and dataquery_type_hint in self.dataquery_variants:
             return self.dataquery_variants[dataquery_type_hint].from_json_hook(data)
 

--- a/testdata/generated/cog/variants/variants.go
+++ b/testdata/generated/cog/variants/variants.go
@@ -33,12 +33,10 @@ type Panelcfg interface {
 type UnknownDataquery map[string]any
 
 func (unknown UnknownDataquery) DataqueryType() string {
-	return ""
+	return "unknown"
 }
 
-func (unknown UnknownDataquery) ImplementsDataqueryVariant() {
-
-}
+func (unknown UnknownDataquery) ImplementsDataqueryVariant() {}
 
 func (unknown UnknownDataquery) Equals(otherCandidate Dataquery) bool {
 	if otherCandidate == nil {


### PR DESCRIPTION
Same than #567, but for Python