### PR TITLE
Go - explicit imports declarations

### DIFF
--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -47,7 +47,7 @@ func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error)
 }
 
 func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.Config.PackageRoot)
 	jenny.typeImportMapper = func(pkg string) string {
 		if imports.IsIdentical(pkg, builder.Package) {
 			return ""

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -55,7 +55,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = builderTypeFormatter(jenny.Config, context, jenny.typeImportMapper)
+	jenny.typeFormatter = builderTypeFormatter(jenny.Config, context, imports, jenny.typeImportMapper)
 	jenny.pathFormatter = makePathFormatter(jenny.typeFormatter)
 
 	// every builder has a dependency on cog's runtime, so let's make sure it's declared.
@@ -69,6 +69,9 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 
 	return jenny.Tmpl.
 		Funcs(map[string]any{
+			"importStdPkg": func(pkg string) string {
+				return imports.Add(pkg, pkg)
+			},
 			"formatPath": jenny.pathFormatter,
 			"formatType": jenny.typeFormatter.formatType,
 			"formatTypeNoBuilder": func(typeDef ast.Type) string {

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -52,8 +52,7 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	typeImportMapper("cog")
-	formatter := builderTypeFormatter(jenny.Config, context, typeImportMapper)
+	formatter := builderTypeFormatter(jenny.Config, context, imports, typeImportMapper)
 
 	dummyImports := NewImportMap()
 	dummyImportMapper := func(pkg string) string {
@@ -66,8 +65,12 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 
 	return jenny.Tmpl.
 		Funcs(map[string]any{
-			"formatType":          builderTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
-			"formatTypeNoBuilder": defaultTypeFormatter(jenny.Config, context, dummyImportMapper).formatType,
+			"importStdPkg": func(pkg string) string {
+				return imports.Add(pkg, pkg)
+			},
+			"importPkg":           typeImportMapper,
+			"formatType":          builderTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
+			"formatTypeNoBuilder": defaultTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
 			"formatPath":          makePathFormatter(formatter),
 			"formatRawRef":        formatRawRef,
 		}).

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -44,7 +44,7 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
 	converter := languages.NewConverterGenerator(jenny.NullableConfig).FromBuilder(context, builder)
 
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.Config.PackageRoot)
 	typeImportMapper := func(pkg string) string {
 		if imports.IsIdentical(pkg, builder.Package) {
 			return ""
@@ -54,7 +54,7 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 	}
 	formatter := builderTypeFormatter(jenny.Config, context, imports, typeImportMapper)
 
-	dummyImports := NewImportMap()
+	dummyImports := NewImportMap(jenny.Config.PackageRoot)
 	dummyImportMapper := func(pkg string) string {
 		return dummyImports.Add(pkg, jenny.Config.importPath(pkg))
 	}

--- a/internal/jennies/golang/equality.go
+++ b/internal/jennies/golang/equality.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
 )
@@ -18,7 +19,7 @@ func newEqualityMethods(tmpl *template.Template) equalityMethods {
 	}
 }
 
-func (jenny equalityMethods) generateForObject(buffer *strings.Builder, context languages.Context, schema *ast.Schema, object ast.Object) error {
+func (jenny equalityMethods) generateForObject(buffer *strings.Builder, context languages.Context, schema *ast.Schema, object ast.Object, imports *common.DirectImportMap) error {
 	if !object.Type.IsStruct() {
 		return nil
 	}
@@ -44,6 +45,9 @@ func (jenny equalityMethods) generateForObject(buffer *strings.Builder, context 
 			return context.ResolveRefs(typeDef).IsEnum()
 		},
 		"resolveRefs": context.ResolveRefs,
+		"importStdPkg": func(pkg string) string {
+			return imports.Add(pkg, pkg)
+		},
 	})
 
 	templateFile := "types/struct_equality_method.tmpl"

--- a/internal/jennies/golang/imports.go
+++ b/internal/jennies/golang/imports.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 )
 
-func NewImportMap() *common.DirectImportMap {
+func NewImportMap(packageRoot string) *common.DirectImportMap {
 	return common.NewDirectImportMap(
 		common.WithAliasSanitizer[common.DirectImportMap](formatPackageName),
 		common.WithImportPathSanitizer[common.DirectImportMap](strings.ToLower),
@@ -18,7 +18,11 @@ func NewImportMap() *common.DirectImportMap {
 
 			statements := make([]string, 0, importMap.Imports.Len())
 			importMap.Imports.Iterate(func(alias string, importPath string) {
-				statements = append(statements, fmt.Sprintf(`	%s "%s"`, alias, importPath))
+				if strings.HasPrefix(importPath, packageRoot) {
+					statements = append(statements, fmt.Sprintf(`	%s "%s"`, alias, importPath))
+				} else { // stdlib import
+					statements = append(statements, fmt.Sprintf(`	"%s"`, importPath))
+				}
 			})
 
 			return fmt.Sprintf(`import (

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -14,6 +14,7 @@ import (
 type JSONMarshalling struct {
 	tmpl          *template.Template
 	config        Config
+	imports       *common.DirectImportMap
 	packageMapper func(string) string
 	typeFormatter *typeFormatter
 }
@@ -27,6 +28,7 @@ func NewJSONMarshalling(config Config, tmpl *template.Template, imports *common.
 				return imports.Add(pkg, pkg)
 			},
 		}),
+		imports:       imports,
 		packageMapper: packageMapper,
 		typeFormatter: typeFormatter,
 	}
@@ -236,6 +238,8 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 		}
 	}
 
+	jenny.imports.Add("json", "encoding/json")
+
 	return fmt.Sprintf(`func (resource *%[1]s) UnmarshalJSON(raw []byte) error {
 	if raw == nil {
 		return nil
@@ -276,7 +280,10 @@ dataqueryTypeHint = *resource.%[1]s.Type
 `, tools.UpperCamelCase(hintField.Name))
 	}
 
+	jenny.packageMapper("cog")
+
 	if field.Type.IsArray() {
+		jenny.packageMapper("cog")
 		return fmt.Sprintf(`
 	%[3]s
 	if fields["%[2]s"] != nil {

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -17,11 +18,14 @@ type JSONMarshalling struct {
 	typeFormatter *typeFormatter
 }
 
-func NewJSONMarshalling(config Config, tmpl *template.Template, packageMapper func(string) string, typeFormatter *typeFormatter) JSONMarshalling {
+func NewJSONMarshalling(config Config, tmpl *template.Template, imports *common.DirectImportMap, packageMapper func(string) string, typeFormatter *typeFormatter) JSONMarshalling {
 	return JSONMarshalling{
 		config: config,
 		tmpl: tmpl.Funcs(template.FuncMap{
 			"formatType": typeFormatter.formatType,
+			"importStdPkg": func(pkg string) string {
+				return imports.Add(pkg, pkg)
+			},
 		}),
 		packageMapper: packageMapper,
 		typeFormatter: typeFormatter,

--- a/internal/jennies/golang/postprocessor.go
+++ b/internal/jennies/golang/postprocessor.go
@@ -14,7 +14,10 @@ func PostProcessFile(file codejen.File) (codejen.File, error) {
 		return file, nil
 	}
 
-	output, err := imports.Process(filepath.Base(file.RelativePath), file.Data, nil)
+	output, err := imports.Process(filepath.Base(file.RelativePath), file.Data, &imports.Options{
+		FormatOnly: true,
+		Comments:   true,
+	})
 	if err != nil {
 		return codejen.File{}, fmt.Errorf("goimports processing of generated file failed: %w", err)
 	}

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -47,7 +47,7 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 	var buffer strings.Builder
 	var err error
 
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.Config.PackageRoot)
 	packageMapper := func(pkg string) string {
 		if imports.IsIdentical(pkg, schema.Package) {
 			return ""

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -55,8 +55,8 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, packageMapper)
-	unmarshallerGenerator := NewJSONMarshalling(jenny.Config, jenny.Tmpl, packageMapper, jenny.typeFormatter)
+	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, imports, packageMapper)
+	unmarshallerGenerator := NewJSONMarshalling(jenny.Config, jenny.Tmpl, imports, packageMapper, jenny.typeFormatter)
 	equalityMethodsGenerator := newEqualityMethods(jenny.Tmpl)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
@@ -75,7 +75,7 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 			return
 		}
 
-		innerErr = equalityMethodsGenerator.generateForObject(&buffer, context, schema, object)
+		innerErr = equalityMethodsGenerator.generateForObject(&buffer, context, schema, object, imports)
 		if innerErr != nil {
 			err = innerErr
 			return

--- a/internal/jennies/golang/runtime.go
+++ b/internal/jennies/golang/runtime.go
@@ -49,6 +49,10 @@ type Builder[ResourceT any] interface {
 func (jenny Runtime) Runtime() ([]byte, error) {
 	imports := NewImportMap()
 	imports.Add("", jenny.Config.importPath("cog/variants"))
+	imports.Add("json", "encoding/json")
+	imports.Add("fmt", "fmt")
+	imports.Add("reflect", "reflect")
+	imports.Add("strings", "strings")
 
 	return jenny.Tmpl.RenderAsBytes("runtime/runtime.tmpl", map[string]any{
 		"imports": imports,

--- a/internal/jennies/golang/runtime.go
+++ b/internal/jennies/golang/runtime.go
@@ -47,7 +47,7 @@ type Builder[ResourceT any] interface {
 }
 
 func (jenny Runtime) Runtime() ([]byte, error) {
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.Config.PackageRoot)
 	imports.Add("", jenny.Config.importPath("cog/variants"))
 	imports.Add("json", "encoding/json")
 	imports.Add("fmt", "fmt")

--- a/internal/jennies/golang/templates/builders/constraints.tmpl
+++ b/internal/jennies/golang/templates/builders/constraints.tmpl
@@ -1,5 +1,6 @@
 {{- define "constraints" }}
 {{- range . }}
+    {{- $errors := importStdPkg "errors" }}
     {{- $argName := .Argument.Name|formatArgName }}
     {{- $leftOperand := $argName }}
     {{- $operator := .Op }}

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -26,10 +26,13 @@ package {{ .Converter.Package | formatPackageName }}
 
 {{- define "value_formatter" -}}
     {{- if .Type.IsAny -}}
+        {{- $cog := importPkg "cog" -}}
         cog.Dump({{ .Path | formatPath }})
     {{- else if .Type.IsScalar -}}
+        {{- $reflect := importStdPkg "fmt" -}}
         fmt.Sprintf("%#v", {{ .Type | maybeDereference }}{{ .Path | formatPath }})
     {{- else -}}
+        {{- $cog := importPkg "cog" -}}
         cog.Dump({{ .Type | maybeDereference }}{{ .Path | formatPath }})
     {{- end -}}
 {{- end }}
@@ -52,6 +55,7 @@ package {{ .Converter.Package | formatPackageName }}
         {{ end }}
     {{- end -}}
     {{- with .Arg.Array -}}
+        {{- $reflect := importStdPkg "strings" -}}
         tmp{{ $.IntoVar }} := []string{}
         for _, {{ .ValueAs | formatPath }} := range {{ .For | formatPath }} {
         {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
@@ -61,6 +65,7 @@ package {{ .Converter.Package | formatPackageName }}
         {{ $.IntoVar }} := "{{ .ForType | formatType }}{" + strings.Join(tmp{{ $.IntoVar }}, ",\n") + "}"
     {{- end -}}
     {{- with .Arg.Map -}}
+        {{- $reflect := importStdPkg "fmt" -}}
         {{ $.IntoVar }} := "map[{{ .IndexType | formatType }}]{{ .ValueType | formatTypeNoBuilder }}{"
         for key, {{ .ValueAs | formatPath }} := range {{ .For | formatPath }} {
         {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
@@ -70,6 +75,7 @@ package {{ .Converter.Package | formatPackageName }}
         {{ $.IntoVar }} += "}"
     {{- end -}}
     {{- with .Arg.Runtime -}}
+        {{- $cog := importPkg "cog" -}}
         {{ $.IntoVar }} := cog.{{ .FuncName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}{{ $runtimeArg.ValuePath | formatPath }}{{ else }}{{ maybeUnptr ($runtimeArg.ValuePath | formatPath) $runtimeArg.ValueType }}{{ end }}, {{ end }})
     {{- end -}}
     {{- with .Arg.Direct -}}
@@ -108,6 +114,7 @@ package {{ .Converter.Package | formatPackageName }}
 {{- end }}
 
 {{- define "converter" -}}
+    {{- $reflect := importStdPkg "strings" -}}
     func {{ .Converter.BuilderName | upperCamelCase }}Converter(input *{{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType  }}) string {
     {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
     calls := []string{

--- a/internal/jennies/golang/templates/runtime/variant_models.tmpl
+++ b/internal/jennies/golang/templates/runtime/variant_models.tmpl
@@ -1,5 +1,9 @@
 package variants
 
+import (
+	"reflect"
+)
+
 type PanelcfgConfig struct {
 	Identifier             string
 	OptionsUnmarshaler     func(raw []byte) (any, error)

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -1,4 +1,6 @@
 func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $fmt := importStdPkg "fmt" -}}
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|upperCamelCase }} != nil {
 		return json.Marshal(resource.{{ .Name|upperCamelCase }})

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
@@ -1,3 +1,6 @@
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $errors := importStdPkg "errors" -}}
+{{- $fmt := importStdPkg "fmt" -}}
 func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
 	if raw == nil {
 		return nil

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
@@ -1,3 +1,5 @@
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $fmt := importStdPkg "fmt" -}}
 func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|upperCamelCase }} != nil {

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_unmarshal.tmpl
@@ -1,3 +1,5 @@
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $errors := importStdPkg "errors" -}}
 func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
 	if raw == nil {
 		return nil

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -7,6 +7,7 @@ func (resource {{ .def.Name|upperCamelCase }}) Equals(other {{ .def.Name|upperCa
 {{/* arguments: Type, Nullable, Dereference, SelfName, OtherName */}}
 {{- define "type_equality_check" }}
 	{{- if .Type.IsAny }}
+		{{- $reflect := importStdPkg "reflect" }}
 		{{- $dereference := ternary "*" "" .Dereference }}
 		// is DeepEqual good enough here?
 		if !reflect.DeepEqual({{ $dereference }}{{ .SelfName }}, {{ $dereference }}{{ .OtherName }}) {

--- a/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
@@ -1,3 +1,4 @@
+{{- $json := importStdPkg "encoding/json" -}}
 func VariantConfig() variants.DataqueryConfig {
 	return variants.DataqueryConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",

--- a/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_panelcfg.json_unmarshal.tmpl
@@ -1,3 +1,4 @@
+{{- $json := importStdPkg "encoding/json" -}}
 func VariantConfig() variants.PanelcfgConfig {
 	return variants.PanelcfgConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -30,6 +30,12 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"formatRawRef": func(_ ast.Type) string {
 				panic("formatRawRef() needs to be overridden by a jenny")
 			},
+			"importStdPkg": func(_ string) string {
+				panic("importStdPkg() needs to be overridden by a jenny")
+			},
+			"importPkg": func(_ string) string {
+				panic("importPkg() needs to be overridden by a jenny")
+			},
 			"emptyValueForGuard": func(_ ast.Type) string {
 				panic("emptyValueForGuard() needs to be overridden by a jenny")
 			},

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type typeFormatter struct {
+	imports       *common.DirectImportMap
 	packageMapper func(pkg string) string
 	config        Config
 
@@ -18,16 +20,18 @@ type typeFormatter struct {
 	context    languages.Context
 }
 
-func defaultTypeFormatter(config Config, context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
+func defaultTypeFormatter(config Config, context languages.Context, imports *common.DirectImportMap, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
+		imports:       imports,
 		packageMapper: packageMapper,
 		config:        config,
 		context:       context,
 	}
 }
 
-func builderTypeFormatter(config Config, context languages.Context, packageMapper func(pkg string) string) *typeFormatter {
+func builderTypeFormatter(config Config, context languages.Context, imports *common.DirectImportMap, packageMapper func(pkg string) string) *typeFormatter {
 	return &typeFormatter{
+		imports:       imports,
 		packageMapper: packageMapper,
 		config:        config,
 		forBuilder:    true,
@@ -69,6 +73,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 			typeName := def.AsScalar().ScalarKind
 			if def.HasHint(ast.HintStringFormatDateTime) {
 				typeName = "time.Time"
+				formatter.imports.Add("time", "time")
 			}
 			if def.Nullable {
 				typeName = "*" + typeName

--- a/internal/jennies/golang/variantsplugins.go
+++ b/internal/jennies/golang/variantsplugins.go
@@ -42,7 +42,7 @@ func (jenny VariantsPlugins) variantModels() ([]byte, error) {
 }
 
 func (jenny VariantsPlugins) variantPlugins(context languages.Context) ([]byte, error) {
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.Config.PackageRoot)
 	var panelSchemas []*ast.Schema
 	var dataquerySchemas []*ast.Schema
 

--- a/testdata/generated/cog/plugins/variants.go
+++ b/testdata/generated/cog/plugins/variants.go
@@ -5,6 +5,10 @@
 
 package plugins
 
+import (
+	cog "github.com/grafana/cog/testdata/generated/cog"
+)
+
 func RegisterDefaultPlugins() {
 
 	// Panelcfg variants

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -6,10 +6,10 @@
 package cog
 
 import (
-	json "encoding/json"
-	fmt "fmt"
-	reflect "reflect"
-	strings "strings"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/grafana/cog/testdata/generated/cog/variants"
 )

--- a/testdata/generated/cog/runtime.go
+++ b/testdata/generated/cog/runtime.go
@@ -6,10 +6,10 @@
 package cog
 
 import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-	"strings"
+	json "encoding/json"
+	fmt "fmt"
+	reflect "reflect"
+	strings "strings"
 
 	"github.com/grafana/cog/testdata/generated/cog/variants"
 )

--- a/testdata/generated/cog/variants/variants.go
+++ b/testdata/generated/cog/variants/variants.go
@@ -5,7 +5,9 @@
 
 package variants
 
-import "reflect"
+import (
+	"reflect"
+)
 
 type PanelcfgConfig struct {
 	Identifier             string

--- a/testdata/generated/equality/types_gen.go
+++ b/testdata/generated/equality/types_gen.go
@@ -5,7 +5,9 @@
 
 package equality
 
-import "reflect"
+import (
+	reflect "reflect"
+)
 
 // Modified by compiler pass 'PrefixEnumValues'
 type Direction string

--- a/testdata/generated/equality/types_gen.go
+++ b/testdata/generated/equality/types_gen.go
@@ -6,7 +6,7 @@
 package equality
 
 import (
-	reflect "reflect"
+	"reflect"
 )
 
 // Modified by compiler pass 'PrefixEnumValues'

--- a/testdata/jennies/builders/array_append/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/array_append/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package sandbox
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/array_append/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/array_append/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package sandbox
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/basic_struct/GoConverter/basic_struct/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/basic_struct/GoConverter/basic_struct/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package basic_struct
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/basic_struct/GoConverter/basic_struct/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/basic_struct/GoConverter/basic_struct/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package basic_struct
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/basic_struct_defaults/GoConverter/basic_struct_defaults/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/basic_struct_defaults/GoConverter/basic_struct_defaults/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package basic_struct_defaults
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/basic_struct_defaults/GoConverter/basic_struct_defaults/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/basic_struct_defaults/GoConverter/basic_struct_defaults/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package basic_struct_defaults
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboard_converter_gen.go
@@ -3,8 +3,8 @@ package builder_delegation
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func DashboardConverter(input *Dashboard) string {

--- a/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboard_converter_gen.go
@@ -3,7 +3,8 @@ package builder_delegation
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func DashboardConverter(input *Dashboard) string {

--- a/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboardlink_converter_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboardlink_converter_gen.go
@@ -3,8 +3,8 @@ package builder_delegation
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func DashboardLinkConverter(input *DashboardLink) string {

--- a/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboardlink_converter_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoConverter/builder_delegation/dashboardlink_converter_gen.go
@@ -3,7 +3,8 @@ package builder_delegation
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func DashboardLinkConverter(input *DashboardLink) string {

--- a/testdata/jennies/builders/composable_slot/GoConverter/composable_slot/lokibuilder_converter_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoConverter/composable_slot/lokibuilder_converter_gen.go
@@ -3,6 +3,7 @@ package composable_slot
 
 
 import (
+	strings "strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/builders/composable_slot/GoConverter/composable_slot/lokibuilder_converter_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoConverter/composable_slot/lokibuilder_converter_gen.go
@@ -3,7 +3,7 @@ package composable_slot
 
 
 import (
-	strings "strings"
+	"strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/builders/constant_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constant_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,7 +3,7 @@ package sandbox
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constant_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constant_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,7 +3,7 @@ package sandbox
 
 
 import (
-	strings "strings"
+	"strings"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
@@ -2,6 +2,7 @@ package constraints
 
 import (
 	cog "github.com/grafana/cog/generated/cog"
+	errors "errors"
 )
 
 var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)

--- a/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
@@ -2,7 +2,7 @@ package constraints
 
 import (
 	cog "github.com/grafana/cog/generated/cog"
-	errors "errors"
+	"errors"
 )
 
 var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)

--- a/testdata/jennies/builders/constraints/GoConverter/constraints/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constraints/GoConverter/constraints/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package constraints
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constraints/GoConverter/constraints/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constraints/GoConverter/constraints/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package constraints
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constructor_argument/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constructor_argument/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package sandbox
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constructor_argument/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/constructor_argument/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package sandbox
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/constructor_initializations/GoConverter/constructor_initializations/somepanel_converter_gen.go
+++ b/testdata/jennies/builders/constructor_initializations/GoConverter/constructor_initializations/somepanel_converter_gen.go
@@ -3,8 +3,8 @@ package constructor_initializations
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomePanelConverter(input *SomePanel) string {

--- a/testdata/jennies/builders/constructor_initializations/GoConverter/constructor_initializations/somepanel_converter_gen.go
+++ b/testdata/jennies/builders/constructor_initializations/GoConverter/constructor_initializations/somepanel_converter_gen.go
@@ -3,7 +3,8 @@ package constructor_initializations
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomePanelConverter(input *SomePanel) string {

--- a/testdata/jennies/builders/dataquery_variant_builder/GoConverter/dataquery_variant_builder/lokibuilder_converter_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoConverter/dataquery_variant_builder/lokibuilder_converter_gen.go
@@ -3,8 +3,8 @@ package dataquery_variant_builder
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func LokiBuilderConverter(input *Loki) string {

--- a/testdata/jennies/builders/dataquery_variant_builder/GoConverter/dataquery_variant_builder/lokibuilder_converter_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoConverter/dataquery_variant_builder/lokibuilder_converter_gen.go
@@ -3,7 +3,8 @@ package dataquery_variant_builder
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func LokiBuilderConverter(input *Loki) string {

--- a/testdata/jennies/builders/envelope_assignment/GoConverter/sandbox/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/envelope_assignment/GoConverter/sandbox/dashboard_converter_gen.go
@@ -3,8 +3,8 @@ package sandbox
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func DashboardConverter(input *Dashboard) string {

--- a/testdata/jennies/builders/envelope_assignment/GoConverter/sandbox/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/envelope_assignment/GoConverter/sandbox/dashboard_converter_gen.go
@@ -3,7 +3,8 @@ package sandbox
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func DashboardConverter(input *Dashboard) string {

--- a/testdata/jennies/builders/foreign_builder/GoConverter/builder_pkg/somenicebuilder_converter_gen.go
+++ b/testdata/jennies/builders/foreign_builder/GoConverter/builder_pkg/somenicebuilder_converter_gen.go
@@ -3,9 +3,9 @@ package builder_pkg
 
 
 import (
-	strings "strings"
+	"strings"
 	some_pkg "github.com/grafana/cog/generated/some_pkg"
-	fmt "fmt"
+	"fmt"
 )
 
 func SomeNiceBuilderConverter(input *some_pkg.SomeStruct) string {

--- a/testdata/jennies/builders/foreign_builder/GoConverter/builder_pkg/somenicebuilder_converter_gen.go
+++ b/testdata/jennies/builders/foreign_builder/GoConverter/builder_pkg/somenicebuilder_converter_gen.go
@@ -3,8 +3,9 @@ package builder_pkg
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
 	some_pkg "github.com/grafana/cog/generated/some_pkg"
+	fmt "fmt"
 )
 
 func SomeNiceBuilderConverter(input *some_pkg.SomeStruct) string {

--- a/testdata/jennies/builders/initialization_safeguards/GoConverter/initialization_safeguards/somepanel_converter_gen.go
+++ b/testdata/jennies/builders/initialization_safeguards/GoConverter/initialization_safeguards/somepanel_converter_gen.go
@@ -3,7 +3,8 @@ package initialization_safeguards
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomePanelConverter(input *SomePanel) string {

--- a/testdata/jennies/builders/initialization_safeguards/GoConverter/initialization_safeguards/somepanel_converter_gen.go
+++ b/testdata/jennies/builders/initialization_safeguards/GoConverter/initialization_safeguards/somepanel_converter_gen.go
@@ -3,8 +3,8 @@ package initialization_safeguards
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomePanelConverter(input *SomePanel) string {

--- a/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package known_any
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/known_any/GoConverter/known_any/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package known_any
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package nullable_map_assignment
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoConverter/nullable_map_assignment/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package nullable_map_assignment
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/package-with-dashes/GoConverter/builderpkg/somenicebuilder_converter_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoConverter/builderpkg/somenicebuilder_converter_gen.go
@@ -3,9 +3,9 @@ package builderpkg
 
 
 import (
-	strings "strings"
+	"strings"
 	withdashes "github.com/grafana/cog/generated/with-dashes"
-	fmt "fmt"
+	"fmt"
 )
 
 func SomeNiceBuilderConverter(input *withdashes.SomeStruct) string {

--- a/testdata/jennies/builders/package-with-dashes/GoConverter/builderpkg/somenicebuilder_converter_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoConverter/builderpkg/somenicebuilder_converter_gen.go
@@ -3,8 +3,9 @@ package builderpkg
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
 	withdashes "github.com/grafana/cog/generated/with-dashes"
+	fmt "fmt"
 )
 
 func SomeNiceBuilderConverter(input *withdashes.SomeStruct) string {

--- a/testdata/jennies/builders/panel_builders/GoConverter/panelbuilder/panel_converter_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoConverter/panelbuilder/panel_converter_gen.go
@@ -3,7 +3,8 @@ package panelbuilder
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func PanelConverter(input *Panel) string {

--- a/testdata/jennies/builders/panel_builders/GoConverter/panelbuilder/panel_converter_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoConverter/panelbuilder/panel_converter_gen.go
@@ -3,8 +3,8 @@ package panelbuilder
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func PanelConverter(input *Panel) string {

--- a/testdata/jennies/builders/properties/GoConverter/properties/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/properties/GoConverter/properties/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package properties
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/properties/GoConverter/properties/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/properties/GoConverter/properties/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package properties
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/references/GoConverter/some_pkg/person_converter_gen.go
+++ b/testdata/jennies/builders/references/GoConverter/some_pkg/person_converter_gen.go
@@ -3,6 +3,7 @@ package some_pkg
 
 
 import (
+	strings "strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/builders/references/GoConverter/some_pkg/person_converter_gen.go
+++ b/testdata/jennies/builders/references/GoConverter/some_pkg/person_converter_gen.go
@@ -3,7 +3,7 @@ package some_pkg
 
 
 import (
-	strings "strings"
+	"strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,8 +3,8 @@ package sandbox
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -3,7 +3,8 @@ package sandbox
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func SomeStructConverter(input *SomeStruct) string {

--- a/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/nestedstruct_converter_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/nestedstruct_converter_gen.go
@@ -3,7 +3,8 @@ package struct_with_defaults
 
 
 import (
-	cog "github.com/grafana/cog/generated/cog"
+	strings "strings"
+	fmt "fmt"
 )
 
 func NestedStructConverter(input *NestedStruct) string {

--- a/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/nestedstruct_converter_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/nestedstruct_converter_gen.go
@@ -3,8 +3,8 @@ package struct_with_defaults
 
 
 import (
-	strings "strings"
-	fmt "fmt"
+	"strings"
+	"fmt"
 )
 
 func NestedStructConverter(input *NestedStruct) string {

--- a/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/struct_converter_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/struct_converter_gen.go
@@ -3,7 +3,7 @@ package struct_with_defaults
 
 
 import (
-	strings "strings"
+	"strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/struct_converter_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoConverter/struct_with_defaults/struct_converter_gen.go
@@ -3,6 +3,7 @@ package struct_with_defaults
 
 
 import (
+	strings "strings"
 	cog "github.com/grafana/cog/generated/cog"
 )
 

--- a/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
+++ b/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
@@ -1,7 +1,7 @@
 package arrays
 
 import (
-	reflect "reflect"
+	"reflect"
 )
 
 // List of tags, maybe?

--- a/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
+++ b/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
@@ -1,5 +1,9 @@
 package arrays
 
+import (
+	reflect "reflect"
+)
+
 // List of tags, maybe?
 type ArrayOfStrings []string
 

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	reflect "reflect"
 	variants "github.com/grafana/cog/generated/cog/variants"
 	cog "github.com/grafana/cog/generated/cog"
 )

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -4,6 +4,7 @@ import (
 	reflect "reflect"
 	variants "github.com/grafana/cog/generated/cog/variants"
 	cog "github.com/grafana/cog/generated/cog"
+	json "encoding/json"
 )
 
 type Dashboard struct {

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -1,10 +1,10 @@
 package dashboard
 
 import (
-	reflect "reflect"
+	"reflect"
 	variants "github.com/grafana/cog/generated/cog/variants"
 	cog "github.com/grafana/cog/generated/cog"
-	json "encoding/json"
+	"encoding/json"
 )
 
 type Dashboard struct {

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -1,5 +1,12 @@
 package disjunctions
 
+import (
+	reflect "reflect"
+	json "encoding/json"
+	fmt "fmt"
+	errors "errors"
+)
+
 // Refresh rate or disabled.
 type RefreshRate = StringOrBool
 

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -1,10 +1,10 @@
 package disjunctions
 
 import (
-	reflect "reflect"
-	json "encoding/json"
-	fmt "fmt"
-	errors "errors"
+	"reflect"
+	"encoding/json"
+	"fmt"
+	"errors"
 )
 
 // Refresh rate or disabled.

--- a/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
+++ b/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
@@ -1,7 +1,7 @@
 package maps
 
 import (
-	reflect "reflect"
+	"reflect"
 )
 
 // String to... something.

--- a/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
+++ b/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
@@ -1,5 +1,9 @@
 package maps
 
+import (
+	reflect "reflect"
+)
+
 // String to... something.
 type MapOfStringToAny map[string]any
 

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -1,5 +1,12 @@
 package withdashes
 
+import (
+	reflect "reflect"
+	json "encoding/json"
+	fmt "fmt"
+	errors "errors"
+)
+
 type SomeStruct struct {
 	FieldAny any `json:"FieldAny"`
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -1,10 +1,10 @@
 package withdashes
 
 import (
-	reflect "reflect"
-	json "encoding/json"
-	fmt "fmt"
-	errors "errors"
+	"reflect"
+	"encoding/json"
+	"fmt"
+	"errors"
 )
 
 type SomeStruct struct {

--- a/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
@@ -1,6 +1,7 @@
 package refs
 
 import (
+	reflect "reflect"
 	otherpkg "github.com/grafana/cog/generated/otherpkg"
 )
 

--- a/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
@@ -1,7 +1,7 @@
 package refs
 
 import (
-	reflect "reflect"
+	"reflect"
 	otherpkg "github.com/grafana/cog/generated/otherpkg"
 )
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -1,10 +1,10 @@
 package struct_complex_fields
 
 import (
-	reflect "reflect"
-	json "encoding/json"
-	fmt "fmt"
-	errors "errors"
+	"reflect"
+	"encoding/json"
+	"fmt"
+	"errors"
 )
 
 // This struct does things.

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -1,5 +1,12 @@
 package struct_complex_fields
 
+import (
+	reflect "reflect"
+	json "encoding/json"
+	fmt "fmt"
+	errors "errors"
+)
+
 // This struct does things.
 type SomeStruct struct {
 	FieldRef SomeOtherStruct `json:"FieldRef"`

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
@@ -1,7 +1,7 @@
 package struct_optional_fields
 
 import (
-	reflect "reflect"
+	"reflect"
 )
 
 type SomeStruct struct {

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
@@ -1,5 +1,9 @@
 package struct_optional_fields
 
+import (
+	reflect "reflect"
+)
+
 type SomeStruct struct {
 	FieldRef *SomeOtherStruct `json:"FieldRef,omitempty"`
 	FieldString *string `json:"FieldString,omitempty"`

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
@@ -1,5 +1,9 @@
 package basic
 
+import (
+	reflect "reflect"
+)
+
 // This
 // is
 // a

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
@@ -1,7 +1,7 @@
 package basic
 
 import (
-	reflect "reflect"
+	"reflect"
 )
 
 // This

--- a/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
@@ -1,7 +1,7 @@
 package time_hint
 
 import (
-	time "time"
+	"time"
 )
 
 type ObjTime time.Time

--- a/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
@@ -1,5 +1,9 @@
 package time_hint
 
+import (
+	time "time"
+)
+
 type ObjTime time.Time
 
 type ObjWithTimeField struct {

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -2,6 +2,7 @@ package variant_dataquery
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
+	json "encoding/json"
 )
 
 type Query struct {

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -2,7 +2,7 @@ package variant_dataquery
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
-	json "encoding/json"
+	"encoding/json"
 )
 
 type Query struct {

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -2,6 +2,7 @@ package variant_panelcfg_full
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
+	json "encoding/json"
 )
 
 type Options struct {

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -2,7 +2,7 @@ package variant_panelcfg_full
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
-	json "encoding/json"
+	"encoding/json"
 )
 
 type Options struct {

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -2,6 +2,7 @@ package variant_panelcfg_only_options
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
+	json "encoding/json"
 )
 
 type Options struct {

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -2,7 +2,7 @@ package variant_panelcfg_only_options
 
 import (
 	variants "github.com/grafana/cog/generated/cog/variants"
-	json "encoding/json"
+	"encoding/json"
 )
 
 type Options struct {


### PR DESCRIPTION
Relying on the post-processing of go files to add missing imports is quite slow. This change shaves ~2s on `go run cmd/cli/main.go generate --config ./config/foundation_sdk.dev.yaml --parameters kind_registry_version=next,grafana_version=main` (not the most accurate benchmark ever, but the difference is pretty noticeable :shrug:)