### PR TITLE
Java: Constructors for no builders

### DIFF
--- a/examples/java/src/main/java/test/CPU.java
+++ b/examples/java/src/main/java/test/CPU.java
@@ -16,38 +16,32 @@ public class CPU {
                 "/ ignoring(cpu) group_left " +
                 "count without (cpu, mode) (node_cpu_seconds_total{job=\"integrations/raspberrypi-node\", mode=\"idle\", instance=\"$instance\"}))";
 
-        Threshold th1 = new Threshold();
-        th1.color = "green";
-
-        Threshold th2 = new Threshold();
-        th2.color = "red";
-        th2.value = 80.0;
-
         return Common.defaultTimeSeries().
                 title("CPU Usage").
                 span(18).
                 stacking(new StackingConfig.Builder().mode(StackingMode.NORMAL)).
                 thresholds(new ThresholdsConfig.Builder().
                         mode(ThresholdsMode.ABSOLUTE).
-                        steps(List.of(th1, th2))).
+                        steps(List.of(
+                                new Threshold(0.0, "green"),
+                                new Threshold(80.0, "red")
+                        ))
+                ).
                 max(1.0).
                 min(0.0).
                 withTarget(Common.basicPrometheusQuery(query, "{{ cpu }}"));
     }
 
     public static Builder<Panel> loadAverageTimeseries() {
-        Threshold th1 = new Threshold();
-        th1.color = "green";
-
-        Threshold th2 = new Threshold();
-        th2.value = 80.0;
-        th2.color = "red";
         return Common.defaultTimeSeries().title("Load Average").
                 span(18).
                 thresholds(
                         new ThresholdsConfig.Builder().
                                 mode(ThresholdsMode.ABSOLUTE).
-                                steps(List.of(th1, th2))
+                                steps(List.of(
+                                        new Threshold(0.0, "green"),
+                                        new Threshold(80.0, "red")
+                                ))
                 ).
                 min(0.0).
                 unit("short").
@@ -58,16 +52,6 @@ public class CPU {
     }
 
     public static Builder<Panel> cpuTemperatureGauge() {
-        Threshold th1 = new Threshold();
-        th1.color = "rgba(50, 172, 45, 0.97)";
-
-        Threshold th2 = new Threshold();
-        th2.value = 65.0;
-        th2.color = "rgba(237, 129, 40, 0.89)";
-
-        Threshold th3 = new Threshold();
-        th3.value = 85.0;
-        th3.color = "rgba(245, 54, 54, 0.9)";
         return Common.defaultGauge().
                 title("CPU Temperature").
                 span(6).
@@ -76,7 +60,12 @@ public class CPU {
                 unit("celsius").
                 thresholds(new ThresholdsConfig.Builder().
                         mode(ThresholdsMode.ABSOLUTE).
-                        steps(List.of(th1, th2, th3))).
+                        steps(List.of(
+                                new Threshold(0.0, "rgba(50, 172, 45, 0.97)"),
+                                new Threshold(65.0, "rgba(237, 129, 40, 0.89)"),
+                                new Threshold(85.0, "rgba(245, 54, 54, 0.9)")
+                        ))
+                ).
                 withTarget(Common.basicPrometheusQuery("avg(node_hwmon_temp_celsius{job=\"integrations/raspberrypi-node\", instance=\"$instance\"}", ""));
     }
 }

--- a/examples/java/src/main/java/test/Common.java
+++ b/examples/java/src/main/java/test/Common.java
@@ -45,12 +45,9 @@ public class Common {
     }
 
     public static com.grafana.foundation.logs.PanelBuilder defaultLogs() {
-        DataSourceRef ref = new DataSourceRef();
-        ref.type = "loki";
-        ref.uid = "grafana-cloud-logs";
         return new com.grafana.foundation.logs.PanelBuilder().
                 span(24).
-                datasource(ref).
+                datasource(new DataSourceRef("loki", "grafana-cloud-logs")).
                 showTime(true).
                 enableLogDetails(true).
                 sortOrder(LogsSortOrder.DESCENDING).

--- a/examples/java/src/main/java/test/Main.java
+++ b/examples/java/src/main/java/test/Main.java
@@ -53,35 +53,21 @@ public class Main {
     }
 
     private static Builder<VariableModel> datasourceVariable() {
-        VariableOption current = new VariableOption();
-        current.selected = true;
-        current.text = StringOrArrayOfString.createString("grafanacloud-potatopi-prom");
-        current.value = StringOrArrayOfString.createString("grafanacloud-prom");
-
         return new VariableModel.DatasourceVariableBuilder("datasource").
                 label("Data Source").
                 hide(VariableHide.DONT_HIDE).
                 type("prometheus").
-                current(current);
+                current(new VariableOption(true, StringOrArrayOfString.createString("grafanacloud-potatopi-prom"), StringOrArrayOfString.createString("grafanacloud-prom")));
     }
 
     private static Builder<VariableModel> queryVariable() {
-        VariableOption current = new VariableOption();
-        current.selected = false;
-        current.text = StringOrArrayOfString.createString("potato");
-        current.value = StringOrArrayOfString.createString("potato");
-
-        DataSourceRef datasource = new DataSourceRef();
-        datasource.uid = "$datasource";
-        datasource.type = "prometheus";
-
         return new VariableModel.QueryVariableBuilder("instance").
                 label("Instance").
                 hide(VariableHide.DONT_HIDE).
                 refresh(VariableRefresh.ON_TIME_RANGE_CHANGED).
                 query(StringOrMap.createString("label_values(node_uname_info{job=\"integrations/raspberrypi-node\", sysname!=\"Darwin\"}, instance)")).
-                datasource(datasource).
-                current(current).
+                datasource(new DataSourceRef("$datasource", "prometheus")).
+                current(new VariableOption(false, StringOrArrayOfString.createString("potato"), StringOrArrayOfString.createString("potato"))).
                 sort(VariableSort.DISABLED);
     }
 

--- a/examples/java/src/main/java/test/Memory.java
+++ b/examples/java/src/main/java/test/Memory.java
@@ -22,20 +22,16 @@ public class Memory {
                 "  node_memory_Cached_bytes{job=\"integrations/raspberrypi-node\", instance=\"$instance\"}" +
                 ")";
 
-        Threshold th1 = new Threshold();
-        th1.color = "green";
-
-        Threshold th2 = new Threshold();
-        th2.color = "red";
-        th2.value = 80.0;
-
         return Common.defaultTimeSeries().
                 title("Memory Usage").
                 span(18).
                 stacking(new StackingConfig.Builder().mode(StackingMode.NORMAL)).
                 thresholds(new ThresholdsConfig.Builder().
                         mode(ThresholdsMode.ABSOLUTE).
-                        steps(List.of(th1, th2))
+                        steps(List.of(
+                                new Threshold(0.0, "green"),
+                                new Threshold(80.0, "red")
+                        ))
                 ).
                 min(0.0).
                 unit("bytes").
@@ -58,17 +54,6 @@ public class Memory {
                 "  avg(node_memory_MemTotal_bytes{job=\"integrations/raspberrypi-node\", instance=\"$instance\"})" +
                 "* 100)";
 
-        Threshold th1 = new Threshold();
-        th1.color = "rgba(50, 172, 45, 0.97)";
-
-        Threshold th2 = new Threshold();
-        th2.value = 80.0;
-        th2.color = "rgba(237, 129, 40, 0.89)";
-
-        Threshold th3 = new Threshold();
-        th3.value = 90.0;
-        th3.color = "rgba(245, 54, 54, 0.9)";
-
         return Common.defaultGauge().
                 title("Memory Usage").
                 span(6).
@@ -77,7 +62,11 @@ public class Memory {
                 unit("percent").
                 thresholds(new ThresholdsConfig.Builder().
                         mode(ThresholdsMode.ABSOLUTE).
-                        steps(List.of(th1, th2, th3))
+                        steps(List.of(
+                                new Threshold(0.0, "rgba(50, 172, 45, 0.97)"),
+                                new Threshold(80.0, "rgba(237, 129, 40, 0.89)"),
+                                new Threshold(90.0, "rgba(245, 54, 54, 0.9)")
+                        ))
                 ).
                 withTarget(Common.basicPrometheusQuery(query, ""));
     }

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -13,12 +13,6 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
-// Skip schemas without builder that aren't set directly in the builders.
-var defaultConstructorsExceptions = map[string]bool{
-	"FieldConfig":       true,
-	"FieldConfigSource": true,
-}
-
 type RawTypes struct {
 	config  Config
 	tmpl    *template.Template
@@ -315,7 +309,8 @@ func (jenny RawTypes) defaultConstructor(object ast.Object) []ast.Argument {
 		return nil
 	}
 
-	if defaultConstructorsExceptions[object.Name] {
+	// Skip schemas without builder that aren't set directly into the builders.
+	if object.Name == "FieldConfig" || object.Name == "FieldConfigSource" {
 		return nil
 	}
 

--- a/internal/jennies/java/templates/types/args.tmpl
+++ b/internal/jennies/java/templates/types/args.tmpl
@@ -1,6 +1,6 @@
 {{- define "args" }}
-    {{- range $i, $arg := . }}
+    {{- range $i, $arg := .Arguments }}
          {{- if gt $i 0 }}, {{- end }}
-         {{- $arg.Type | formatBuilderFieldType }} {{ $arg.Name | escapeVar | lowerCamelCase }}
+         {{- if $.IsBuilder}}{{- $arg.Type | formatBuilderFieldType }}{{ else }}{{ $arg.Type | formatType }}{{ end }} {{ $arg.Name | escapeVar | lowerCamelCase }}
     {{- end }}
 {{- end }}

--- a/internal/jennies/java/templates/types/builder.tmpl
+++ b/internal/jennies/java/templates/types/builder.tmpl
@@ -6,7 +6,7 @@
         private {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar }};
         {{- end }}
         
-        public {{ .BuilderName }}Builder({{- template "args" .Builder.Constructor.Args }}) {
+        public {{ .BuilderName }}Builder({{- template "args" (dict "Arguments" .Builder.Constructor.Args "IsBuilder" true) }}) {
             this.internal = new {{ .Builder.ObjectName }}();
         {{- range .Builder.Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
@@ -25,7 +25,7 @@
         }
         
     {{- range $opt := .Builder.Options }}
-    public {{ if $.Builder.IsGeneric }}T {{ else }}{{ $.BuilderName }}Builder {{ end }}{{ .Name | lowerCamelCase | escapeVar }}({{- template "args" .Args }}) {
+    public {{ if $.Builder.IsGeneric }}T {{ else }}{{ $.BuilderName }}Builder {{ end }}{{ .Name | lowerCamelCase | escapeVar }}({{- template "args" (dict "Arguments" .Args "IsBuilder" true) }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.Builder.BuilderName "OptionName" $opt.Name) }}
         {{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -31,7 +31,7 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- else if .DefaultConstructorArgs }}
     public {{ $.Name }}() {}
     
-    public {{ $.Name }}({{- template "args" .DefaultConstructorArgs }}) {
+    public {{ $.Name }}({{- template "args" dict "Arguments" .DefaultConstructorArgs "IsBuilder" false }}) {
         {{- range .DefaultConstructorArgs }}
         this.{{ .Name | escapeVar | lowerCamelCase }} = {{ .Name | escapeVar | lowerCamelCase }};
         {{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -28,6 +28,14 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
         return {{ $.Name | lowerCamelCase }};
     }
     {{- end }}
+    {{- else if .DefaultConstructorArgs }}
+    public {{ $.Name }}() {}
+    
+    public {{ $.Name }}({{- template "args" .DefaultConstructorArgs }}) {
+        {{- range .DefaultConstructorArgs }}
+        this.{{ .Name | escapeVar | lowerCamelCase }} = {{ .Name | escapeVar | lowerCamelCase }};
+        {{- end }}
+    }
     {{- end }}
     
     {{- if .Variant }}

--- a/internal/jennies/java/templates/types/panel_builder.tmpl
+++ b/internal/jennies/java/templates/types/panel_builder.tmpl
@@ -10,7 +10,7 @@ package {{ .Package }};
 public class PanelBuilder implements {{ if not (eq .ImportAlias "") }}{{ .ImportAlias }}.{{ end }}cog.Builder<Panel> {
     private Panel internal;
 
-    public PanelBuilder({{- template "args" .Constructor.Args }}) {
+    public PanelBuilder({{- template "args" (dict "Arguments" .Constructor.Args "IsBuilder" true) }}) {
         this.internal = new Panel();
         {{- range .Constructor.Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
@@ -25,7 +25,7 @@ public class PanelBuilder implements {{ if not (eq .ImportAlias "") }}{{ .Import
     }
     
     {{- range .Options }}
-    public PanelBuilder {{ .Name | lowerCamelCase }}({{- template "args" .Args }}) {
+    public PanelBuilder {{ .Name | lowerCamelCase }}({{- template "args" (dict "Arguments" .Args "IsBuilder" true) }}) {
         {{- range .Assignments }}
             {{- template "assignment" (dict "Assignment" . "BuilderName" "PanelBuilder" "OptionName" "Panel") }}
         {{- end }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -104,6 +104,7 @@ type ClassTemplate struct {
 	ShouldAddSerializer     bool
 	ShouldAddDeserializer   bool
 	ShouldAddFactoryMethods bool
+	DefaultConstructorArgs  []ast.Argument
 }
 
 type ConstantTemplate struct {

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Variable.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilders/sandbox/Variable.java
@@ -10,6 +10,12 @@ public class Variable {
     public String name;
     @JsonProperty("value")
     public String value;
+    public Variable() {}
+    
+    public Variable(String name,String value) {
+        this.name = name;
+        this.value = value;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/foreign_builder/JavaBuilders/some_pkg/SomeStruct.java
+++ b/testdata/jennies/builders/foreign_builder/JavaBuilders/some_pkg/SomeStruct.java
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 public class SomeStruct {
     @JsonProperty("title")
     public String title;
+    public SomeStruct() {}
+    
+    public SomeStruct(String title) {
+        this.title = title;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/LegendOptions.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/LegendOptions.java
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 public class LegendOptions {
     @JsonProperty("show")
     public Boolean show;
+    public LegendOptions() {}
+    
+    public LegendOptions(Boolean show) {
+        this.show = show;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilders/initialization_safeguards/Options.java
@@ -10,6 +10,11 @@ public class Options {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty("legend")
     public LegendOptions legend;
+    public Options() {}
+    
+    public Options(LegendOptions legend) {
+        this.legend = legend;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/known_any/JavaBuilders/known_any/Config.java
+++ b/testdata/jennies/builders/known_any/JavaBuilders/known_any/Config.java
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 public class Config {
     @JsonProperty("title")
     public String title;
+    public Config() {}
+    
+    public Config(String title) {
+        this.title = title;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/package-with-dashes/JavaBuilders/withdashes/SomeStruct.java
+++ b/testdata/jennies/builders/package-with-dashes/JavaBuilders/withdashes/SomeStruct.java
@@ -8,6 +8,11 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 public class SomeStruct {
     @JsonProperty("title")
     public String title;
+    public SomeStruct() {}
+    
+    public SomeStruct(String title) {
+        this.title = title;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/builders/references/JavaBuilders/other_pkg/Name.java
+++ b/testdata/jennies/builders/references/JavaBuilders/other_pkg/Name.java
@@ -10,6 +10,12 @@ public class Name {
     public String firstName;
     @JsonProperty("last_name")
     public String lastName;
+    public Name() {}
+    
+    public Name(String firstName,String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
     
     public String toJSON() throws JsonProcessingException {
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
+++ b/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
@@ -3,4 +3,9 @@ package arrays;
 
 public class SomeStruct {
     public Object fieldAny;
+    public SomeStruct() {}
+    
+    public SomeStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
@@ -6,4 +6,10 @@ import java.util.List;
 public class RefStruct {
     public Map<String, String> labels;
     public List<String> tags;
+    public RefStruct() {}
+    
+    public RefStruct(Map<String, String> labels,List<String> tags) {
+        this.labels = labels;
+        this.tags = tags;
+    }
 }

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
@@ -6,4 +6,12 @@ public class SomeStruct {
     public Long maybeId;
     public String title;
     public refStruct refStruct;
+    public SomeStruct() {}
+    
+    public SomeStruct(Long id,Long maybeId,String title,refStruct refStruct) {
+        this.id = id;
+        this.maybeId = maybeId;
+        this.title = title;
+        this.refStruct = refStruct;
+    }
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
@@ -5,4 +5,10 @@ import java.util.List;
 public class Dashboard {
     public String title;
     public List<Panel> panels;
+    public Dashboard() {}
+    
+    public Dashboard(String title,List<Panel> panels) {
+        this.title = title;
+        this.panels = panels;
+    }
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
@@ -4,4 +4,10 @@ package dashboard;
 public class DataSourceRef {
     public String type;
     public String uid;
+    public DataSourceRef() {}
+    
+    public DataSourceRef(String type,String uid) {
+        this.type = type;
+        this.uid = uid;
+    }
 }

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
@@ -12,7 +12,7 @@ public class Panel {
     public FieldConfigSource fieldConfig;
     public Panel() {}
     
-    public Panel(String title,String type,DataSourceRef datasource,Object options,cog.Builder<List<Dataquery>> targets,FieldConfigSource fieldConfig) {
+    public Panel(String title,String type,DataSourceRef datasource,Object options,List<Dataquery> targets,FieldConfigSource fieldConfig) {
         this.title = title;
         this.type = type;
         this.datasource = datasource;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
@@ -10,4 +10,14 @@ public class Panel {
     public Object options;
     public List<Dataquery> targets;
     public FieldConfigSource fieldConfig;
+    public Panel() {}
+    
+    public Panel(String title,String type,DataSourceRef datasource,Object options,cog.Builder<List<Dataquery>> targets,FieldConfigSource fieldConfig) {
+        this.title = title;
+        this.type = type;
+        this.datasource = datasource;
+        this.options = options;
+        this.targets = targets;
+        this.fieldConfig = fieldConfig;
+    }
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
@@ -4,4 +4,10 @@ package disjunctions;
 public class BoolOrRef {
     public Boolean bool;
     public SomeStruct someStruct;
+    public BoolOrRef() {}
+    
+    public BoolOrRef(Boolean bool,SomeStruct someStruct) {
+        this.bool = bool;
+        this.someStruct = someStruct;
+    }
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
@@ -4,4 +4,10 @@ package disjunctions;
 public class SomeOtherStruct {
     public String type;
     public Byte foo;
+    public SomeOtherStruct() {}
+    
+    public SomeOtherStruct(String type,Byte foo) {
+        this.type = type;
+        this.foo = foo;
+    }
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
@@ -4,4 +4,10 @@ package disjunctions;
 public class SomeStruct {
     public String type;
     public Object fieldAny;
+    public SomeStruct() {}
+    
+    public SomeStruct(String type,Object fieldAny) {
+        this.type = type;
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
@@ -4,4 +4,10 @@ package disjunctions;
 public class YetAnotherStruct {
     public String type;
     public Integer bar;
+    public YetAnotherStruct() {}
+    
+    public YetAnotherStruct(String type,Integer bar) {
+        this.type = type;
+        this.bar = bar;
+    }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
@@ -6,4 +6,11 @@ public class DefaultsStructComplexField {
     public String uid;
     public DefaultsStructComplexFieldNested nested;
     public List<String> array;
+    public DefaultsStructComplexField() {}
+    
+    public DefaultsStructComplexField(String uid,DefaultsStructComplexFieldNested nested,List<String> array) {
+        this.uid = uid;
+        this.nested = nested;
+        this.array = array;
+    }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
@@ -3,4 +3,9 @@ package defaults;
 
 public class DefaultsStructComplexFieldNested {
     public String nestedVal;
+    public DefaultsStructComplexFieldNested() {}
+    
+    public DefaultsStructComplexFieldNested(String nestedVal) {
+        this.nestedVal = nestedVal;
+    }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
@@ -4,4 +4,10 @@ package defaults;
 public class DefaultsStructPartialComplexField {
     public String uid;
     public Long intVal;
+    public DefaultsStructPartialComplexField() {}
+    
+    public DefaultsStructPartialComplexField(String uid,Long intVal) {
+        this.uid = uid;
+        this.intVal = intVal;
+    }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
@@ -4,4 +4,10 @@ package defaults;
 public class NestedStruct {
     public String stringVal;
     public Long intVal;
+    public NestedStruct() {}
+    
+    public NestedStruct(String stringVal,Long intVal) {
+        this.stringVal = stringVal;
+        this.intVal = intVal;
+    }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
@@ -7,4 +7,13 @@ public class Struct {
     public NestedStruct emptyFields;
     public DefaultsStructComplexField complexField;
     public DefaultsStructPartialComplexField partialComplexField;
+    public Struct() {}
+    
+    public Struct(NestedStruct allFields,NestedStruct partialFields,NestedStruct emptyFields,DefaultsStructComplexField complexField,DefaultsStructPartialComplexField partialComplexField) {
+        this.allFields = allFields;
+        this.partialFields = partialFields;
+        this.emptyFields = emptyFields;
+        this.complexField = complexField;
+        this.partialComplexField = partialComplexField;
+    }
 }

--- a/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
+++ b/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
@@ -3,4 +3,9 @@ package intersections;
 
 public class SomeStruct {
     public Boolean fieldBool;
+    public SomeStruct() {}
+    
+    public SomeStruct(Boolean fieldBool) {
+        this.fieldBool = fieldBool;
+    }
 }

--- a/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
+++ b/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
@@ -3,4 +3,9 @@ package maps;
 
 public class SomeStruct {
     public Object fieldAny;
+    public SomeStruct() {}
+    
+    public SomeStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
@@ -3,4 +3,9 @@ package withdashes;
 
 public class SomeStruct {
     public Object fieldAny;
+    public SomeStruct() {}
+    
+    public SomeStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
@@ -3,4 +3,9 @@ package refs;
 
 public class RefToSomeStruct {
     public Object fieldAny;
+    public RefToSomeStruct() {}
+    
+    public RefToSomeStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
@@ -3,4 +3,9 @@ package struct_complex_fields;
 
 public class SomeOtherStruct {
     public Object fieldAny;
+    public SomeOtherStruct() {}
+    
+    public SomeOtherStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -14,4 +14,17 @@ public class SomeStruct {
     public Map<String, String> fieldMapOfStringToString;
     public StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
     public String fieldRefToConstant;
+    public SomeStruct() {}
+    
+    public SomeStruct(SomeOtherStruct fieldRef,StringOrBool fieldDisjunctionOfScalars,StringOrSomeOtherStruct fieldMixedDisjunction,String fieldDisjunctionWithNull,SomeStructOperator operator,List<String> fieldArrayOfStrings,Map<String, String> fieldMapOfStringToString,StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct,String fieldRefToConstant) {
+        this.fieldRef = fieldRef;
+        this.fieldDisjunctionOfScalars = fieldDisjunctionOfScalars;
+        this.fieldMixedDisjunction = fieldMixedDisjunction;
+        this.fieldDisjunctionWithNull = fieldDisjunctionWithNull;
+        this.operator = operator;
+        this.fieldArrayOfStrings = fieldArrayOfStrings;
+        this.fieldMapOfStringToString = fieldMapOfStringToString;
+        this.fieldAnonymousStruct = fieldAnonymousStruct;
+        this.fieldRefToConstant = fieldRefToConstant;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
@@ -4,4 +4,10 @@ package struct_complex_fields;
 public class StringOrSomeOtherStruct {
     public String string;
     public SomeOtherStruct someOtherStruct;
+    public StringOrSomeOtherStruct() {}
+    
+    public StringOrSomeOtherStruct(String string,SomeOtherStruct someOtherStruct) {
+        this.string = string;
+        this.someOtherStruct = someOtherStruct;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
@@ -3,4 +3,9 @@ package struct_complex_fields;
 
 public class StructComplexFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
+    public StructComplexFieldsSomeStructFieldAnonymousStruct() {}
+    
+    public StructComplexFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
@@ -7,4 +7,13 @@ public class SomeStruct {
     public String fieldStringWithConstantValue;
     public Float fieldFloat32;
     public Integer fieldInt32;
+    public SomeStruct() {}
+    
+    public SomeStruct(Boolean fieldBool,String fieldString,String fieldStringWithConstantValue,Float fieldFloat32,Integer fieldInt32) {
+        this.fieldBool = fieldBool;
+        this.fieldString = fieldString;
+        this.fieldStringWithConstantValue = fieldStringWithConstantValue;
+        this.fieldFloat32 = fieldFloat32;
+        this.fieldInt32 = fieldInt32;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
@@ -3,4 +3,9 @@ package struct_optional_fields;
 
 public class SomeOtherStruct {
     public Object fieldAny;
+    public SomeOtherStruct() {}
+    
+    public SomeOtherStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
@@ -8,4 +8,13 @@ public class SomeStruct {
     public SomeStructOperator operator;
     public List<String> fieldArrayOfStrings;
     public StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
+    public SomeStruct() {}
+    
+    public SomeStruct(SomeOtherStruct fieldRef,String fieldString,SomeStructOperator operator,List<String> fieldArrayOfStrings,StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct) {
+        this.fieldRef = fieldRef;
+        this.fieldString = fieldString;
+        this.operator = operator;
+        this.fieldArrayOfStrings = fieldArrayOfStrings;
+        this.fieldAnonymousStruct = fieldAnonymousStruct;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
@@ -3,4 +3,9 @@ package struct_optional_fields;
 
 public class StructOptionalFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct() {}
+    
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
+        this.fieldAny = fieldAny;
+    }
 }

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
@@ -23,4 +23,23 @@ public class SomeStruct {
     public Short fieldInt16;
     public Integer fieldInt32;
     public Long fieldInt64;
+    public SomeStruct() {}
+    
+    public SomeStruct(Object fieldAny,Boolean fieldBool,Byte fieldBytes,String fieldString,String fieldStringWithConstantValue,Float fieldFloat32,Double fieldFloat64,Integer fieldUint8,Short fieldUint16,Integer fieldUint32,Long fieldUint64,Integer fieldInt8,Short fieldInt16,Integer fieldInt32,Long fieldInt64) {
+        this.fieldAny = fieldAny;
+        this.fieldBool = fieldBool;
+        this.fieldBytes = fieldBytes;
+        this.fieldString = fieldString;
+        this.fieldStringWithConstantValue = fieldStringWithConstantValue;
+        this.fieldFloat32 = fieldFloat32;
+        this.fieldFloat64 = fieldFloat64;
+        this.fieldUint8 = fieldUint8;
+        this.fieldUint16 = fieldUint16;
+        this.fieldUint32 = fieldUint32;
+        this.fieldUint64 = fieldUint64;
+        this.fieldInt8 = fieldInt8;
+        this.fieldInt16 = fieldInt16;
+        this.fieldInt32 = fieldInt32;
+        this.fieldInt64 = fieldInt64;
+    }
 }

--- a/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
+++ b/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
@@ -3,4 +3,9 @@ package time_hint;
 
 public class ObjWithTimeField {
     public String registeredAt;
+    public ObjWithTimeField() {}
+    
+    public ObjWithTimeField(String registeredAt) {
+        this.registeredAt = registeredAt;
+    }
 }

--- a/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
+++ b/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
@@ -4,6 +4,12 @@ package variant_dataquery;
 public class Query implements cog.variants.Dataquery {
     public String expr;
     public Boolean instant;
+    public Query() {}
+    
+    public Query(String expr,Boolean instant) {
+        this.expr = expr;
+        this.instant = instant;
+    }
     public String dataqueryName() {
         return "prometheus";
     }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
@@ -3,4 +3,9 @@ package variant_panelcfg_full;
 
 public class Options {
     public String timeseriesOption;
+    public Options() {}
+    
+    public Options(String timeseriesOption) {
+        this.timeseriesOption = timeseriesOption;
+    }
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
@@ -3,4 +3,9 @@ package variant_panelcfg_only_options;
 
 public class Options {
     public String content;
+    public Options() {}
+    
+    public Options(String content) {
+        this.content = content;
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/grafana/cog/issues/512

It adds constructors for [these](https://github.com/grafana/cog/blob/main/config/veneers/dashboard.common.yaml#L13-L21) schemas without builder. We can omit some cases where we are creating the empty object and set values one to one. 
Apart of this, it simplifies to set the values of the converters to avoid to create extra code to generate an object.

[These](https://github.com/grafana/cog/blob/main/config/veneers/dashboard.common.yaml#L82-L83) other two are skipped because builders asks for their internal values, but not for the whole object.