### PR TITLE
Cache go vendors in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,8 @@ jobs:
           devbox run go run cmd/cli/main.go generate \
             --config ./config/foundation_sdk.dev.yaml \
             --parameters output_dir=./generated/%l,grafana_version=${{ matrix.kind_version == 'next' && 'main' || matrix.kind_version }},kind_registry_version=${{ matrix.kind_version }},go_package_root=github.com/grafana/cog/generated/go
+        env:
+          GOGC: 'off'
 
       - name: Compile generated Go code
         run: devbox run ./scripts/ci/build-go.sh
@@ -154,6 +156,8 @@ jobs:
 
       - name: Run code generation
         run: make gen-sdk-dev
+        env:
+          GOGC: 'off'
 
       - name: Run the Go example
         run: make run-go-example

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          key: go-deps-${{ runner.os }}-${{ matrix.kind_version }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 
@@ -107,8 +107,18 @@ jobs:
       - name: Lint generated Python code
         run: devbox run mypy generated/python/
 
+      # See https://docs.gradle.org/current/userguide/build_cache.html
+      - name: Restore Gradle build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+          key: gradle-build-cache-${{ runner.os }}-${{ matrix.kind_version }}
+          restore-keys: |
+            gradle-build-cache-${{ runner.os }}-
+
       - name: Compile generated Java code
-        run: devbox run gradle build -p generated/java
+        run: devbox run gradle build --build-cache -p generated/java
 
       # See https://phpstan.org/user-guide/result-cache
       # See https://psalm.dev/docs/running_psalm/configuration/#cachedirectory
@@ -141,7 +151,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          key: go-deps-${{ runner.os }}-next-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 
@@ -167,6 +177,16 @@ jobs:
 
       - name: Run the PHP example
         run: make run-php-example
+
+      # See https://docs.gradle.org/current/userguide/build_cache.html
+      - name: Restore Gradle build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+          key: gradle-build-cache-${{ runner.os }}-${{ matrix.kind_version }}
+          restore-keys: |
+            gradle-build-cache-${{ runner.os }}-
 
       - name: Run Java example
         run: make run-java-example

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
         with:
@@ -30,6 +39,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
@@ -50,6 +68,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
@@ -90,6 +117,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            vendor
-          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 
@@ -44,8 +45,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            vendor
-          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 
@@ -73,8 +75,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            vendor
-          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 
@@ -122,8 +125,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            vendor
-          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,18 @@ jobs:
       - name: Compile generated Java code
         run: devbox run gradle build -p generated/java
 
+      # See https://phpstan.org/user-guide/result-cache
+      # See https://psalm.dev/docs/running_psalm/configuration/#cachedirectory
+      - name: Restore PHP linters cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/phpstan
+            ~/.cache/psalm
+          key: php-linters-result-cache-${{ matrix.kind_version }}
+          restore-keys: |
+            php-linters-result-cache-
+
       - name: Lint generated PHP code with phpstan
         run: devbox run phpstan analyze --memory-limit 512M -c .config/ci/php/phpstan.neon
 

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            vendor
-          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -13,6 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            vendor
+          key: go-deps-${{ runner.os }}-primes-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
+
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0
         with:

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -19,7 +19,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          key: go-deps-${{ runner.os }}-next-${{ hashFiles('go.sum') }}
           restore-keys: |
             go-deps-${{ runner.os }}
 

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -40,6 +40,7 @@ jobs:
           FOUNDATION_SDK_PATH: ./grafana-foundation-sdk
           FOUNDATION_SDK_REPO: https://github.com/grafana/grafana-foundation-sdk.git
           LOG_LEVEL: '7' # debug
+          GOGC: 'off'
 
       - name: Preview diff
         run: |

--- a/devbox.json
+++ b/devbox.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
   "packages": [
-    "python@3.12",
+    "python3Minimal@3.12",
     "go@1.23",
     "php@8.3",
     "php83Packages.phpstan@1.11",
     "python312Packages.mypy@1.10",
     "golangci-lint@1.61",
     "php83Packages.psalm@5.25",
-    "nodejs_18@18.20",
+    "nodejs-slim_18@18.20",
     "nodePackages.ts-node@10.9.2",
     "jre17_minimal@17",
     "gradle@8.10"

--- a/devbox.lock
+++ b/devbox.lock
@@ -222,10 +222,10 @@
         }
       }
     },
-    "nodejs_18@18.20": {
+    "nodejs-slim_18@18.20": {
       "last_modified": "2024-09-10T15:01:03Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#nodejs_18",
+      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#nodejs-slim_18",
       "source": "devbox-search",
       "version": "18.20.4",
       "systems": {
@@ -233,57 +233,57 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/mq4a000w2661rsz18bc66kspz46xg36i-nodejs-18.20.4",
+              "path": "/nix/store/hx3cdzpy6hkds2nsvl8j0swisj7akaxi-nodejs-slim-18.20.4",
               "default": true
             },
             {
               "name": "libv8",
-              "path": "/nix/store/m6bjaxvy75snd24fk3kki98f80k0zazj-nodejs-18.20.4-libv8"
+              "path": "/nix/store/q2k60bij8qjiqfdfjjji9rwy49rv4c38-nodejs-slim-18.20.4-libv8"
             }
           ],
-          "store_path": "/nix/store/mq4a000w2661rsz18bc66kspz46xg36i-nodejs-18.20.4"
+          "store_path": "/nix/store/hx3cdzpy6hkds2nsvl8j0swisj7akaxi-nodejs-slim-18.20.4"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/f92p8im867b0ih7x75fhvzq1n03a88nm-nodejs-18.20.4",
+              "path": "/nix/store/n7j0nx9jn7qbsmrfr1m6qckwcci1hh46-nodejs-slim-18.20.4",
               "default": true
             },
             {
               "name": "libv8",
-              "path": "/nix/store/bd2r8dn44lx8bkjikf7y0nlg9swyn90d-nodejs-18.20.4-libv8"
+              "path": "/nix/store/xgghys4v1yq32mw5sq62gsdclc3yc51n-nodejs-slim-18.20.4-libv8"
             }
           ],
-          "store_path": "/nix/store/f92p8im867b0ih7x75fhvzq1n03a88nm-nodejs-18.20.4"
+          "store_path": "/nix/store/n7j0nx9jn7qbsmrfr1m6qckwcci1hh46-nodejs-slim-18.20.4"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6ig5ijfhc8amfwh3y9kdh7yrfcv6wnzh-nodejs-18.20.4",
+              "path": "/nix/store/3nmyki1dgnrm5zl9xlnl8hd19blycprw-nodejs-slim-18.20.4",
               "default": true
             },
             {
               "name": "libv8",
-              "path": "/nix/store/74gg33cz9cksv940ffxrbx75z160k5cr-nodejs-18.20.4-libv8"
+              "path": "/nix/store/p091xicvfla9swbg8dj7qqxrnzx6qbl6-nodejs-slim-18.20.4-libv8"
             }
           ],
-          "store_path": "/nix/store/6ig5ijfhc8amfwh3y9kdh7yrfcv6wnzh-nodejs-18.20.4"
+          "store_path": "/nix/store/3nmyki1dgnrm5zl9xlnl8hd19blycprw-nodejs-slim-18.20.4"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lgw9z5sf9n6pm2dqmd92z4gq4irslnq1-nodejs-18.20.4",
+              "path": "/nix/store/3cyp4pcrv1mdbc6h2b14qyfncbwan0qm-nodejs-slim-18.20.4",
               "default": true
             },
             {
               "name": "libv8",
-              "path": "/nix/store/rgrg7ccyvbzj6v9fdhbzvr3di2hl4458-nodejs-18.20.4-libv8"
+              "path": "/nix/store/gy9q30lzksxgnwrkz45a9m8fzd0y9dlk-nodejs-slim-18.20.4-libv8"
             }
           ],
-          "store_path": "/nix/store/lgw9z5sf9n6pm2dqmd92z4gq4irslnq1-nodejs-18.20.4"
+          "store_path": "/nix/store/3cyp4pcrv1mdbc6h2b14qyfncbwan0qm-nodejs-slim-18.20.4"
         }
       }
     },
@@ -496,10 +496,10 @@
         }
       }
     },
-    "python@3.12": {
+    "python3Minimal@3.12": {
       "last_modified": "2024-09-10T15:01:03Z",
       "plugin_version": "0.0.4",
-      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#python3",
+      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#python3Minimal",
       "source": "devbox-search",
       "version": "3.12.5",
       "systems": {
@@ -507,49 +507,49 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9pj4rzx5pbynkkxq1srzwjhywmcfxws3-python3-3.12.5",
+              "path": "/nix/store/nhv9f4dwjzcrkm00slwkhlipj522mw35-python3-minimal-3.12.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/9pj4rzx5pbynkkxq1srzwjhywmcfxws3-python3-3.12.5"
+          "store_path": "/nix/store/nhv9f4dwjzcrkm00slwkhlipj522mw35-python3-minimal-3.12.5"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6iq3nhgdyp8a5wzwf097zf2mn4zyqxr6-python3-3.12.5",
+              "path": "/nix/store/n4vkrii54s5l2aacgh97igdm9qqfsy4h-python3-minimal-3.12.5",
               "default": true
             },
             {
               "name": "debug",
-              "path": "/nix/store/xc4hygp28y7g1rvjf0vi7fj0d83a75pj-python3-3.12.5-debug"
+              "path": "/nix/store/czsyx1fk5pk3f28qf5d9v9kqbi3jvpbg-python3-minimal-3.12.5-debug"
             }
           ],
-          "store_path": "/nix/store/6iq3nhgdyp8a5wzwf097zf2mn4zyqxr6-python3-3.12.5"
+          "store_path": "/nix/store/n4vkrii54s5l2aacgh97igdm9qqfsy4h-python3-minimal-3.12.5"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ks8acr22s4iggnmvxydm5czl30racy32-python3-3.12.5",
+              "path": "/nix/store/rlmdkyp50zz5zil9bjwwnaj8h8bxwm5x-python3-minimal-3.12.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ks8acr22s4iggnmvxydm5czl30racy32-python3-3.12.5"
+          "store_path": "/nix/store/rlmdkyp50zz5zil9bjwwnaj8h8bxwm5x-python3-minimal-3.12.5"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5",
+              "path": "/nix/store/saa0d82cwvsy8y8qx3z8lp64gh98a689-python3-minimal-3.12.5",
               "default": true
             },
             {
               "name": "debug",
-              "path": "/nix/store/0a39pi2s6kxqc3kjjz2y9yzibd62zhhb-python3-3.12.5-debug"
+              "path": "/nix/store/mpmak22cd17zkqca9ammp8sin61gdy7b-python3-minimal-3.12.5-debug"
             }
           ],
-          "store_path": "/nix/store/h3i0acpmr8mrjx07519xxmidv8mpax4y-python3-3.12.5"
+          "store_path": "/nix/store/saa0d82cwvsy8y8qx3z8lp64gh98a689-python3-minimal-3.12.5"
         }
       }
     }


### PR DESCRIPTION
Take advantage of build/result caches to speedup the CI.

Devbox is still the most time-consuming task, not sure how to address it right now but it also installs an absolute bunch of things so... :shrug: 