### PR TITLE
Veneers/rename arguments

### DIFF
--- a/config/veneers/cloudwatch.go.yaml
+++ b/config/veneers/cloudwatch.go.yaml
@@ -10,3 +10,6 @@ options:
   - struct_fields_as_arguments:
       by_name: QueryEditorOperator.value
       fields: [ ArrayOfQueryEditorOperatorType ]
+  - rename_arguments:
+      by_name: QueryEditorOperator.value
+      as: [operatorTypes]

--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -135,9 +135,14 @@ options:
   - array_to_append:
       by_name: Dashboard.link
 
-  # Dashboard.annotations([]AnnotationQuery) instead of Dashboard.annotations(AnnotationContainer)
+  # annotations([]AnnotationQuery) instead of annotations(AnnotationContainer)
   - struct_fields_as_arguments:
       by_name: Dashboard.annotations
+  # annotations(annotations) instead of annotations(list)
+  - rename_arguments:
+      by_name: Dashboard.annotations
+      as: [annotations]
+
   # Append a single `annotation` value instead of a list of everything
   - duplicate:
       by_name: Dashboard.annotations
@@ -172,6 +177,10 @@ options:
   - struct_fields_as_arguments:
       by_name: Dashboard.templating
       fields: [list]
+  # Templating(variables) instead of Templating(list)
+  - rename_arguments:
+      by_name: Dashboard.templating
+      as: [variables]
   # Append a single variable instead forcing to define every variable at once
   - duplicate:
       by_name: Dashboard.templating

--- a/config/veneers/tempo.go.yaml
+++ b/config/veneers/tempo.go.yaml
@@ -10,3 +10,6 @@ options:
   - struct_fields_as_arguments:
       by_name: TraceqlFilter.value
       fields: [ ArrayOfString ]
+  - rename_arguments:
+      by_name: TraceqlFilter.value
+      as: [values]

--- a/internal/tools/strings.go
+++ b/internal/tools/strings.go
@@ -57,3 +57,24 @@ func Indent(input string, spaces int) string {
 	pad := strings.Repeat(" ", spaces)
 	return pad + strings.ReplaceAll(input, "\n", "\n"+pad)
 }
+
+func Singularize(input string) string {
+	var rules = []struct {
+		regex       string
+		replacement string
+	}{
+		{`(?i)s$`, ``},    // tags → tag
+		{`(?i)ies$`, `y`}, // strategies → strategy
+	}
+
+	for _, rule := range rules {
+		re := regexp.MustCompile(rule.regex)
+		result := re.ReplaceAllString(input, rule.replacement)
+
+		if result != input {
+			return result
+		}
+	}
+
+	return input
+}

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -55,6 +55,7 @@ func ArrayToAppendAction() RewriteAction {
 
 		newFirstArg := option.Args[0]
 		newFirstArg.Type = option.Args[0].Type.AsArray().ValueType
+		newFirstArg.Name = tools.Singularize(newFirstArg.Name)
 
 		// Update the assignment to do an append instead of a list assignment
 		oldAssignments := option.Assignments
@@ -63,6 +64,7 @@ func ArrayToAppendAction() RewriteAction {
 		newFirstAssignment.Method = ast.AppendAssignment
 		// TODO: what if there is an envelope in the value assignment?
 		if newFirstAssignment.Value.Argument != nil {
+			newFirstAssignment.Value.Argument.Name = newFirstArg.Name
 			newFirstAssignment.Value.Argument.Type = newFirstArg.Type
 		}
 

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -21,6 +21,30 @@ func RenameAction(newName string) RewriteAction {
 	}
 }
 
+// RenameArgumentsAction renames the arguments of an options.
+func RenameArgumentsAction(newNames []string) RewriteAction {
+	return func(_ ast.Schemas, _ ast.Builder, option ast.Option) []ast.Option {
+		if len(newNames) != len(option.Args) {
+			return []ast.Option{option}
+		}
+
+		for i, arg := range option.Args {
+			previousName := arg.Name
+			option.Args[i].Name = newNames[i]
+
+			for j, assignment := range option.Assignments {
+				if assignment.Value.Argument != nil && assignment.Value.Argument.Name == previousName {
+					option.Assignments[j].Value.Argument.Name = newNames[i]
+				}
+			}
+		}
+
+		option.AddToVeneerTrail("RenameArguments")
+
+		return []ast.Option{option}
+	}
+}
+
 // ArrayToAppendAction updates the option to perform an "append" assignment.
 //
 // Example:

--- a/internal/veneers/option/actions_test.go
+++ b/internal/veneers/option/actions_test.go
@@ -260,14 +260,14 @@ func TestArrayToAppendAction_withArrayArgument(t *testing.T) {
 	// expected output
 	expectedOption := ast.Option{
 		Args: []ast.Argument{
-			{Name: "tags", Type: ast.String()},
+			{Name: "tag", Type: ast.String()},
 		},
 		Assignments: []ast.Assignment{
 			ast.ArgumentAssignment(
 				ast.Path{
 					{Identifier: "tags", Type: ast.NewArray(ast.String())},
 				},
-				ast.Argument{Name: "tags", Type: ast.String()},
+				ast.Argument{Name: "tag", Type: ast.String()},
 				ast.Method(ast.AppendAssignment),
 			),
 		},

--- a/internal/veneers/option/rules.go
+++ b/internal/veneers/option/rules.go
@@ -23,6 +23,13 @@ func ArrayToAppend(selector Selector) RewriteRule {
 	}
 }
 
+func RenameArguments(selector Selector, newNames []string) RewriteRule {
+	return RewriteRule{
+		Selector: selector,
+		Action:   RenameArgumentsAction(newNames),
+	}
+}
+
 func Omit(selector Selector) RewriteRule {
 	return RewriteRule{
 		Selector: selector,

--- a/internal/yaml/option.go
+++ b/internal/yaml/option.go
@@ -15,6 +15,7 @@ import (
 type OptionRule struct {
 	Omit                    *OptionSelector          `yaml:"omit"`
 	Rename                  *RenameOption            `yaml:"rename"`
+	RenameArguments         *RenameArguments         `yaml:"rename_arguments"`
 	UnfoldBoolean           *UnfoldBoolean           `yaml:"unfold_boolean"`
 	StructFieldsAsArguments *StructFieldsAsArguments `yaml:"struct_fields_as_arguments"`
 	StructFieldsAsOptions   *StructFieldsAsOptions   `yaml:"struct_fields_as_options"`
@@ -36,6 +37,10 @@ func (rule OptionRule) AsRewriteRule(pkg string) (option.RewriteRule, error) {
 
 	if rule.Rename != nil {
 		return rule.Rename.AsRewriteRule(pkg)
+	}
+
+	if rule.RenameArguments != nil {
+		return rule.RenameArguments.AsRewriteRule(pkg)
 	}
 
 	if rule.UnfoldBoolean != nil {
@@ -82,6 +87,21 @@ func (rule RenameOption) AsRewriteRule(pkg string) (option.RewriteRule, error) {
 	}
 
 	return option.Rename(selector, rule.As), nil
+}
+
+type RenameArguments struct {
+	OptionSelector `yaml:",inline"`
+
+	As []string `yaml:"as"`
+}
+
+func (rule RenameArguments) AsRewriteRule(pkg string) (option.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return option.RewriteRule{}, err
+	}
+
+	return option.RenameArguments(selector, rule.As), nil
 }
 
 type UnfoldBoolean struct {

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -634,6 +634,9 @@
         "rename": {
           "$ref": "#/$defs/YamlRenameOption"
         },
+        "rename_arguments": {
+          "$ref": "#/$defs/YamlRenameArguments"
+        },
         "unfold_boolean": {
           "$ref": "#/$defs/YamlUnfoldBoolean"
         },
@@ -713,6 +716,29 @@
         "set": {
           "items": {
             "$ref": "#/$defs/AstStructField"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlRenameArguments": {
+      "properties": {
+        "by_name": {
+          "type": "string",
+          "description": "objectName.optionName"
+        },
+        "by_builder": {
+          "type": "string",
+          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
+        },
+        "by_names": {
+          "$ref": "#/$defs/YamlByNamesSelector"
+        },
+        "as": {
+          "items": {
+            "type": "string"
           },
           "type": "array"
         }


### PR DESCRIPTION
This PR brings two "quality of life" improvements for argument names in builder options.

* arguments are "singularized" when the `ArrayToAppend` option veneer is used
* a new `RenameArguments` veneer is defined, giving us finer control on argument names

All of this just to ensure that arguments look good when humans read the builders' code (and when we'll generate documentation for builders)