### PR TITLE
Restore missing team.Team object

### DIFF
--- a/config/compiler/team.yaml
+++ b/config/compiler/team.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/grafana/cog/main/schemas/compiler_passes.json
+
+passes:
+  #########
+  # Teams #
+  #########
+
+  - rename_object:
+      from: team.CreateTeamCommand
+      to: Team
+
+  - fields_set_required:
+      fields: [ team.Team.name ]

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -32,6 +32,7 @@ inputs:
       package: expr
       transformations:
         - '%__config_dir%/compiler/expr_passes.yaml'
+
   - openapi:
       url: 'https://raw.githubusercontent.com/grafana/grafana/%grafana_version%/public/openapi3.json'
       no_validate: true
@@ -45,6 +46,16 @@ inputs:
         - TimeIntervalItem
       transformations:
         - '%__config_dir%/compiler/alerting.yaml'
+
+  - if: '"%grafana_version%" == "main" || semver("%grafana_version%").MoreThanEqual(semver("v11.2.x"))'
+    openapi:
+      url: 'https://raw.githubusercontent.com/grafana/grafana/%grafana_version%/public/openapi3.json'
+      no_validate: true
+      package: team
+      allowed_objects:
+        - CreateTeamCommand
+      transformations:
+        - '%__config_dir%/compiler/team.yaml'
 
   # The schema for testdata queries is gone from the kind-registry since v11.0.x
   - if: '"%grafana_version%" == "main" || semver("%grafana_version%").MoreThanEqual(semver("v11.0.x"))'


### PR DESCRIPTION
Looks like this object was deleted from the kind-registry with v11.2.x by https://github.com/grafana/grafana/pull/90418