### PR TITLE
Go/panel unmarshalling as config tmpl

### DIFF
--- a/config/templates/README.md
+++ b/config/templates/README.md
@@ -9,6 +9,7 @@ a particular naming convention, and renders them.
 For types, the following blocks are supported:
 
 * `object_{{ Package }}_{{ ObjectName }}_custom_unmarshal`: allows the definition of a custom unmarshal function for the object.
+* `object_{{ Package }}_{{ ObjectName }}_field_{{ FieldName}}_custom_strict_unmarshal`: allows the definition of a custom — strict — unmarshal logic for a field.
 
 
 For builders, the following blocks are supported:

--- a/config/templates/go/object_dashboard_Panel_custom_unmarshal.tmpl
+++ b/config/templates/go/object_dashboard_Panel_custom_unmarshal.tmpl
@@ -1,0 +1,96 @@
+{{- define "object_dashboard_Panel_custom_unmarshal" }}
+{{- $fmt := importStdPkg "fmt" -}}
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $cog := importPkg "cog" }}
+func (resource *{{ .Object.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
+    if raw == nil {
+        return nil
+    }
+
+    fields := make(map[string]json.RawMessage)
+    if err := json.Unmarshal(raw, &fields); err != nil {
+        return err
+    }
+    {{- range $field := .Object.Type.Struct.Fields }}
+    {{- if eq $field.Name "options" }}
+    {{ template "unmarshal_dashboard_panel_options" }}
+	{{- else if eq $field.Name "fieldConfig" }}
+	{{ template "unmarshal_dashboard_panel_fieldConfig" }}
+	{{- else if eq $field.Name "targets" }}
+	{{ continue }}
+    {{- else }}
+    if fields["{{ $field.Name }}"] != nil {
+		if err := json.Unmarshal(fields["{{ $field.Name }}"], &resource.{{ $field.Name|upperCamelCase }}); err != nil {
+			return fmt.Errorf("error decoding field '{{ $field.Name }}': %w", err)
+		}
+	}
+    {{- end }}
+    {{- end }}
+
+	{{ template "unmarshal_dashboard_panel_targets" }}
+
+    return nil
+}
+
+{{ end }}
+
+{{- define "unmarshal_dashboard_panel_options" -}}
+	if fields["options"] != nil {
+		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
+		if found && variantCfg.OptionsUnmarshaler != nil {
+			options, err := variantCfg.OptionsUnmarshaler(fields["options"])
+			if err != nil {
+				return err
+			}
+			resource.Options = options
+		} else {
+			if err := json.Unmarshal(fields["options"], &resource.Options); err != nil {
+				return err
+			}
+		}
+	}
+{{- end -}}
+
+{{- define "unmarshal_dashboard_panel_fieldConfig" -}}
+	if fields["fieldConfig"] != nil {
+		if err := json.Unmarshal(fields["fieldConfig"], &resource.FieldConfig); err != nil {
+			return err
+		}
+
+		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
+		if found && variantCfg.FieldConfigUnmarshaler != nil {
+			fakeFieldConfigSource := struct {
+				Defaults struct {
+					Custom json.RawMessage `json:"custom"`
+				} `json:"defaults"`
+			}{}
+			if err := json.Unmarshal(fields["fieldConfig"], &fakeFieldConfigSource); err != nil {
+				return err
+			}
+
+			if fakeFieldConfigSource.Defaults.Custom != nil {
+				customFieldConfig, err := variantCfg.FieldConfigUnmarshaler(fakeFieldConfigSource.Defaults.Custom)
+				if err != nil {
+					return err
+				}
+
+				resource.FieldConfig.Defaults.Custom = customFieldConfig
+			}
+		}
+	}
+{{- end -}}
+
+{{- define "unmarshal_dashboard_panel_targets" -}}
+	if fields["targets"] != nil {
+		dataqueryTypeHint := ""
+		if resource.Datasource != nil && resource.Datasource.Type != nil {
+			dataqueryTypeHint = *resource.Datasource.Type
+		}
+
+		targets, err := cog.UnmarshalDataqueryArray(fields["targets"], dataqueryTypeHint)
+		if err != nil {
+			return err
+		}
+		resource.Targets = targets
+	}
+{{- end -}}

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -171,58 +171,6 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 			continue
 		}
 
-		if obj.SelfRef.ReferredPkg == "dashboard" && obj.Name == "Panel" && field.Name == "options" {
-			buffer.WriteString(fmt.Sprintf(`
-	if fields["%[1]s"] != nil {
-		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
-		if found && variantCfg.OptionsUnmarshaler != nil {
-			options, err := variantCfg.OptionsUnmarshaler(fields["%[1]s"])
-			if err != nil {
-				return err
-			}
-			resource.%[2]s = options
-		} else {
-			if err := json.Unmarshal(fields["%[1]s"], &resource.%[2]s); err != nil {
-				return err
-			}
-		}
-	}
-`, field.Name, tools.UpperCamelCase(field.Name)))
-			continue
-		}
-
-		if obj.SelfRef.ReferredPkg == "dashboard" && obj.Name == "Panel" && field.Name == "fieldConfig" {
-			buffer.WriteString(fmt.Sprintf(`
-	if fields["%[1]s"] != nil {
-		if err := json.Unmarshal(fields["%[1]s"], &resource.%[2]s); err != nil {
-			return err
-		}
-
-		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
-		if found && variantCfg.FieldConfigUnmarshaler != nil {
-			fakeFieldConfigSource := struct{
-				Defaults struct {
-					Custom json.RawMessage `+"`json:\"custom\"`"+` 
-				} `+"`json:\"defaults\"`"+`
-			}{}
-			if err := json.Unmarshal(fields["%[1]s"], &fakeFieldConfigSource); err != nil {
-				return err
-			}
-
-			if fakeFieldConfigSource.Defaults.Custom != nil {
-				customFieldConfig, err := variantCfg.FieldConfigUnmarshaler(fakeFieldConfigSource.Defaults.Custom)
-				if err != nil {
-					return err
-				}
-
-				resource.%[2]s.Defaults.Custom = customFieldConfig
-			}
-		}
-	}
-`, field.Name, tools.UpperCamelCase(field.Name)))
-			continue
-		}
-
 		jenny.imports.Add("fmt", "fmt")
 		buffer.WriteString(fmt.Sprintf(`
 	if fields["%[1]s"] != nil {

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -378,44 +378,14 @@ func (resource *Panel) UnmarshalJSON(raw []byte) error {
 	}
 
 	if fields["options"] != nil {
-		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
-		if found && variantCfg.OptionsUnmarshaler != nil {
-			options, err := variantCfg.OptionsUnmarshaler(fields["options"])
-			if err != nil {
-				return err
-			}
-			resource.Options = options
-		} else {
-			if err := json.Unmarshal(fields["options"], &resource.Options); err != nil {
-				return err
-			}
+		if err := json.Unmarshal(fields["options"], &resource.Options); err != nil {
+			return fmt.Errorf("error decoding field 'options': %w", err)
 		}
 	}
 
 	if fields["fieldConfig"] != nil {
 		if err := json.Unmarshal(fields["fieldConfig"], &resource.FieldConfig); err != nil {
-			return err
-		}
-
-		variantCfg, found := cog.ConfigForPanelcfgVariant(resource.Type)
-		if found && variantCfg.FieldConfigUnmarshaler != nil {
-			fakeFieldConfigSource := struct{
-				Defaults struct {
-					Custom json.RawMessage `json:"custom"` 
-				} `json:"defaults"`
-			}{}
-			if err := json.Unmarshal(fields["fieldConfig"], &fakeFieldConfigSource); err != nil {
-				return err
-			}
-
-			if fakeFieldConfigSource.Defaults.Custom != nil {
-				customFieldConfig, err := variantCfg.FieldConfigUnmarshaler(fakeFieldConfigSource.Defaults.Custom)
-				if err != nil {
-					return err
-				}
-
-				resource.FieldConfig.Defaults.Custom = customFieldConfig
-			}
+			return fmt.Errorf("error decoding field 'fieldConfig': %w", err)
 		}
 	}
 


### PR DESCRIPTION
Instead of having panels-only unmarshalling logic hardcoded into a Go jenny that is meant to be generic, let's use the configurable templates.

Note: we should do the same for other languages than go, it would simplify the jennies and make them completely agnostic to dashboard-related schemas (eventually).