### PR TITLE
Ignore vendor and Java folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@
 /examples/php/vendor
 /.devbox
 /gradle.properties
+/vendor
+
+# Java building folders
+.gradle/
+build/
 
 .idea


### PR DESCRIPTION
When you generate the sdk or execute Java tests in local, it generates some build folders that we should ignore.