### PR TITLE
Php/converter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main] # so that we build a Go cache that can be re-used in PRs
 
+env:
+  DEVBOX_VERSION: 0.13.1
+
 jobs:
   linters:
     name: Linters
@@ -16,6 +19,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
           enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run golangci-lint
         run: make lint
@@ -31,6 +35,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
           enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Tests
         run: make tests
@@ -50,6 +55,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
           enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Clone kind-registry
         run: git clone --depth=1 https://github.com/grafana/kind-registry.git ../kind-registry
@@ -71,9 +77,9 @@ jobs:
 
       - name: Compile generated Java code
         run: devbox run gradle build -p generated/java
-      
+
       - name: Lint generated PHP code with phpstan
-        run: devbox run phpstan analyze --memory-limit 256M -c .config/ci/php/phpstan.neon
+        run: devbox run phpstan analyze --memory-limit 512M -c .config/ci/php/phpstan.neon
 
       - name: Lint generated PHP code with psalm
         run: devbox run psalm -c .config/ci/php/psalm.xml generated/php
@@ -89,6 +95,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
           enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Clone kind-registry
         run: git clone --depth=1 https://github.com/grafana/kind-registry.git ../kind-registry

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -2,6 +2,9 @@ name: Foundation-sdk diff preview
 on:
   pull_request: ~
 
+env:
+  DEVBOX_VERSION: 0.13.1
+
 jobs:
   sdk_diff:
     name: Generate diff
@@ -14,6 +17,7 @@ jobs:
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
           enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Dry-run release
         shell: bash

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -89,6 +89,7 @@ output:
 
   types: true
   builders: true
+  converters: true
 
   languages:
     - go:

--- a/devbox.lock
+++ b/devbox.lock
@@ -175,8 +175,8 @@
       }
     },
     "nodePackages.ts-node@10.9.2": {
-      "last_modified": "2024-09-13T05:52:00Z",
-      "resolved": "github:NixOS/nixpkgs/673d99f1406cb09b8eb6feab4743ebdf70046557#nodePackages.ts-node",
+      "last_modified": "2024-09-23T10:58:17Z",
+      "resolved": "github:NixOS/nixpkgs/568bfef547c14ca438c56a0bece08b8bb2b71a9c#nodePackages.ts-node",
       "source": "devbox-search",
       "version": "10.9.2",
       "systems": {
@@ -184,41 +184,41 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/kmchq7l6lyfl6q5dxh82kyvxd2r2hrgy-ts-node-10.9.2",
+              "path": "/nix/store/3zm6xc7hzn1msjha4srgqphdi3l4cxr9-ts-node-10.9.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/kmchq7l6lyfl6q5dxh82kyvxd2r2hrgy-ts-node-10.9.2"
+          "store_path": "/nix/store/3zm6xc7hzn1msjha4srgqphdi3l4cxr9-ts-node-10.9.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6kgfhn3mczsgv39b15l1iv4vhjmiyfvp-ts-node-10.9.2",
+              "path": "/nix/store/56q9lbgk20cqwqlqar1mm1l1h31c7pif-ts-node-10.9.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/6kgfhn3mczsgv39b15l1iv4vhjmiyfvp-ts-node-10.9.2"
+          "store_path": "/nix/store/56q9lbgk20cqwqlqar1mm1l1h31c7pif-ts-node-10.9.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/49pyi3l8xd1cw5fw5rgd3jy9782184p7-ts-node-10.9.2",
+              "path": "/nix/store/vpihhsb85fx3qyy87l6f77fpw7sm0y8d-ts-node-10.9.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/49pyi3l8xd1cw5fw5rgd3jy9782184p7-ts-node-10.9.2"
+          "store_path": "/nix/store/vpihhsb85fx3qyy87l6f77fpw7sm0y8d-ts-node-10.9.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/l8phr8qy3mdj1wy0cy4afl27acc8f28b-ts-node-10.9.2",
+              "path": "/nix/store/nvmzzqg1x44w0lys42ws7pkvbwgh6ap9-ts-node-10.9.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/l8phr8qy3mdj1wy0cy4afl27acc8f28b-ts-node-10.9.2"
+          "store_path": "/nix/store/nvmzzqg1x44w0lys42ws7pkvbwgh6ap9-ts-node-10.9.2"
         }
       }
     },
@@ -288,8 +288,8 @@
       }
     },
     "php83Packages.phpstan@1.11": {
-      "last_modified": "2024-09-10T15:01:03Z",
-      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#php83Packages.phpstan",
+      "last_modified": "2024-09-28T20:36:15Z",
+      "resolved": "github:NixOS/nixpkgs/19d2ec01a20afa6a816a10d3a57b4c49b3d1293b#php83Packages.phpstan",
       "source": "devbox-search",
       "version": "1.11.8",
       "systems": {
@@ -297,47 +297,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pyw05w2xsnndx3k1s4yns80gax4l6jm5-phpstan-1.11.8",
+              "path": "/nix/store/5sidqrbm6jwgglzfp5j1c5sc4m46qxz2-phpstan-1.11.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pyw05w2xsnndx3k1s4yns80gax4l6jm5-phpstan-1.11.8"
+          "store_path": "/nix/store/5sidqrbm6jwgglzfp5j1c5sc4m46qxz2-phpstan-1.11.8"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/raxgmljp14ilfyi8jzngqa28c1wl35c6-phpstan-1.11.8",
+              "path": "/nix/store/7msdy2byk1xzn5pmdqpxg4vzs97qhlcm-phpstan-1.11.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/raxgmljp14ilfyi8jzngqa28c1wl35c6-phpstan-1.11.8"
+          "store_path": "/nix/store/7msdy2byk1xzn5pmdqpxg4vzs97qhlcm-phpstan-1.11.8"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/icd857ch4plc4qw4fnnixhnmibr926dm-phpstan-1.11.8",
+              "path": "/nix/store/r8ph0bh12wywfnwlnraqrfj5i4947d8b-phpstan-1.11.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/icd857ch4plc4qw4fnnixhnmibr926dm-phpstan-1.11.8"
+          "store_path": "/nix/store/r8ph0bh12wywfnwlnraqrfj5i4947d8b-phpstan-1.11.8"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dicy20zii0b1xpqflh4jxmz0ywsmj04k-phpstan-1.11.8",
+              "path": "/nix/store/vvbcf62600lnrnsz6wnxi8l4lrp9advr-phpstan-1.11.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/dicy20zii0b1xpqflh4jxmz0ywsmj04k-phpstan-1.11.8"
+          "store_path": "/nix/store/vvbcf62600lnrnsz6wnxi8l4lrp9advr-phpstan-1.11.8"
         }
       }
     },
     "php83Packages.psalm@5.25": {
-      "last_modified": "2024-09-10T15:01:03Z",
-      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#php83Packages.psalm",
+      "last_modified": "2024-09-28T20:36:15Z",
+      "resolved": "github:NixOS/nixpkgs/19d2ec01a20afa6a816a10d3a57b4c49b3d1293b#php83Packages.psalm",
       "source": "devbox-search",
       "version": "5.25.0",
       "systems": {
@@ -345,41 +345,41 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/2ipakcda8icl7r86s0qjkd627mrcfvl3-psalm-5.25.0",
+              "path": "/nix/store/h1wnfcnaw7nhp357dc0wcaz9w8ikmyv8-psalm-5.25.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/2ipakcda8icl7r86s0qjkd627mrcfvl3-psalm-5.25.0"
+          "store_path": "/nix/store/h1wnfcnaw7nhp357dc0wcaz9w8ikmyv8-psalm-5.25.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/w32iqghc4gxydkfqgrds69i0bg23jjaf-psalm-5.25.0",
+              "path": "/nix/store/4w4m1r72la7mziv8ac83ar0jsn12jrmp-psalm-5.25.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/w32iqghc4gxydkfqgrds69i0bg23jjaf-psalm-5.25.0"
+          "store_path": "/nix/store/4w4m1r72la7mziv8ac83ar0jsn12jrmp-psalm-5.25.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/phmq70pf9wmqm0vf03qhf9w9zmszcjf9-psalm-5.25.0",
+              "path": "/nix/store/p38qj9ckg20ycg3avdbin9ip8h6nxpkh-psalm-5.25.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/phmq70pf9wmqm0vf03qhf9w9zmszcjf9-psalm-5.25.0"
+          "store_path": "/nix/store/p38qj9ckg20ycg3avdbin9ip8h6nxpkh-psalm-5.25.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/l5l5pbf9yny98982f3rd2z8dsnaas5sg-psalm-5.25.0",
+              "path": "/nix/store/zq02h3hv6464b666qjdyyybpnmvr8zhl-psalm-5.25.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/l5l5pbf9yny98982f3rd2z8dsnaas5sg-psalm-5.25.0"
+          "store_path": "/nix/store/zq02h3hv6464b666qjdyyybpnmvr8zhl-psalm-5.25.0"
         }
       }
     },

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -66,9 +66,10 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 	return jenny.Tmpl.
 		Funcs(map[string]any{
-			"formatType":   builderTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
-			"formatPath":   makePathFormatter(formatter),
-			"formatRawRef": formatRawRef,
+			"formatType":          builderTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
+			"formatTypeNoBuilder": defaultTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
+			"formatPath":          makePathFormatter(formatter),
+			"formatRawRef":        formatRawRef,
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
 			"Imports":   imports,

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -52,6 +52,15 @@ package {{ .Converter.Package | formatPackageName }}
         }
         {{ $.IntoVar }} := "{{ .ForType | formatType }}{" + strings.Join(tmp{{ $.IntoVar }}, ",\n") + "}"
     {{- end -}}
+    {{- with .Arg.Map -}}
+        {{ $.IntoVar }} := "map[{{ .IndexType | formatType }}]{{ .ValueType | formatTypeNoBuilder }}{"
+        for key, {{ .ValueAs | formatPath }} := range {{ .For | formatPath }} {
+        {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
+            {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" .ForArg) }}
+            {{ $.IntoVar }} += "\t" + fmt.Sprintf("%#v", key) + ": " + {{ $subIntoVar }} +","
+        }
+        {{ $.IntoVar }} += "}"
+    {{- end -}}
     {{- with .Arg.Runtime -}}
         {{ $.IntoVar }} := cog.{{ .FuncName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}{{ $runtimeArg.ValuePath | formatPath }}{{ else }}{{ maybeUnptr ($runtimeArg.ValuePath | formatPath) $runtimeArg.ValueType }}{{ end }}, {{ end }})
     {{- end -}}

--- a/internal/jennies/php/builder.go
+++ b/internal/jennies/php/builder.go
@@ -3,7 +3,6 @@ package php
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
@@ -84,7 +83,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 	return jenny.tmpl.
 		Funcs(map[string]any{
 			"fullNamespaceRef": jenny.config.fullNamespaceRef,
-			"formatPath":       jenny.formatFieldPath,
+			"formatPath":       formatFieldPath,
 			"formatType":       jenny.typeFormatter.formatType,
 			"formatRawType": func(def ast.Type) string {
 				return jenny.typeFormatter.doFormatType(def, false)
@@ -125,10 +124,4 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 			"NamespaceRoot": jenny.config.NamespaceRoot,
 			"Builder":       builder,
 		})
-}
-
-func (jenny *Builder) formatFieldPath(fieldPath ast.Path) string {
-	return strings.Join(tools.Map(fieldPath, func(item ast.PathItem) string {
-		return formatFieldName(item.Identifier)
-	}), "->")
 }

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -47,7 +47,8 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 	return jenny.tmpl.
 		Funcs(map[string]any{
-			"resolveRefs": context.ResolveRefs,
+			"fullNamespaceRef": jenny.config.fullNamespaceRef,
+			"resolveRefs":      context.ResolveRefs,
 			"resolvesToStruct": func(typeDef ast.Type) bool {
 				return context.ResolveRefs(typeDef).IsStruct()
 			},

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -47,6 +47,13 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 	return jenny.tmpl.
 		Funcs(map[string]any{
+			"resolveRefs": context.ResolveRefs,
+			"resolvesToStruct": func(typeDef ast.Type) bool {
+				return context.ResolveRefs(typeDef).IsStruct()
+			},
+			"resolvesToMap": func(typeDef ast.Type) bool {
+				return context.ResolveRefs(typeDef).IsMap()
+			},
 			"resolvesToEnum": func(typeDef ast.Type) bool {
 				return context.ResolveRefs(typeDef).IsEnum()
 			},

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -52,6 +52,43 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			"formatRawRef": func(pkg string, ref string) string {
 				return formatter.formatRef(ast.NewRef(pkg, ref), false)
 			},
+			"disjunctionCaseForType": func(input string, typeDef ast.Type) string {
+				// TODO: shaky at best
+				if typeDef.IsAnyOf(ast.KindArray, ast.KindMap) {
+					return fmt.Sprintf("is_array(%s)", input)
+				}
+
+				if typeDef.IsScalar() {
+					testMap := map[ast.ScalarKind]string{
+						ast.KindBytes:   "is_string",
+						ast.KindString:  "is_string",
+						ast.KindFloat32: "is_float",
+						ast.KindFloat64: "is_float",
+						ast.KindUint8:   "is_int",
+						ast.KindUint16:  "is_int",
+						ast.KindUint32:  "is_int",
+						ast.KindUint64:  "is_int",
+						ast.KindInt8:    "is_int",
+						ast.KindInt16:   "is_int",
+						ast.KindInt32:   "is_int",
+						ast.KindInt64:   "is_int",
+						ast.KindBool:    "is_bool",
+					}
+
+					testFunc := testMap[typeDef.Scalar.ScalarKind]
+					if testFunc == "" {
+						return "/* unhandled scalar type */"
+					}
+
+					return fmt.Sprintf("%s(%s)", testFunc, input)
+				}
+
+				if typeDef.IsRef() {
+					return fmt.Sprintf("%s instanceof %s", input, formatter.formatRef(typeDef.Ref.AsType(), false))
+				}
+
+				return "/* unhandled type */"
+			},
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
 			"NamespaceRoot": jenny.config.NamespaceRoot,

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -47,6 +47,9 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 	return jenny.tmpl.
 		Funcs(map[string]any{
+			"resolvesToEnum": func(typeDef ast.Type) bool {
+				return context.ResolveRefs(typeDef).IsEnum()
+			},
 			"formatType": builderTypeFormatter(jenny.config, context).formatType,
 			"formatPath": formatFieldPath,
 			"formatRawRef": func(pkg string, ref string) string {

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -1,0 +1,60 @@
+package php
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+type Converter struct {
+	config         Config
+	nullableConfig languages.NullableConfig
+	tmpl           *template.Template
+}
+
+func (jenny *Converter) JennyName() string {
+	return "PHPConverter"
+}
+
+func (jenny *Converter) Generate(context languages.Context) (codejen.Files, error) {
+	files := codejen.Files{}
+
+	for _, builder := range context.Builders {
+		output, err := jenny.generateConverter(context, builder)
+		if err != nil {
+			return nil, err
+		}
+
+		filename := filepath.Join(
+			"src",
+			formatPackageName(builder.Package),
+			fmt.Sprintf("%sConverter.php", formatObjectName(builder.Name)),
+		)
+
+		files = append(files, *codejen.NewFile(filename, output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
+	converter := languages.NewConverterGenerator(jenny.nullableConfig).FromBuilder(context, builder)
+	formatter := builderTypeFormatter(jenny.config, context)
+
+	return jenny.tmpl.
+		Funcs(map[string]any{
+			"formatType": builderTypeFormatter(jenny.config, context).formatType,
+			"formatPath": formatFieldPath,
+			"formatRawRef": func(pkg string, ref string) string {
+				return formatter.formatRef(ast.NewRef(pkg, ref), false)
+			},
+		}).
+		RenderAsBytes("converters/converter.tmpl", map[string]any{
+			"NamespaceRoot": jenny.config.NamespaceRoot,
+			"Converter":     converter,
+		})
+}

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -44,6 +44,9 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
 	converter := languages.NewConverterGenerator(jenny.nullableConfig).FromBuilder(context, builder)
 	formatter := builderTypeFormatter(jenny.config, context)
+	schema, schemaFound := context.Schemas.Locate(builder.Package)
+
+	inputIsDataquery := schemaFound && schema.Metadata.Variant == ast.SchemaVariantDataQuery && schema.EntryPoint == builder.For.Name
 
 	return jenny.tmpl.
 		Funcs(map[string]any{
@@ -102,7 +105,8 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			},
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
-			"NamespaceRoot": jenny.config.NamespaceRoot,
-			"Converter":     converter,
+			"NamespaceRoot":    jenny.config.NamespaceRoot,
+			"Converter":        converter,
+			"InputIsDataquery": inputIsDataquery,
 		})
 }

--- a/internal/jennies/php/converter_test.go
+++ b/internal/jennies/php/converter_test.go
@@ -1,0 +1,45 @@
+package php
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConverter_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
+		TestDataRoot: "../../../testdata/jennies/builders",
+		Name:         "PHPConverter",
+		Skip: map[string]string{
+			"anonymous_struct":                  "anonymous structs are eliminated with compiler passes",
+			"builder_delegation_in_disjunction": "disjunctions are eliminated with compiler passes",
+			"dashboard_panel":                   "this test if for Java generics for dashboard.Panel",
+		},
+	}
+
+	config := Config{
+		NamespaceRoot: "Grafana\\Foundation",
+	}
+	language := New(config)
+	jenny := Converter{
+		config:         config,
+		nullableConfig: language.NullableKinds(),
+		tmpl:           initTemplates([]string{}),
+	}
+
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
+		var err error
+		req := require.New(tc)
+
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
+		context, err = languages.GenerateBuilderNilChecks(language, context)
+		req.NoError(err)
+
+		files, err := jenny.Generate(context)
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/php/jennies.go
+++ b/internal/jennies/php/jennies.go
@@ -14,6 +14,8 @@ const LanguageRef = "php"
 type Config struct {
 	debug bool
 
+	converters bool
+
 	NamespaceRoot string `yaml:"namespace_root"`
 
 	// BuilderTemplatesDirectories holds a list of directories containing templates
@@ -37,6 +39,7 @@ func (config Config) fullNamespaceRef(typeName string) string {
 func (config Config) MergeWithGlobal(global languages.Config) Config {
 	newConfig := config
 	newConfig.debug = global.Debug
+	newConfig.converters = global.Converters
 
 	return newConfig
 }
@@ -68,6 +71,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 		Runtime{config: config, tmpl: tmpl},
 		common.If[languages.Context](globalConfig.Types, RawTypes{config: config, tmpl: tmpl}),
 		common.If[languages.Context](globalConfig.Builders, &Builder{config: config, tmpl: tmpl}),
+		common.If[languages.Context](globalConfig.Builders && globalConfig.Converters, &Converter{config: config, tmpl: tmpl, nullableConfig: language.NullableKinds()}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -325,10 +325,12 @@ func (jenny RawTypes) convertDisjunctionFunc(disjunction ast.DisjunctionType) st
 
 	decodingSwitch += "}"
 
-	return fmt.Sprintf(`(function($input) {
+	dataqueryRef := jenny.config.fullNamespaceRef("Cog\\Dataquery")
+
+	return fmt.Sprintf(`(function(%s $input) {
 
     %s
-})`, decodingSwitch)
+})`, dataqueryRef, decodingSwitch)
 }
 
 func (jenny RawTypes) generateConstructor(context languages.Context, def ast.Object) string {

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -99,7 +99,7 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
     {{- $argsCount := sub1 (len .Args) -}}
     {{- with .ArgumentGuards -}}if ({{ template "guards" . }}) { {{- end }}
     {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} { {{- end }}
-    $buffer .= '{{ .Option.Name | formatOptionName }}(';
+    $buffer = '{{ .Option.Name | formatOptionName }}(';
     {{- range $i, $arg := .Args }}
         {{- $intoVar := print "arg" $i }}
         {{ template "prepare_arg" (dict "IntoVar" $intoVar "Arg" $arg) }}
@@ -109,7 +109,6 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     {{ with .ArgumentGuards -}} } {{- end }}
     {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} } {{- end }}
 {{- end }}
@@ -135,7 +134,6 @@ final class {{ .Converter.BuilderName | upperCamelCase }}Converter
         $calls = [
             '(new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }}))',
         ];
-        $buffer = '';
 
         {{- range .Converter.Mappings }}
             {{ template "conversion_mapping" . }}

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -52,7 +52,20 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
         ${{ $.IntoVar }} = {{ "Cog\\Runtime" | fullNamespaceRef }}::get()->{{ .FuncName|formatOptionName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}${{ $runtimeArg.ValuePath | formatPath }}{{ else }}${{ $runtimeArg.ValuePath | formatPath }}{{ end }}, {{ end }});
     {{- end -}}
     {{- with .Arg.Direct -}}
-        ${{ $.IntoVar }} = {{- template "value_formatter" (dict "Type" .ValueType "Path" .ValuePath) -}};
+        ${{ $.IntoVar }} = {{- template "value_formatter" (dict "Path" .ValuePath) -}};
+    {{- end -}}
+    {{- with .Arg.Disjunction -}}
+        switch (true) {
+            {{- range $branch := .Branches }}
+            case {{ disjunctionCaseForType (print "$" (formatPath .Of.ValuePath)) $branch.Type }}:
+                {{- $subIntoVar := print "disjunction" .Of.ValuePath.Last.Identifier }}
+                {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" $branch.Arg) }}
+                ${{ $.IntoVar }} = ${{ $subIntoVar }};
+                break;
+            {{- end }}
+            default:
+                throw new \ValueError('disjunction branch not handled');
+        }
     {{- end -}}
 {{- end }}
 
@@ -93,7 +106,7 @@ final class {{ .Converter.BuilderName | upperCamelCase }}Converter
     {
         {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
         $calls = [
-            'new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }})',
+            '(new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }}))',
         ];
         $buffer = '';
 
@@ -101,7 +114,7 @@ final class {{ .Converter.BuilderName | upperCamelCase }}Converter
             {{ template "conversion_mapping" . }}
         {{- end }}
 
-        return \implode("->\t\n", $calls);
+        return \implode("\n\t->", $calls);
     }
 }
 {{- end }}

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -12,6 +12,7 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
 
     {{- if and (eq $operator "!==") (eq .Value nil) -}}
         ${{ .Path | formatPath }} !== null
+        {{- if ne .Path.Last.TypeHint nil }} && ${{ .Path | formatPath }} instanceof {{ formatRawRef .Path.Last.TypeHint.Ref.ReferredPkg .Path.Last.TypeHint.Ref.ReferredType }}{{ end }}
     {{- else -}}
         {{- $leftOperand := print "$" (.Path | formatPath) -}}
         {{- if eq .Op "minLength" -}}

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -29,6 +29,18 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
 {{- define "value_formatter" -}}
     {{- if and (.Type.IsRef) (resolvesToEnum .Type) -}}
     '{{ formatRawRef .Type.Ref.ReferredPkg .Type.Ref.ReferredType }}::fromValue("'.${{ .Path | formatPath }}.'")'
+    {{- else if and (.Type.IsRef) (resolvesToStruct .Type) -}}
+    {{- $structDef := (resolveRefs .Type).Struct -}}
+    '(new {{ formatRawRef .Type.Ref.ReferredPkg .Type.Ref.ReferredType }}(
+        {{- range $field := $structDef.Fields -}}
+        {{- $valuePath := $.Path.AppendStructField $field -}}
+        {{- if $field.Type.Nullable -}}
+        '.((${{ $valuePath | formatPath }} !== null) ? '{{ $field.Name }}: '.{{- template "value_formatter" (dict "Type" $field.Type "Path" $valuePath) -}}.', ' : '').'
+        {{- else -}}
+        {{ $field.Name }}: '.{{- template "value_formatter" (dict "Type" $field.Type "Path" $valuePath) -}}.',
+        {{- end -}}
+        {{- end -}}
+    ))'
     {{- else -}}
     \var_export(${{ .Path | formatPath }}, true)
     {{- end -}}
@@ -51,6 +63,15 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
         $tmp{{ $.IntoVar }}[] = ${{ $subIntoVar }};
         }
         ${{ $.IntoVar }} = "[" . implode(", \n", $tmp{{ $.IntoVar }}) . "]";
+    {{- end -}}
+    {{- with .Arg.Map -}}
+        ${{ $.IntoVar }} = "[";
+        foreach (${{ .For | formatPath }} as $key => ${{ .ValueAs | formatPath }}) {
+        {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
+            {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" .ForArg) }}
+            ${{ $.IntoVar }} .= "\t".var_export($key, true)." => ${{ $subIntoVar }},";
+        }
+        ${{ $.IntoVar }} .= "]";
     {{- end -}}
     {{- with .Arg.Runtime -}}
         ${{ $.IntoVar }} = {{ "Cog\\Runtime" | fullNamespaceRef }}::get()->{{ .FuncName|formatOptionName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}${{ $runtimeArg.ValuePath | formatPath }}{{ else }}${{ $runtimeArg.ValuePath | formatPath }}{{ end }}, {{ end }});

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -1,0 +1,108 @@
+<?php
+
+namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
+
+{{ template "converter" . }}
+
+{{- define "guard" }}
+{{- $operator := .Op -}}
+{{- if eq $operator "==" -}}{{ $operator = "===" }}{{- end -}}
+{{- if eq $operator "!=" -}}{{ $operator = "!==" }}{{- end -}}
+{{- if eq $operator "!=" -}}{{ $operator = "!==" }}{{- end -}}
+
+    {{- if and (eq $operator "!==") (eq .Value nil) -}}
+        ${{ .Path | formatPath }} !== null
+    {{- else -}}
+        {{- $leftOperand := print "$" (.Path | formatPath) -}}
+        {{- if eq .Op "minLength" -}}
+            {{- $leftOperand = print "count(" $leftOperand ")" -}}
+            {{- $operator = ">=" -}}
+        {{- end -}}
+        {{- if eq .Op "maxLength" -}}
+            {{- $leftOperand = print "count(" $leftOperand ")" -}}
+            {{- $operator = "<=" -}}
+        {{- end -}}
+        {{- $leftOperand }} {{ $operator}} {{ .Value | formatScalar -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "value_formatter" -}}
+    \var_export(${{ .Path | formatPath }}, true)
+{{- end }}
+
+{{- define "guards" }}
+    {{- $guardsCount := sub1 (len .) -}}
+    {{- range $i, $guard := . }}{{- template "guard" $guard }}{{ if ne $i $guardsCount }} && {{ end }}{{ end }}
+{{- end }}
+
+{{- define "prepare_arg" -}}
+    {{- with .Arg.Builder -}}
+        ${{ $.IntoVar }} = {{ formatRawRef .BuilderPkg (print .BuilderName "Converter") }}::convert(${{ .ValuePath | formatPath }});
+    {{- end -}}
+    {{- with .Arg.Array -}}
+        $tmp{{ $.IntoVar }} = [];
+        foreach (${{ .For | formatPath }} as ${{ .ValueAs | formatPath }}) {
+        {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
+        {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" .ForArg) }}
+        $tmp{{ $.IntoVar }}[] = ${{ $subIntoVar }};
+        }
+        ${{ $.IntoVar }} = "[" . implode(", \n", $tmp{{ $.IntoVar }}) . "]";
+    {{- end -}}
+    {{- with .Arg.Runtime -}}
+        ${{ $.IntoVar }} = {{ "Cog\\Runtime" | fullNamespaceRef }}::get()->{{ .FuncName|formatOptionName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}${{ $runtimeArg.ValuePath | formatPath }}{{ else }}${{ $runtimeArg.ValuePath | formatPath }}{{ end }}, {{ end }});
+    {{- end -}}
+    {{- with .Arg.Direct -}}
+        ${{ $.IntoVar }} = {{- template "value_formatter" (dict "Type" .ValueType "Path" .ValuePath) -}};
+    {{- end -}}
+{{- end }}
+
+{{- define "option_mapping" -}}
+    {{- $argsCount := sub1 (len .Args) -}}
+    {{- with .ArgumentGuards -}}if ({{ template "guards" . }}) { {{- end }}
+    {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} { {{- end }}
+    $buffer .= '{{ .Option.Name | formatOptionName }}(';
+    {{- range $i, $arg := .Args }}
+        {{- $intoVar := print "arg" $i }}
+        {{ template "prepare_arg" (dict "IntoVar" $intoVar "Arg" $arg) }}
+        $buffer .= ${{ $intoVar }};
+        {{ if ne $i $argsCount }}$buffer .= ', ';{{- end }}
+    {{- end }}
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    {{ with .ArgumentGuards -}} } {{- end }}
+    {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} } {{- end }}
+{{- end }}
+
+{{- define "conversion_mapping" -}}
+    {{- $firstOpt := .Options | first }}
+    {{- with $firstOpt.Guards -}}if ({{ template "guards" . }}) { {{- end }}
+    {{ if ne .RepeatFor nil -}}foreach (${{ .RepeatFor | formatPath }} as ${{ .RepeatAs }}) { {{- end }}
+    {{- range $optMapping := .Options }}
+        {{ template "option_mapping" $optMapping }}
+    {{- end }}
+    {{ if ne .RepeatFor nil -}} } {{- end }}
+    {{ with $firstOpt.Guards -}} } {{- end }}
+{{- end }}
+
+{{- define "converter" -}}
+final class {{ .Converter.BuilderName | upperCamelCase }}Converter
+{
+    public static function convert({{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType }} $input): string
+    {
+        {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
+        $calls = [
+            'new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }})',
+        ];
+        $buffer = '';
+
+        {{- range .Converter.Mappings }}
+            {{ template "conversion_mapping" . }}
+        {{- end }}
+
+        return \implode("->\t\n", $calls);
+    }
+}
+{{- end }}
+

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -27,7 +27,11 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
 {{- end }}
 
 {{- define "value_formatter" -}}
+    {{- if and (.Type.IsRef) (resolvesToEnum .Type) -}}
+    '{{ formatRawRef .Type.Ref.ReferredPkg .Type.Ref.ReferredType }}::fromValue("'.${{ .Path | formatPath }}.'")'
+    {{- else -}}
     \var_export(${{ .Path | formatPath }}, true)
+    {{- end -}}
 {{- end }}
 
 {{- define "guards" }}
@@ -52,7 +56,7 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
         ${{ $.IntoVar }} = {{ "Cog\\Runtime" | fullNamespaceRef }}::get()->{{ .FuncName|formatOptionName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}${{ $runtimeArg.ValuePath | formatPath }}{{ else }}${{ $runtimeArg.ValuePath | formatPath }}{{ end }}, {{ end }});
     {{- end -}}
     {{- with .Arg.Direct -}}
-        ${{ $.IntoVar }} = {{- template "value_formatter" (dict "Path" .ValuePath) -}};
+        ${{ $.IntoVar }} = {{- template "value_formatter" (dict "Type" .ValueType "Path" .ValuePath) -}};
     {{- end -}}
     {{- with .Arg.Disjunction -}}
         switch (true) {
@@ -106,7 +110,7 @@ final class {{ .Converter.BuilderName | upperCamelCase }}Converter
     {
         {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
         $calls = [
-            '(new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }}))',
+            '(new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }}))',
         ];
         $buffer = '';
 

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -127,8 +127,9 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
 {{- define "converter" -}}
 final class {{ .Converter.BuilderName | upperCamelCase }}Converter
 {
-    public static function convert({{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType }} $input): string
+    public static function convert({{ if .InputIsDataquery }}{{ "Cog\\Dataquery" | fullNamespaceRef }}{{ else }}{{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType }}{{ end }} $input): string
     {
+        {{ if .InputIsDataquery }}assert($input instanceof {{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType }});{{ end }}
         {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
         $calls = [
             '(new {{ formatRawRef .Converter.Package .Converter.BuilderName }}Builder({{ with .Converter.ConstructorArgs}}'.{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} . ", " .{{ end }}{{ end }}.'{{ end }}))',

--- a/internal/jennies/php/templates/runtime/dataquery_config.tmpl
+++ b/internal/jennies/php/templates/runtime/dataquery_config.tmpl
@@ -12,11 +12,18 @@ final class DataqueryConfig
     public $fromArray;
 
     /**
-     * @param callable(array<string, mixed>): Dataquery $fromArray
+     * @var (callable(Dataquery): string)|null
      */
-    public function __construct(string $identifier, callable $fromArray)
+    public $convert;
+
+    /**
+     * @param callable(array<string, mixed>): Dataquery $fromArray
+     * @param (callable(Dataquery): string)|null $convert
+     */
+    public function __construct(string $identifier, callable $fromArray, ?callable $convert)
     {
         $this->identifier = $identifier;
         $this->fromArray = $fromArray;
+        $this->convert = $convert;
     }
 }

--- a/internal/jennies/php/templates/runtime/dataquery_variant.tmpl
+++ b/internal/jennies/php/templates/runtime/dataquery_variant.tmpl
@@ -4,4 +4,5 @@ namespace {{ .NamespaceRoot }}\Cog;
 
 interface Dataquery
 {
+    public function dataqueryType(): string;
 }

--- a/internal/jennies/php/templates/runtime/panelcfg_config.tmpl
+++ b/internal/jennies/php/templates/runtime/panelcfg_config.tmpl
@@ -7,7 +7,7 @@ final class PanelcfgConfig
     public readonly string $identifier;
 
     /**
-     * @var (callable(object): string)|null
+     * @var (callable(\Grafana\Foundation\Dashboard\Panel): string)|null
      */
     public $convert;
 
@@ -22,11 +22,11 @@ final class PanelcfgConfig
     public $fieldConfigFromArray;
 
     /**
-     * @param (callable(object): string)|null $convert
+     * @param (callable(\Grafana\Foundation\Dashboard\Panel): string)|null $convert
      * @param (callable(array<string, mixed>): object)|null $optionsFromArray
      * @param (callable(array<string, mixed>): object)|null $fieldConfigFromArray
      */
-    public function __construct(string $identifier, ?callable $convert, ?callable $optionsFromArray = null, ?callable $fieldConfigFromArray = null)
+    public function __construct(string $identifier, ?callable $convert = null, ?callable $optionsFromArray = null, ?callable $fieldConfigFromArray = null)
     {
         $this->identifier = $identifier;
         $this->convert = $convert;

--- a/internal/jennies/php/templates/runtime/panelcfg_config.tmpl
+++ b/internal/jennies/php/templates/runtime/panelcfg_config.tmpl
@@ -7,6 +7,11 @@ final class PanelcfgConfig
     public readonly string $identifier;
 
     /**
+     * @var (callable(object): string)|null
+     */
+    public $convert;
+
+    /**
      * @var (callable(array<string, mixed>): object)|null
      */
     public $optionsFromArray;
@@ -17,12 +22,14 @@ final class PanelcfgConfig
     public $fieldConfigFromArray;
 
     /**
+     * @param (callable(object): string)|null $convert
      * @param (callable(array<string, mixed>): object)|null $optionsFromArray
      * @param (callable(array<string, mixed>): object)|null $fieldConfigFromArray
      */
-    public function __construct(string $identifier, ?callable $optionsFromArray = null, ?callable $fieldConfigFromArray = null)
+    public function __construct(string $identifier, ?callable $convert, ?callable $optionsFromArray = null, ?callable $fieldConfigFromArray = null)
     {
         $this->identifier = $identifier;
+        $this->convert = $convert;
         $this->optionsFromArray = $optionsFromArray;
         $this->fieldConfigFromArray = $fieldConfigFromArray;
     }

--- a/internal/jennies/php/templates/runtime/runtime.tmpl
+++ b/internal/jennies/php/templates/runtime/runtime.tmpl
@@ -93,4 +93,32 @@ final class Runtime
         }
         return $queries;
     }
+
+    public function convertPanelToCode($panel, string $panelType): string
+    {
+        if (!$this->panelcfgVariantExists($panelType)) {
+            return '/* could not convert panel to PHP */';
+        }
+
+        $convert = $this->panelcfgVariants[$panelType]->convert;
+        if ($convert === null) {
+            return '/* could not convert panel to PHP */';
+        }
+
+        return $convert($panel);
+    }
+
+    public function convertDataqueryToCode(Dataquery $dataquery): string
+    {
+        if (!isset($this->dataqueryVariants[$dataquery->dataqueryType()])) {
+            return '/* could not convert dataquery to PHP */';
+        }
+
+        $convert = $this->dataqueryVariants[$dataquery->dataqueryType()]->convert;
+        if ($convert === null) {
+            return '/* could not convert dataquery to PHP */';
+        }
+
+        return $convert($dataquery);
+    }
 }

--- a/internal/jennies/php/templates/runtime/runtime.tmpl
+++ b/internal/jennies/php/templates/runtime/runtime.tmpl
@@ -94,7 +94,7 @@ final class Runtime
         return $queries;
     }
 
-    public function convertPanelToCode($panel, string $panelType): string
+    public function convertPanelToCode(\Grafana\Foundation\Dashboard\Panel $panel, string $panelType): string
     {
         if (!$this->panelcfgVariantExists($panelType)) {
             return '/* could not convert panel to PHP */';

--- a/internal/jennies/php/templates/runtime/unknown_dataquery.tmpl
+++ b/internal/jennies/php/templates/runtime/unknown_dataquery.tmpl
@@ -20,6 +20,11 @@ final class UnknownDataquery implements \ArrayAccess, \JsonSerializable, Dataque
 	    $this->data = $data;
 	}
 
+    public function dataqueryType(): string
+    {
+        return 'unknown';
+    }
+
     /**
      * @param string $offset
      * @param mixed $value

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -45,6 +45,9 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"formatValue": func(_ ast.Type, _ any) bool {
 				panic("formatValue() needs to be overridden by a jenny")
 			},
+			"disjunctionCaseForType": func(input string, typeDef ast.Type) string {
+				panic("disjunctionCaseForType() needs to be overridden by a jenny")
+			},
 		}),
 		template.Funcs(map[string]any{
 			"formatPath":           formatFieldPath,

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -51,6 +51,15 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"resolvesToEnum": func(typeDef ast.Type) bool {
 				panic("refResolvesToEnum() needs to be overridden by a jenny")
 			},
+			"resolvesToStruct": func(typeDef ast.Type) bool {
+				panic("resolvesToStruct() needs to be overridden by a jenny")
+			},
+			"resolvesToMap": func(typeDef ast.Type) bool {
+				panic("resolvesToMap() needs to be overridden by a jenny")
+			},
+			"resolveRefs": func(typeDef ast.Type) ast.Type {
+				panic("resolveRefs() needs to be overridden by a jenny")
+			},
 		}),
 		template.Funcs(map[string]any{
 			"formatPath":           formatFieldPath,

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/template"
 )
 
-//go:embed templates/builders/*.tmpl templates/runtime/*.tmpl templates/types/*.tmpl
+//go:embed templates/builders/*.tmpl templates/converters/*.tmpl templates/runtime/*.tmpl templates/types/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -21,11 +21,11 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"fullNamespaceRef": func(_ string) string {
 				panic("fullNamespaceRef() needs to be overridden by a jenny")
 			},
-			"formatPath": func(_ ast.Path) string {
-				panic("formatPath() needs to be overridden by a jenny")
+			"formatType":    func(_ ast.Type) string { panic("formatType() needs to be overridden by a jenny") },
+			"formatRawType": func(_ ast.Type) string { panic("formatRawType() needs to be overridden by a jenny") },
+			"formatRawRef": func(pkg string, ref string) string {
+				panic("formatRawRef() needs to be overridden by a jenny")
 			},
-			"formatType":               func(_ ast.Type) string { panic("formatType() needs to be overridden by a jenny") },
-			"formatRawType":            func(_ ast.Type) string { panic("formatRawType() needs to be overridden by a jenny") },
 			"formatRawTypeNotNullable": func(_ ast.Type) string { panic("formatRawTypeNotNullable() needs to be overridden by a jenny") },
 			"typeHasBuilder": func(_ ast.Type) bool {
 				panic("typeHasBuilder() needs to be overridden by a jenny")
@@ -47,6 +47,7 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			},
 		}),
 		template.Funcs(map[string]any{
+			"formatPath":           formatFieldPath,
 			"formatPackageName":    formatPackageName,
 			"formatObjectName":     formatObjectName,
 			"formatOptionName":     formatOptionName,

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -48,6 +48,9 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"disjunctionCaseForType": func(input string, typeDef ast.Type) string {
 				panic("disjunctionCaseForType() needs to be overridden by a jenny")
 			},
+			"resolvesToEnum": func(typeDef ast.Type) bool {
+				panic("refResolvesToEnum() needs to be overridden by a jenny")
+			},
 		}),
 		template.Funcs(map[string]any{
 			"formatPath":           formatFieldPath,

--- a/internal/jennies/php/tools.go
+++ b/internal/jennies/php/tools.go
@@ -62,6 +62,12 @@ func formatCommentsBlock(comments []string) string {
 	return buffer.String()
 }
 
+func formatFieldPath(fieldPath ast.Path) string {
+	return strings.Join(tools.Map(fieldPath, func(item ast.PathItem) string {
+		return formatFieldName(item.Identifier)
+	}), "->")
+}
+
 func formatValue(val any) string {
 	if val == nil {
 		return "null"

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -40,6 +40,15 @@ type ArrayArgMapping struct {
 	ValueType ast.Type
 }
 
+type MapArgMapping struct {
+	For       ast.Path
+	ForType   ast.Type
+	ForArg    *ArgumentMapping
+	ValueAs   ast.Path
+	IndexType ast.Type
+	ValueType ast.Type
+}
+
 type RuntimeArgMapping struct {
 	FuncName string
 	Args     []*DirectArgMapping
@@ -60,6 +69,7 @@ type ArgumentMapping struct {
 	Runtime     *RuntimeArgMapping
 	Builder     *BuilderArgMapping
 	Array       *ArrayArgMapping
+	Map         *MapArgMapping
 	Disjunction *DisjunctionArgMapping
 
 	// TODO: used? necessary?
@@ -332,6 +342,25 @@ func (generator *ConverterGenerator) argumentForType(context Context, converter 
 				ForArg:    &forArg,
 				ValueAs:   valueAs,
 				ValueType: typeDef.Array.ValueType,
+			},
+		}
+	}
+
+	if typeDef.IsMap() {
+		valueAs := ast.Path{
+			{Identifier: argName, Type: typeDef.Map.ValueType, Root: true},
+		}
+
+		forArg := generator.argumentForType(context, converter, argName+"Value", valueAs, typeDef.Map.ValueType)
+
+		return ArgumentMapping{
+			Map: &MapArgMapping{
+				For:       valuePath,
+				ForType:   typeDef,
+				ForArg:    &forArg,
+				ValueAs:   valueAs,
+				IndexType: typeDef.Map.IndexType,
+				ValueType: typeDef.Map.ValueType,
 			},
 		}
 	}

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -508,12 +508,7 @@ func (generator *ConverterGenerator) pathNotNullGuards(converter Converter, path
 	var guards []MappingGuard
 
 	for i, chunk := range path {
-		chunkType := chunk.Type
-		if chunk.TypeHint != nil {
-			chunkType = *chunk.TypeHint
-		}
-
-		if !generator.nullableTypes.TypeIsNullable(chunkType) {
+		if !generator.nullableTypes.TypeIsNullable(chunk.Type) {
 			continue
 		}
 

--- a/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -10,18 +10,16 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];
-        $buffer = '';
             if (count($input->tags) >= 1) {
     foreach ($input->tags as $item) {
         
-    $buffer .= 'tags(';
+    $buffer = 'tags(';
         $arg0 =\var_export($item, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     }
     }

--- a/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/array_append/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if (count($input->tags) >= 1) {
+    foreach ($input->tags as $item) {
+        
+    $buffer .= 'tags(';
+        $arg0 =\var_export($item, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    }
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Grafana\Foundation\BasicStruct;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\BasicStruct\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\BasicStruct\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'id(';
+        $arg0 =\var_export($input->id, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            if ($input->uid !== "") {
+    
+        
+    $buffer .= 'uid(';
+        $arg0 =\var_export($input->uid, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if (count($input->tags) >= 1) {
+    
+        
+    $buffer .= 'tags(';
+        $tmparg0 = [];
+        foreach ($input->tags as $arg1) {
+        $tmptagsarg1 =\var_export($arg1, true);
+        $tmparg0[] = $tmptagsarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            
+    
+        {
+    $buffer .= 'liveNow(';
+        $arg0 =\var_export($input->liveNow, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\BasicStruct\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\BasicStruct\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct/PHPConverter/src/BasicStruct/SomeStructConverter.php
@@ -10,39 +10,36 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\BasicStruct\SomeStructBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'id(';
+    $buffer = 'id(';
         $arg0 =\var_export($input->id, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             if ($input->uid !== "") {
     
         
-    $buffer .= 'uid(';
+    $buffer = 'uid(';
         $arg0 =\var_export($input->uid, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if (count($input->tags) >= 1) {
     
         
-    $buffer .= 'tags(';
+    $buffer = 'tags(';
         $tmparg0 = [];
         foreach ($input->tags as $arg1) {
         $tmptagsarg1 =\var_export($arg1, true);
@@ -54,21 +51,19 @@ final class SomeStructConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             
     
         {
-    $buffer .= 'liveNow(';
+    $buffer = 'liveNow(';
         $arg0 =\var_export($input->liveNow, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
@@ -10,39 +10,36 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\BasicStructDefaults\SomeStructBuilder())',
         ];
-        $buffer = '';
             if ($input->id !== 42) {
     
         
-    $buffer .= 'id(';
+    $buffer = 'id(';
         $arg0 =\var_export($input->id, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->uid !== "" && $input->uid !== "default-uid") {
     
         
-    $buffer .= 'uid(';
+    $buffer = 'uid(';
         $arg0 =\var_export($input->uid, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if (count($input->tags) >= 1) {
     
         
-    $buffer .= 'tags(';
+    $buffer = 'tags(';
         $tmparg0 = [];
         foreach ($input->tags as $arg1) {
         $tmptagsarg1 =\var_export($arg1, true);
@@ -54,21 +51,19 @@ final class SomeStructConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->liveNow !== true) {
     
         
-    $buffer .= 'liveNow(';
+    $buffer = 'liveNow(';
         $arg0 =\var_export($input->liveNow, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Grafana\Foundation\BasicStructDefaults;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\BasicStructDefaults\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\BasicStructDefaults\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->id !== 42) {
+    
+        
+    $buffer .= 'id(';
+        $arg0 =\var_export($input->id, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->uid !== "" && $input->uid !== "default-uid") {
+    
+        
+    $buffer .= 'uid(';
+        $arg0 =\var_export($input->uid, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if (count($input->tags) >= 1) {
+    
+        
+    $buffer .= 'tags(';
+        $tmparg0 = [];
+        foreach ($input->tags as $arg1) {
+        $tmptagsarg1 =\var_export($arg1, true);
+        $tmparg0[] = $tmptagsarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->liveNow !== true) {
+    
+        
+    $buffer .= 'liveNow(';
+        $arg0 =\var_export($input->liveNow, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
+++ b/testdata/jennies/builders/basic_struct_defaults/PHPConverter/src/BasicStructDefaults/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\BasicStructDefaults\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\BasicStructDefaults\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
@@ -10,39 +10,36 @@ final class DashboardConverter
         $calls = [
             '(new \Grafana\Foundation\BuilderDelegation\DashboardBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'id(';
+    $buffer = 'id(';
         $arg0 =\var_export($input->id, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if (count($input->links) >= 1) {
     
         
-    $buffer .= 'links(';
+    $buffer = 'links(';
         $tmparg0 = [];
         foreach ($input->links as $arg1) {
         $tmplinksarg1 = \Grafana\Foundation\BuilderDelegation\DashboardLinkConverter::convert($arg1);
@@ -54,14 +51,13 @@ final class DashboardConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if (count($input->linksOfLinks) >= 1) {
     
         
-    $buffer .= 'linksOfLinks(';
+    $buffer = 'linksOfLinks(';
         $tmparg0 = [];
         foreach ($input->linksOfLinks as $arg1) {
         $tmptmplinksOfLinksarg1 = [];
@@ -78,21 +74,19 @@ final class DashboardConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             
     
         {
-    $buffer .= 'singleLink(';
+    $buffer = 'singleLink(';
         $arg0 = \Grafana\Foundation\BuilderDelegation\DashboardLinkConverter::convert($input->singleLink);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
@@ -6,6 +6,7 @@ final class DashboardConverter
 {
     public static function convert(\Grafana\Foundation\BuilderDelegation\Dashboard $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\BuilderDelegation\DashboardBuilder())',
         ];

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardConverter.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Grafana\Foundation\BuilderDelegation;
+
+final class DashboardConverter
+{
+    public static function convert(\Grafana\Foundation\BuilderDelegation\Dashboard $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\BuilderDelegation\DashboardBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'id(';
+        $arg0 =\var_export($input->id, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if (count($input->links) >= 1) {
+    
+        
+    $buffer .= 'links(';
+        $tmparg0 = [];
+        foreach ($input->links as $arg1) {
+        $tmplinksarg1 = \Grafana\Foundation\BuilderDelegation\DashboardLinkConverter::convert($arg1);
+        $tmparg0[] = $tmplinksarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if (count($input->linksOfLinks) >= 1) {
+    
+        
+    $buffer .= 'linksOfLinks(';
+        $tmparg0 = [];
+        foreach ($input->linksOfLinks as $arg1) {
+        $tmptmplinksOfLinksarg1 = [];
+        foreach ($arg1 as $arg1Value) {
+        $tmparg1arg1Value = \Grafana\Foundation\BuilderDelegation\DashboardLinkConverter::convert($arg1Value);
+        $tmptmplinksOfLinksarg1[] = $tmparg1arg1Value;
+        }
+        $tmplinksOfLinksarg1 = "[" . implode(", \n", $tmptmplinksOfLinksarg1) . "]";
+        $tmparg0[] = $tmplinksOfLinksarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            
+    
+        {
+    $buffer .= 'singleLink(';
+        $arg0 = \Grafana\Foundation\BuilderDelegation\DashboardLinkConverter::convert($input->singleLink);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\BuilderDelegation;
+
+final class DashboardLinkConverter
+{
+    public static function convert(\Grafana\Foundation\BuilderDelegation\DashboardLink $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\BuilderDelegation\DashboardLinkBuilder())',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->url !== "") {
+    
+        
+    $buffer .= 'url(';
+        $arg0 =\var_export($input->url, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
@@ -6,6 +6,7 @@ final class DashboardLinkConverter
 {
     public static function convert(\Grafana\Foundation\BuilderDelegation\DashboardLink $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\BuilderDelegation\DashboardLinkBuilder())',
         ];

--- a/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
+++ b/testdata/jennies/builders/builder_delegation/PHPConverter/src/BuilderDelegation/DashboardLinkConverter.php
@@ -10,32 +10,29 @@ final class DashboardLinkConverter
         $calls = [
             '(new \Grafana\Foundation\BuilderDelegation\DashboardLinkBuilder())',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->url !== "") {
     
         
-    $buffer .= 'url(';
+    $buffer = 'url(';
         $arg0 =\var_export($input->url, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
@@ -6,6 +6,7 @@ final class LokiBuilderConverter
 {
     public static function convert(\Grafana\Foundation\ComposableSlot\Dashboard $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\ComposableSlot\LokiBuilderBuilder())',
         ];

--- a/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Grafana\Foundation\ComposableSlot;
+
+final class LokiBuilderConverter
+{
+    public static function convert(\Grafana\Foundation\ComposableSlot\Dashboard $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\ComposableSlot\LokiBuilderBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'target(';
+        $arg0 = \Grafana\Foundation\Cog\Runtime::get()->convertDataqueryToCode($input->target, );
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            if (count($input->targets) >= 1) {
+    
+        
+    $buffer .= 'targets(';
+        $tmparg0 = [];
+        foreach ($input->targets as $arg1) {
+        $tmptargetsarg1 = \Grafana\Foundation\Cog\Runtime::get()->convertDataqueryToCode($arg1, );
+        $tmparg0[] = $tmptargetsarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/composable_slot/PHPConverter/src/ComposableSlot/LokiBuilderConverter.php
@@ -10,25 +10,23 @@ final class LokiBuilderConverter
         $calls = [
             '(new \Grafana\Foundation\ComposableSlot\LokiBuilderBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'target(';
+    $buffer = 'target(';
         $arg0 = \Grafana\Foundation\Cog\Runtime::get()->convertDataqueryToCode($input->target, );
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             if (count($input->targets) >= 1) {
     
         
-    $buffer .= 'targets(';
+    $buffer = 'targets(';
         $tmparg0 = [];
         foreach ($input->targets as $arg1) {
         $tmptargetsarg1 = \Grafana\Foundation\Cog\Runtime::get()->convertDataqueryToCode($arg1, );
@@ -40,7 +38,6 @@ final class LokiBuilderConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->editable === true) {
+    
+        
+    $buffer .= 'editable(';
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->editable === false) {
+    
+        
+    $buffer .= 'readonly(';
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->autoRefresh !== null && $input->autoRefresh === true) {
+    
+        
+    $buffer .= 'autoRefresh(';
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->autoRefresh !== null && $input->autoRefresh === false) {
+    
+        
+    $buffer .= 'noAutoRefresh(';
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constant_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -10,48 +10,43 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];
-        $buffer = '';
             if ($input->editable === true) {
     
         
-    $buffer .= 'editable(';
+    $buffer = 'editable(';
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->editable === false) {
     
         
-    $buffer .= 'readonly(';
+    $buffer = 'readonly(';
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->autoRefresh !== null && $input->autoRefresh === true) {
     
         
-    $buffer .= 'autoRefresh(';
+    $buffer = 'autoRefresh(';
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->autoRefresh !== null && $input->autoRefresh === false) {
     
         
-    $buffer .= 'noAutoRefresh(';
+    $buffer = 'noAutoRefresh(';
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
+++ b/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Constraints\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Constraints\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
+++ b/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
@@ -10,32 +10,29 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Constraints\SomeStructBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'id(';
+    $buffer = 'id(';
         $arg0 =\var_export($input->id, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
+++ b/testdata/jennies/builders/constraints/PHPConverter/src/Constraints/SomeStructConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\Constraints;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Constraints\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Constraints\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'id(';
+        $arg0 =\var_export($input->id, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder('.\var_export($input->title, true).'))',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -10,18 +10,16 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder('.\var_export($input->title, true).'))',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/constructor_argument/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder('.\var_export($input->title, true).'))',
         ];

--- a/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
+++ b/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\ConstructorInitializations;
+
+final class SomePanelConverter
+{
+    public static function convert(\Grafana\Foundation\ConstructorInitializations\SomePanel $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\ConstructorInitializations\SomePanelBuilder())',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
+++ b/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
@@ -6,6 +6,7 @@ final class SomePanelConverter
 {
     public static function convert(\Grafana\Foundation\ConstructorInitializations\SomePanel $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\ConstructorInitializations\SomePanelBuilder())',
         ];

--- a/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
+++ b/testdata/jennies/builders/constructor_initializations/PHPConverter/src/ConstructorInitializations/SomePanelConverter.php
@@ -10,18 +10,16 @@ final class SomePanelConverter
         $calls = [
             '(new \Grafana\Foundation\ConstructorInitializations\SomePanelBuilder())',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\DataqueryVariantBuilder;
+
+final class LokiBuilderConverter
+{
+    public static function convert(\Grafana\Foundation\DataqueryVariantBuilder\Loki $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\DataqueryVariantBuilder\LokiBuilderBuilder())',
+        ];
+        $buffer = '';
+            if ($input->expr !== "") {
+    
+        
+    $buffer .= 'expr(';
+        $arg0 =\var_export($input->expr, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
@@ -6,6 +6,7 @@ final class LokiBuilderConverter
 {
     public static function convert(\Grafana\Foundation\DataqueryVariantBuilder\Loki $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\DataqueryVariantBuilder\LokiBuilderBuilder())',
         ];

--- a/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
+++ b/testdata/jennies/builders/dataquery_variant_builder/PHPConverter/src/DataqueryVariantBuilder/LokiBuilderConverter.php
@@ -10,18 +10,16 @@ final class LokiBuilderConverter
         $calls = [
             '(new \Grafana\Foundation\DataqueryVariantBuilder\LokiBuilderBuilder())',
         ];
-        $buffer = '';
             if ($input->expr !== "") {
     
         
-    $buffer .= 'expr(';
+    $buffer = 'expr(';
         $arg0 =\var_export($input->expr, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
+++ b/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
@@ -10,11 +10,10 @@ final class DashboardConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\DashboardBuilder())',
         ];
-        $buffer = '';
             if (count($input->variables) >= 1) {
     foreach ($input->variables as $item) {
         
-    $buffer .= 'withVariable(';
+    $buffer = 'withVariable(';
         $arg0 =\var_export($item->name, true);
         $buffer .= $arg0;
         $buffer .= ', ';
@@ -24,7 +23,6 @@ final class DashboardConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     }
     }

--- a/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
+++ b/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class DashboardConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\Dashboard $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\DashboardBuilder())',
+        ];
+        $buffer = '';
+            if (count($input->variables) >= 1) {
+    foreach ($input->variables as $item) {
+        
+    $buffer .= 'withVariable(';
+        $arg0 =\var_export($item->name, true);
+        $buffer .= $arg0;
+        $buffer .= ', ';
+        $arg1 =\var_export($item->value, true);
+        $buffer .= $arg1;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    }
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
+++ b/testdata/jennies/builders/envelope_assignment/PHPConverter/src/Sandbox/DashboardConverter.php
@@ -6,6 +6,7 @@ final class DashboardConverter
 {
     public static function convert(\Grafana\Foundation\Sandbox\Dashboard $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Sandbox\DashboardBuilder())',
         ];

--- a/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
@@ -6,6 +6,7 @@ final class SomeNiceBuilderConverter
 {
     public static function convert(\Grafana\Foundation\SomePkg\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\BuilderPkg\SomeNiceBuilderBuilder())',
         ];

--- a/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\BuilderPkg;
+
+final class SomeNiceBuilderConverter
+{
+    public static function convert(\Grafana\Foundation\SomePkg\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\BuilderPkg\SomeNiceBuilderBuilder())',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/foreign_builder/PHPConverter/src/BuilderPkg/SomeNiceBuilderConverter.php
@@ -10,18 +10,16 @@ final class SomeNiceBuilderConverter
         $calls = [
             '(new \Grafana\Foundation\BuilderPkg\SomeNiceBuilderBuilder())',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
+++ b/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\InitializationSafeguards;
+
+final class SomePanelConverter
+{
+    public static function convert(\Grafana\Foundation\InitializationSafeguards\SomePanel $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\InitializationSafeguards\SomePanelBuilder())',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->options !== null) {
+    
+        
+    $buffer .= 'showLegend(';
+        $arg0 =\var_export($input->options->legend->show, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
+++ b/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
@@ -6,6 +6,7 @@ final class SomePanelConverter
 {
     public static function convert(\Grafana\Foundation\InitializationSafeguards\SomePanel $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\InitializationSafeguards\SomePanelBuilder())',
         ];

--- a/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
+++ b/testdata/jennies/builders/initialization_safeguards/PHPConverter/src/InitializationSafeguards/SomePanelConverter.php
@@ -10,32 +10,29 @@ final class SomePanelConverter
         $calls = [
             '(new \Grafana\Foundation\InitializationSafeguards\SomePanelBuilder())',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->options !== null) {
     
         
-    $buffer .= 'showLegend(';
+    $buffer = 'showLegend(';
         $arg0 =\var_export($input->options->legend->show, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
@@ -11,7 +11,7 @@ func SomeStructConverter(input *SomeStruct) string {
     `known_any.NewSomeStructBuilder()`,
     }
     var buffer strings.Builder
-        if input.Config.(*Config).Title != "" {
+        if input.Config != nil && input.Config.(*Config).Title != "" {
         
     buffer.WriteString(`Title(`)
         arg0 :=fmt.Sprintf("%#v", input.Config.(*Config).Title)

--- a/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
+++ b/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
@@ -11,7 +11,7 @@ final class SomeStructConverter
             '(new \Grafana\Foundation\KnownAny\SomeStructBuilder())',
         ];
         $buffer = '';
-            if ($input->config->title !== "") {
+            if ($input->config !== null && $input->config instanceof \Grafana\Foundation\KnownAny\Config && $input->config->title !== "") {
     
         
     $buffer .= 'title(';

--- a/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
+++ b/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\KnownAny;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\KnownAny\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\KnownAny\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->config->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->config->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
+++ b/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\KnownAny\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\KnownAny\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
+++ b/testdata/jennies/builders/known_any/PHPConverter/src/KnownAny/SomeStructConverter.php
@@ -10,18 +10,16 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\KnownAny\SomeStructBuilder())',
         ];
-        $buffer = '';
             if ($input->config !== null && $input->config instanceof \Grafana\Foundation\KnownAny\Config && $input->config->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->config->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
@@ -14,7 +14,12 @@ func SomeStructConverter(input *SomeStruct) string {
         if input.Config != nil {
         
     buffer.WriteString(`Config(`)
-        arg0 :=cog.Dump(input.Config)
+        arg0 := "map[string]string{"
+        for key, arg1 := range input.Config {
+            tmpconfigarg1 :=fmt.Sprintf("%#v", arg1)
+            arg0 += "\t" + fmt.Sprintf("%#v", key) + ": " + tmpconfigarg1 +","
+        }
+        arg0 += "}"
         buffer.WriteString(arg0)
         
     buffer.WriteString(")")

--- a/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
+++ b/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
@@ -10,11 +10,10 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\NullableMapAssignment\SomeStructBuilder())',
         ];
-        $buffer = '';
             if ($input->config !== null) {
     
         
-    $buffer .= 'config(';
+    $buffer = 'config(';
         $arg0 = "[";
         foreach ($input->config as $key => $arg1) {
             $tmpconfigarg1 =\var_export($arg1, true);
@@ -26,7 +25,6 @@ final class SomeStructConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
+++ b/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Grafana\Foundation\NullableMapAssignment;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\NullableMapAssignment\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\NullableMapAssignment\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->config !== null) {
+    
+        
+    $buffer .= 'config(';
+        $arg0 = "[";
+        foreach ($input->config as $key => $arg1) {
+            $tmpconfigarg1 =\var_export($arg1, true);
+            $arg0 .= "\t".var_export($key, true)." => $tmpconfigarg1,";
+        }
+        $arg0 .= "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
+++ b/testdata/jennies/builders/nullable_map_assignment/PHPConverter/src/NullableMapAssignment/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\NullableMapAssignment\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\NullableMapAssignment\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\Builderpkg;
+
+final class SomeNiceBuilderConverter
+{
+    public static function convert(\Grafana\Foundation\Withdashes\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Builderpkg\SomeNiceBuilderBuilder())',
+        ];
+        $buffer = '';
+            if ($input->title !== "") {
+    
+        
+    $buffer .= 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
@@ -6,6 +6,7 @@ final class SomeNiceBuilderConverter
 {
     public static function convert(\Grafana\Foundation\Withdashes\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Builderpkg\SomeNiceBuilderBuilder())',
         ];

--- a/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
+++ b/testdata/jennies/builders/package-with-dashes/PHPConverter/src/Builderpkg/SomeNiceBuilderConverter.php
@@ -10,18 +10,16 @@ final class SomeNiceBuilderConverter
         $calls = [
             '(new \Grafana\Foundation\Builderpkg\SomeNiceBuilderBuilder())',
         ];
-        $buffer = '';
             if ($input->title !== "") {
     
         
-    $buffer .= 'title(';
+    $buffer = 'title(';
         $arg0 =\var_export($input->title, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
+++ b/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Grafana\Foundation\Panelbuilder;
+
+final class PanelConverter
+{
+    public static function convert(\Grafana\Foundation\Panelbuilder\Panel $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Panelbuilder\PanelBuilder())',
+        ];
+        $buffer = '';
+            if ($input->onlyFromThisDashboard !== false) {
+    
+        
+    $buffer .= 'onlyFromThisDashboard(';
+        $arg0 =\var_export($input->onlyFromThisDashboard, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->onlyInTimeRange !== false) {
+    
+        
+    $buffer .= 'onlyInTimeRange(';
+        $arg0 =\var_export($input->onlyInTimeRange, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if (count($input->tags) >= 1) {
+    
+        
+    $buffer .= 'tags(';
+        $tmparg0 = [];
+        foreach ($input->tags as $arg1) {
+        $tmptagsarg1 =\var_export($arg1, true);
+        $tmparg0[] = $tmptagsarg1;
+        }
+        $arg0 = "[" . implode(", \n", $tmparg0) . "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->limit !== 10) {
+    
+        
+    $buffer .= 'limit(';
+        $arg0 =\var_export($input->limit, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->showUser !== true) {
+    
+        
+    $buffer .= 'showUser(';
+        $arg0 =\var_export($input->showUser, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->showTime !== true) {
+    
+        
+    $buffer .= 'showTime(';
+        $arg0 =\var_export($input->showTime, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->showTags !== true) {
+    
+        
+    $buffer .= 'showTags(';
+        $arg0 =\var_export($input->showTags, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->navigateToPanel !== true) {
+    
+        
+    $buffer .= 'navigateToPanel(';
+        $arg0 =\var_export($input->navigateToPanel, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->navigateBefore !== "" && $input->navigateBefore !== "10m") {
+    
+        
+    $buffer .= 'navigateBefore(';
+        $arg0 =\var_export($input->navigateBefore, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            if ($input->navigateAfter !== "" && $input->navigateAfter !== "10m") {
+    
+        
+    $buffer .= 'navigateAfter(';
+        $arg0 =\var_export($input->navigateAfter, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
+++ b/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
@@ -10,39 +10,36 @@ final class PanelConverter
         $calls = [
             '(new \Grafana\Foundation\Panelbuilder\PanelBuilder())',
         ];
-        $buffer = '';
             if ($input->onlyFromThisDashboard !== false) {
     
         
-    $buffer .= 'onlyFromThisDashboard(';
+    $buffer = 'onlyFromThisDashboard(';
         $arg0 =\var_export($input->onlyFromThisDashboard, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->onlyInTimeRange !== false) {
     
         
-    $buffer .= 'onlyInTimeRange(';
+    $buffer = 'onlyInTimeRange(';
         $arg0 =\var_export($input->onlyInTimeRange, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if (count($input->tags) >= 1) {
     
         
-    $buffer .= 'tags(';
+    $buffer = 'tags(';
         $tmparg0 = [];
         foreach ($input->tags as $arg1) {
         $tmptagsarg1 =\var_export($arg1, true);
@@ -54,105 +51,97 @@ final class PanelConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->limit !== 10) {
     
         
-    $buffer .= 'limit(';
+    $buffer = 'limit(';
         $arg0 =\var_export($input->limit, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->showUser !== true) {
     
         
-    $buffer .= 'showUser(';
+    $buffer = 'showUser(';
         $arg0 =\var_export($input->showUser, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->showTime !== true) {
     
         
-    $buffer .= 'showTime(';
+    $buffer = 'showTime(';
         $arg0 =\var_export($input->showTime, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->showTags !== true) {
     
         
-    $buffer .= 'showTags(';
+    $buffer = 'showTags(';
         $arg0 =\var_export($input->showTags, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->navigateToPanel !== true) {
     
         
-    $buffer .= 'navigateToPanel(';
+    $buffer = 'navigateToPanel(';
         $arg0 =\var_export($input->navigateToPanel, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->navigateBefore !== "" && $input->navigateBefore !== "10m") {
     
         
-    $buffer .= 'navigateBefore(';
+    $buffer = 'navigateBefore(';
         $arg0 =\var_export($input->navigateBefore, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             if ($input->navigateAfter !== "" && $input->navigateAfter !== "10m") {
     
         
-    $buffer .= 'navigateAfter(';
+    $buffer = 'navigateAfter(';
         $arg0 =\var_export($input->navigateAfter, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
+++ b/testdata/jennies/builders/panel_builders/PHPConverter/src/Panelbuilder/PanelConverter.php
@@ -6,6 +6,7 @@ final class PanelConverter
 {
     public static function convert(\Grafana\Foundation\Panelbuilder\Panel $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Panelbuilder\PanelBuilder())',
         ];

--- a/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
+++ b/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Properties\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Properties\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
+++ b/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
@@ -10,18 +10,16 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Properties\SomeStructBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'id(';
+    $buffer = 'id(';
         $arg0 =\var_export($input->id, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
+++ b/testdata/jennies/builders/properties/PHPConverter/src/Properties/SomeStructConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\Properties;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Properties\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Properties\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'id(';
+        $arg0 =\var_export($input->id, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
+++ b/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
@@ -6,6 +6,7 @@ final class PersonConverter
 {
     public static function convert(\Grafana\Foundation\SomePkg\Person $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\SomePkg\PersonBuilder())',
         ];

--- a/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
+++ b/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
@@ -10,18 +10,16 @@ final class PersonConverter
         $calls = [
             '(new \Grafana\Foundation\SomePkg\PersonBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'name(';
+    $buffer = 'name(';
         $arg0 =\var_export($input->name, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
+++ b/testdata/jennies/builders/references/PHPConverter/src/SomePkg/PersonConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Grafana\Foundation\SomePkg;
+
+final class PersonConverter
+{
+    public static function convert(\Grafana\Foundation\SomePkg\Person $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\SomePkg\PersonBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'name(';
+        $arg0 =\var_export($input->name, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -6,6 +6,7 @@ final class SomeStructConverter
 {
     public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -10,11 +10,10 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];
-        $buffer = '';
             if ($input->time !== null && $input->time->from !== "" && $input->time->from !== "now-6h" && $input->time->to !== "" && $input->time->to !== "now") {
     
         
-    $buffer .= 'time(';
+    $buffer = 'time(';
         $arg0 =\var_export($input->time->from, true);
         $buffer .= $arg0;
         $buffer .= ', ';
@@ -24,7 +23,6 @@ final class SomeStructConverter
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->time !== null && $input->time->from !== "" && $input->time->from !== "now-6h" && $input->time->to !== "" && $input->time->to !== "now") {
+    
+        
+    $buffer .= 'time(';
+        $arg0 =\var_export($input->time->from, true);
+        $buffer .= $arg0;
+        $buffer .= ', ';
+        $arg1 =\var_export($input->time->to, true);
+        $buffer .= $arg1;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\StructWithDefaults;
+
+final class NestedStructConverter
+{
+    public static function convert(\Grafana\Foundation\StructWithDefaults\NestedStruct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\StructWithDefaults\NestedStructBuilder())',
+        ];
+        $buffer = '';
+            if ($input->stringVal !== "") {
+    
+        
+    $buffer .= 'stringVal(';
+        $arg0 =\var_export($input->stringVal, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    
+    
+    }
+            
+    
+        {
+    $buffer .= 'intVal(';
+        $arg0 =\var_export($input->intVal, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
@@ -10,32 +10,29 @@ final class NestedStructConverter
         $calls = [
             '(new \Grafana\Foundation\StructWithDefaults\NestedStructBuilder())',
         ];
-        $buffer = '';
             if ($input->stringVal !== "") {
     
         
-    $buffer .= 'stringVal(';
+    $buffer = 'stringVal(';
         $arg0 =\var_export($input->stringVal, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     
     
     }
             
     
         {
-    $buffer .= 'intVal(';
+    $buffer = 'intVal(';
         $arg0 =\var_export($input->intVal, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/NestedStructConverter.php
@@ -6,6 +6,7 @@ final class NestedStructConverter
 {
     public static function convert(\Grafana\Foundation\StructWithDefaults\NestedStruct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\StructWithDefaults\NestedStructBuilder())',
         ];

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
@@ -6,6 +6,7 @@ final class StructConverter
 {
     public static function convert(\Grafana\Foundation\StructWithDefaults\Struct $input): string
     {
+        
         $calls = [
             '(new \Grafana\Foundation\StructWithDefaults\StructBuilder())',
         ];

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
@@ -10,74 +10,68 @@ final class StructConverter
         $calls = [
             '(new \Grafana\Foundation\StructWithDefaults\StructBuilder())',
         ];
-        $buffer = '';
             
     
         {
-    $buffer .= 'allFields(';
+    $buffer = 'allFields(';
         $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->allFields);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             
     
         {
-    $buffer .= 'partialFields(';
+    $buffer = 'partialFields(';
         $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->partialFields);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             
     
         {
-    $buffer .= 'emptyFields(';
+    $buffer = 'emptyFields(';
         $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->emptyFields);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             
     
         {
-    $buffer .= 'complexField(';
+    $buffer = 'complexField(';
         $arg0 =\var_export($input->complexField, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     
             
     
         {
-    $buffer .= 'partialComplexField(';
+    $buffer = 'partialComplexField(';
         $arg0 =\var_export($input->partialComplexField, true);
         $buffer .= $arg0;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    $buffer = '';
     }
     
     

--- a/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPConverter/src/StructWithDefaults/StructConverter.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Grafana\Foundation\StructWithDefaults;
+
+final class StructConverter
+{
+    public static function convert(\Grafana\Foundation\StructWithDefaults\Struct $input): string
+    {
+        $calls = [
+            '(new \Grafana\Foundation\StructWithDefaults\StructBuilder())',
+        ];
+        $buffer = '';
+            
+    
+        {
+    $buffer .= 'allFields(';
+        $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->allFields);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            
+    
+        {
+    $buffer .= 'partialFields(';
+        $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->partialFields);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            
+    
+        {
+    $buffer .= 'emptyFields(';
+        $arg0 = \Grafana\Foundation\StructWithDefaults\NestedStructConverter::convert($input->emptyFields);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            
+    
+        {
+    $buffer .= 'complexField(';
+        $arg0 =\var_export($input->complexField, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+            
+    
+        {
+    $buffer .= 'partialComplexField(';
+        $arg0 =\var_export($input->partialComplexField, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    $buffer = '';
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/rawtypes/variant_dataquery/PHPRawTypes/src/VariantDataquery/Query.php
+++ b/testdata/jennies/rawtypes/variant_dataquery/PHPRawTypes/src/VariantDataquery/Query.php
@@ -44,4 +44,9 @@ class Query implements \JsonSerializable, \Grafana\Foundation\Cog\Dataquery
         }
         return $data;
     }
+
+    public function dataqueryType(): string
+    {
+        return "prometheus";
+    }
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/VariantConfig.php
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/VariantConfig.php
@@ -9,7 +9,7 @@ final class VariantConfig
         return new \Grafana\Foundation\Cog\PanelcfgConfig(
             identifier: 'timeseries',
             optionsFromArray: [\Grafana\Foundation\VariantPanelcfgFull\Options::class, 'fromArray'],
-            fieldConfigFromArray: [\Grafana\Foundation\VariantPanelcfgFull\FieldConfig::class, 'fromArray']
+            fieldConfigFromArray: [\Grafana\Foundation\VariantPanelcfgFull\FieldConfig::class, 'fromArray'],
         );
     }
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/PHPRawTypes/src/VariantPanelcfgOnlyOptions/VariantConfig.php
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/PHPRawTypes/src/VariantPanelcfgOnlyOptions/VariantConfig.php
@@ -9,7 +9,7 @@ final class VariantConfig
         return new \Grafana\Foundation\Cog\PanelcfgConfig(
             identifier: 'text',
             optionsFromArray: [\Grafana\Foundation\VariantPanelcfgOnlyOptions\Options::class, 'fromArray'],
-            fieldConfigFromArray: null
+            fieldConfigFromArray: null,
         );
     }
 }


### PR DESCRIPTION
Similar to #566, but for PHP.

Contributes to #314

Having a converter jenny for both PHP and Go will allow us to gain more confidence/expertise on that feature. Making sure that the approach can work for other languages too, and start prototyping integration in other tools such as [grizzly](https://github.com/grafana/grizzly/) and the [Grafana VS Code extension](https://github.com/grafana/grafana-vs-code-extension).