### PR TITLE
Fix missing builders due to incorrect ComposeDashboardPanel veneer

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -498,7 +498,7 @@
     },
     "python@3.12": {
       "last_modified": "2024-09-10T15:01:03Z",
-      "plugin_version": "0.0.3",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#python3",
       "source": "devbox-search",
       "version": "3.12.5",


### PR DESCRIPTION
Some builders were missing, turns out because of a bug in the Panel composition veneer.

Example: [`PieChartLegendOptions`](https://github.com/grafana/grafana-foundation-sdk/blob/8c1e08449403c1e93492452bde3362758c0ecd21/go/piechart/types_gen.go#L42) should have a builder