### PR TITLE
Java: Create DataqueryConfig and function to return the dataquery name

### DIFF
--- a/internal/jennies/java/registry.go
+++ b/internal/jennies/java/registry.go
@@ -23,7 +23,12 @@ func (jenny Registry) JennyName() string {
 }
 
 func (jenny Registry) Generate(context languages.Context) (codejen.Files, error) {
-	panelRegistry, err := jenny.renderPanelConfig()
+	panelConfig, err := jenny.renderPanelConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	dataqueryConfig, err := jenny.renderDataqueryConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +49,8 @@ func (jenny Registry) Generate(context languages.Context) (codejen.Files, error)
 	}
 
 	return codejen.Files{
-		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/PanelConfig.java"), []byte(panelRegistry), jenny),
+		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/PanelConfig.java"), []byte(panelConfig), jenny),
+		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/DataqueryConfig.java"), []byte(dataqueryConfig), jenny),
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/Registry.java"), []byte(registry), jenny),
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/UnknownDataquery.java"), []byte(unknownDataquery), jenny),
 		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "cog/variants/UnknownDataquerySerializer.java"), []byte(unknownDataquerySerializer), jenny),
@@ -53,6 +59,12 @@ func (jenny Registry) Generate(context languages.Context) (codejen.Files, error)
 
 func (jenny Registry) renderPanelConfig() (string, error) {
 	return jenny.tmpl.Render("runtime/panel_config.tmpl", map[string]any{
+		"Package": jenny.formatPackage("cog.variants"),
+	})
+}
+
+func (jenny Registry) renderDataqueryConfig() (string, error) {
+	return jenny.tmpl.Render("runtime/dataquery_config.tmpl", map[string]any{
 		"Package": jenny.formatPackage("cog.variants"),
 	})
 }

--- a/internal/jennies/java/templates/runtime/dataquery_config.tmpl
+++ b/internal/jennies/java/templates/runtime/dataquery_config.tmpl
@@ -1,0 +1,13 @@
+package {{ .Package }};
+
+public class DataqueryConfig {
+    private final Class<? extends Dataquery> dataquery;
+
+    public DataqueryConfig(Class<? extends Dataquery> dataquery) {
+        this.dataquery = dataquery;
+    }
+
+    public Class<? extends Dataquery> getDataquery() {
+        return dataquery;
+    }
+}

--- a/internal/jennies/java/templates/runtime/registry.tmpl
+++ b/internal/jennies/java/templates/runtime/registry.tmpl
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class Registry {
     private static final Map<String, PanelConfig> panelRegistry = new HashMap<>();
-    private static final Map<String, Class<? extends Dataquery>> dataqueryRegistry = new HashMap<>();
+    private static final Map<String, DataqueryConfig> dataqueryRegistry = new HashMap<>();
     
     static {
         {{- range .PanelSchemas }}
@@ -19,11 +19,11 @@ public class Registry {
     }
 
     public static void registerDataquery(String type, Class<? extends Dataquery> clazz) {
-        dataqueryRegistry.put(type, clazz);
+        dataqueryRegistry.put(type, new DataqueryConfig(clazz));
     }
 
     public static Class<? extends Dataquery> getDataquery(String type) {
-        return dataqueryRegistry.get(type);
+        return dataqueryRegistry.get(type).getDataquery();
     }
     
     public static void registerPanel(String type, Class<?> options, Class<?> fieldConfig) {

--- a/internal/jennies/java/templates/runtime/unknown_dataquery.tmpl
+++ b/internal/jennies/java/templates/runtime/unknown_dataquery.tmpl
@@ -8,4 +8,8 @@ import java.util.Map;
 @JsonSerialize(using = UnknownDataquerySerializer.class)
 public class UnknownDataquery implements Dataquery {
     public final Map<String, Object> genericFields = new HashMap<>();
+    
+    public String dataqueryName() {
+        return "unknown";
+    }
 }

--- a/internal/jennies/java/templates/runtime/variants.tmpl
+++ b/internal/jennies/java/templates/runtime/variants.tmpl
@@ -1,4 +1,5 @@
 package {{ .Package }};
 
 public interface {{ .Variant }} {
+    String dataqueryName();
 }

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -29,6 +29,12 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     }
     {{- end }}
     {{- end }}
+    
+    {{- if .Variant }}
+    public String dataqueryName() {
+        return "{{ .Identifier | lower }}";
+    }
+    {{- end }}
 
     {{- if and (ne .ToJSONFunction "") (not .Extends) }}
     {{ .ToJSONFunction }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -98,6 +98,7 @@ type ClassTemplate struct {
 	HasBuilder bool
 
 	Variant                 string
+	Identifier              string
 	Annotation              string
 	ToJSONFunction          string
 	ShouldAddSerializer     bool

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 public class Loki implements cog.variants.Dataquery {
     @JsonProperty("expr")
     public String expr;
+    public String dataqueryName() {
+        return "loki";
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/dataquery_variant_builder/builders_context.json
+++ b/testdata/jennies/builders/dataquery_variant_builder/builders_context.json
@@ -2,7 +2,9 @@
   "Schemas": [
     {
       "Package": "dataquery_variant_builder",
-      "Metadata": {},
+      "Metadata": {
+        "Identifier": "loki"
+      },
       "Objects": {
         "Loki": {
           "Name": "Loki",

--- a/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
+++ b/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
@@ -4,4 +4,7 @@ package variant_dataquery;
 public class Query implements cog.variants.Dataquery {
     public String expr;
     public Boolean instant;
+    public String dataqueryName() {
+        return "prometheus";
+    }
 }


### PR DESCRIPTION
Contributes to: https://github.com/grafana/cog/issues/591

It creates a DataqueryConfig (like panel one), to be able to add any information that we could need in the Registry.

Dataquery now implements `dataqueryName()` function to return the name (useful for the converter's stuff).