### PR TITLE
Use the same output dir in dev and "prod" mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           devbox run go run cmd/cli/main.go generate \
             --config ./config/foundation_sdk.dev.yaml \
-            --parameters output_dir=./generated/%l,grafana_version=${{ matrix.kind_version == 'next' && 'main' || matrix.kind_version }},kind_registry_version=${{ matrix.kind_version }},go_package_root=github.com/grafana/cog/generated/go
+            --parameters grafana_version=${{ matrix.kind_version == 'next' && 'main' || matrix.kind_version }},kind_registry_version=${{ matrix.kind_version }}
         env:
           GOGC: 'off'
 
@@ -190,3 +190,6 @@ jobs:
 
       - name: Run Java example
         run: make run-java-example
+
+      - name: Run Python example
+        run: make run-python-example

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ docs: dev-env-check-binaries ## Generates the documentation.
 gen-sdk-dev: dev-env-check-binaries ## Generates a dev version of the Foundation SDK.
 	rm -rf generated
 	$(RUN_DEVBOX) go run cmd/cli/main.go generate \
-		--config ./config/foundation_sdk.dev.yaml \
-		--parameters kind_registry_version=next,grafana_version=main
+		--config ./config/foundation_sdk.dev.yaml
 
 .PHONY: gen-tests
 gen-tests: dev-env-check-binaries ## Generates the code described by tests schemas.
@@ -59,7 +58,7 @@ run-go-example: dev-env-check-binaries ## Runs the Go example.
 
 .PHONY: run-java-example
 run-java-example: dev-env-check-binaries ## Runs the Java example.
-	$(RUN_DEVBOX) gradle publishToMavenLocal -p generated
+	$(RUN_DEVBOX) gradle publishToMavenLocal -p generated/java
 	$(RUN_DEVBOX) gradle run -p examples/java
 
 .PHONY: run-php-example
@@ -70,6 +69,10 @@ run-php-example: dev-env-check-binaries ## Runs the PHP example.
 .PHONY: run-ts-example
 run-ts-example: dev-env-check-binaries ## Runs the Typescript example.
 	$(RUN_DEVBOX) ts-node examples/typescript
+
+.PHONY: run-python-example
+run-python-example: dev-env-check-binaries ## Runs the Python example.
+	$(RUN_DEVBOX) python examples/python/main.py
 
 .PHONY: dev-env-check-binaires
 dev-env-check-binaries: ## Check that the required binary are present.

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -3,11 +3,11 @@
 debug: true
 
 parameters:
-  output_dir: './generated'
+  output_dir: './generated/%l'
   kind_registry_path: '../kind-registry'
-  kind_registry_version: 'v10.4.x'
-  grafana_version: 'v10.4.x'
-  go_package_root: 'github.com/grafana/cog/generated'
+  kind_registry_version: 'next'
+  grafana_version: 'main'
+  go_package_root: 'github.com/grafana/cog/generated/go'
   php_namespace_root: 'Grafana\Foundation'
   java_package_path: 'com.grafana.foundation'
 

--- a/config/foundation_sdk.yaml
+++ b/config/foundation_sdk.yaml
@@ -3,7 +3,7 @@
 debug: false
 
 parameters:
-  output_dir: './generated'
+  output_dir: './generated/%l'
   kind_registry_path: '../kind-registry'
   kind_registry_version: 'v10.4.x'
   grafana_version: 'v10.4.x'

--- a/config/templates/python/object_dashboard_Panel_custom_unmarshal.tmpl
+++ b/config/templates/python/object_dashboard_Panel_custom_unmarshal.tmpl
@@ -14,10 +14,10 @@
             {{ continue}}
         {{- else if $field.Type.IsRef }}
         if "{{ $field.Name }}" in data:
-            args["{{ $field.Name }}"] = {{ $field.Type.AsRef|formatFullyQualifiedRef }}.from_json(data["{{ $field.Name }}"])
+            args["{{ $field.Name|formatIdentifier }}"] = {{ $field.Type.AsRef|formatFullyQualifiedRef }}.from_json(data["{{ $field.Name }}"])
         {{- else }}
         if "{{ $field.Name }}" in data:
-            args["{{ $field.Name }}"] = data["{{ $field.Name }}"]
+            args["{{ $field.Name|formatIdentifier }}"] = data["{{ $field.Name }}"]
         {{- end }}
         {{- end }}
 

--- a/devbox.json
+++ b/devbox.json
@@ -15,7 +15,8 @@
   ],
   "shell": {
     "init_hook": [
-      "echo 'Installing dependencies...' && make deps"
+      "echo 'Installing dependencies...' && make deps",
+      "export PYTHONPATH=$PYTHONPATH:$(pwd)/generated/python"
     ]
   }
 }

--- a/examples/_go/common.go
+++ b/examples/_go/common.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common"
-	"github.com/grafana/cog/generated/dashboard"
-	"github.com/grafana/cog/generated/gauge"
-	"github.com/grafana/cog/generated/logs"
-	"github.com/grafana/cog/generated/loki"
-	"github.com/grafana/cog/generated/prometheus"
-	"github.com/grafana/cog/generated/timeseries"
+	"github.com/grafana/cog/generated/go/common"
+	"github.com/grafana/cog/generated/go/dashboard"
+	"github.com/grafana/cog/generated/go/gauge"
+	"github.com/grafana/cog/generated/go/logs"
+	"github.com/grafana/cog/generated/go/loki"
+	"github.com/grafana/cog/generated/go/prometheus"
+	"github.com/grafana/cog/generated/go/timeseries"
 )
 
 func toPtr[T any](input T) *T {

--- a/examples/_go/cpu.go
+++ b/examples/_go/cpu.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common"
-	"github.com/grafana/cog/generated/dashboard"
-	"github.com/grafana/cog/generated/gauge"
-	"github.com/grafana/cog/generated/timeseries"
+	"github.com/grafana/cog/generated/go/common"
+	"github.com/grafana/cog/generated/go/dashboard"
+	"github.com/grafana/cog/generated/go/gauge"
+	"github.com/grafana/cog/generated/go/timeseries"
 )
 
 func cpuUsageTimeseries() *timeseries.PanelBuilder {

--- a/examples/_go/disk.go
+++ b/examples/_go/disk.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common"
-	"github.com/grafana/cog/generated/dashboard"
-	"github.com/grafana/cog/generated/table"
-	"github.com/grafana/cog/generated/timeseries"
+	"github.com/grafana/cog/generated/go/common"
+	"github.com/grafana/cog/generated/go/dashboard"
+	"github.com/grafana/cog/generated/go/table"
+	"github.com/grafana/cog/generated/go/timeseries"
 )
 
 func diskIOTimeseries() *timeseries.PanelBuilder {

--- a/examples/_go/logs.go
+++ b/examples/_go/logs.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/logs"
+	"github.com/grafana/cog/generated/go/logs"
 )
 
 func errorsInSystemLogs() *logs.PanelBuilder {

--- a/examples/_go/main.go
+++ b/examples/_go/main.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/grafana/cog/generated/cog/plugins"
-	"github.com/grafana/cog/generated/common"
-	"github.com/grafana/cog/generated/dashboard"
+	"github.com/grafana/cog/generated/go/cog/plugins"
+	"github.com/grafana/cog/generated/go/common"
+	"github.com/grafana/cog/generated/go/dashboard"
 )
 
 func dashboardBuilder() []byte {

--- a/examples/_go/memory.go
+++ b/examples/_go/memory.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/common"
-	"github.com/grafana/cog/generated/dashboard"
-	"github.com/grafana/cog/generated/gauge"
-	"github.com/grafana/cog/generated/timeseries"
+	"github.com/grafana/cog/generated/go/common"
+	"github.com/grafana/cog/generated/go/dashboard"
+	"github.com/grafana/cog/generated/go/gauge"
+	"github.com/grafana/cog/generated/go/timeseries"
 )
 
 func memoryUsageTimeseries() *timeseries.PanelBuilder {

--- a/examples/_go/network.go
+++ b/examples/_go/network.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/grafana/cog/generated/timeseries"
+	"github.com/grafana/cog/generated/go/timeseries"
 )
 
 func networkReceivedTimeseries() *timeseries.PanelBuilder {

--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -4,7 +4,7 @@
     "autoload": {
         "psr-4": {
             "App\\": "./src",
-            "Grafana\\Foundation\\": "../../generated/src"
+            "Grafana\\Foundation\\": "../../generated/php/src"
         }
     },
     "require": {}

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -1,12 +1,12 @@
 import json
-from generated.builders.dashboard import (
+from grafana_foundation_sdk.builders.dashboard import (
     Dashboard,
     TimePicker,
     Row,
     DatasourceVariable,
     QueryVariable,
 )
-from generated.models.dashboard import (
+from grafana_foundation_sdk.models.dashboard import (
     Dashboard as DashboardModel,
     DashboardCursorSync,
     VariableHide,
@@ -15,16 +15,16 @@ from generated.models.dashboard import (
     DataSourceRef,
     VariableSort,
 )
-from generated.models.common import (
+from grafana_foundation_sdk.models.common import (
     TimeZoneBrowser,
 )
-from generated.cog.encoder import JSONEncoder
-from generated.cog.plugins import register_default_plugins
-from examples.python.raspberry.cpu import cpu_usage_timeseries, cpu_load_average_timeseries, cpu_temperature_gauge
-from examples.python.raspberry.disk import disk_io_timeseries, disk_space_usage_table
-from examples.python.raspberry.logs import errors_in_system_logs, all_system_logs, auth_logs, kernel_logs
-from examples.python.raspberry.memory import memory_usage_timeseries, memory_usage_gauge
-from examples.python.raspberry.network import network_received_timeseries, network_transmitted_timeseries
+from grafana_foundation_sdk.cog.encoder import JSONEncoder
+from grafana_foundation_sdk.cog.plugins import register_default_plugins
+from raspberry.cpu import cpu_usage_timeseries, cpu_load_average_timeseries, cpu_temperature_gauge
+from raspberry.disk import disk_io_timeseries, disk_space_usage_table
+from raspberry.logs import errors_in_system_logs, all_system_logs, auth_logs, kernel_logs
+from raspberry.memory import memory_usage_timeseries, memory_usage_gauge
+from raspberry.network import network_received_timeseries, network_transmitted_timeseries
 
 
 def build_dashboard() -> Dashboard:

--- a/examples/python/raspberry/common.py
+++ b/examples/python/raspberry/common.py
@@ -1,12 +1,12 @@
-from generated.builders.timeseries import Panel as TimeseriesBuilder
-from generated.builders.gauge import Panel as GaugeBuilder
-from generated.builders.logs import Panel as LogsBuilder
-from generated.builders.prometheus import Dataquery as PrometheusQueryBuilder
-from generated.builders.loki import Dataquery as LokiQueryBuilder
-from generated.models.dashboard import DataSourceRef
-from generated.models.prometheus import PromQueryFormat
-from generated.models.common import GraphDrawStyle, VisibilityMode, LegendPlacement, LegendDisplayMode, VizOrientation, LogsSortOrder
-from generated.builders.common import VizLegendOptions as VizLegendOptionsBuilder, ReduceDataOptions as ReduceDataOptionsBuilder
+from grafana_foundation_sdk.builders.timeseries import Panel as TimeseriesBuilder
+from grafana_foundation_sdk.builders.gauge import Panel as GaugeBuilder
+from grafana_foundation_sdk.builders.logs import Panel as LogsBuilder
+from grafana_foundation_sdk.builders.prometheus import Dataquery as PrometheusQueryBuilder
+from grafana_foundation_sdk.builders.loki import Dataquery as LokiQueryBuilder
+from grafana_foundation_sdk.models.dashboard import DataSourceRef
+from grafana_foundation_sdk.models.prometheus import PromQueryFormat
+from grafana_foundation_sdk.models.common import GraphDrawStyle, VisibilityMode, LegendPlacement, LegendDisplayMode, VizOrientation, LogsSortOrder
+from grafana_foundation_sdk.builders.common import VizLegendOptions as VizLegendOptionsBuilder, ReduceDataOptions as ReduceDataOptionsBuilder
 
 
 def default_timeseries() -> TimeseriesBuilder:

--- a/examples/python/raspberry/cpu.py
+++ b/examples/python/raspberry/cpu.py
@@ -1,9 +1,9 @@
-import generated.models.dashboard as dashboard
-from generated.builders.dashboard import ThresholdsConfig as ThresholdsConfigBuilder
-from generated.cog import builder as cogbuilder
+import grafana_foundation_sdk.models.dashboard as dashboard
+from grafana_foundation_sdk.builders.dashboard import ThresholdsConfig as ThresholdsConfigBuilder
+from grafana_foundation_sdk.cog import builder as cogbuilder
 from .common import default_timeseries, basic_prometheus_query, default_gauge
-from generated.builders.common import StackingConfig as StackingConfigBuilder
-from generated.models.common import StackingMode
+from grafana_foundation_sdk.builders.common import StackingConfig as StackingConfigBuilder
+from grafana_foundation_sdk.models.common import StackingMode
 
 
 def cpu_usage_timeseries() -> cogbuilder.Builder[dashboard.Panel]:

--- a/examples/python/raspberry/disk.py
+++ b/examples/python/raspberry/disk.py
@@ -1,8 +1,8 @@
-import generated.models.dashboard as dashboard
-from generated.cog import builder as cogbuilder
-from generated.builders.table import Panel as TableBuilder
-from generated.models.common import FieldTextAlignment, TableAutoCellOptions, TableCellHeight
-from generated.builders.common import TableFooterOptions
+import grafana_foundation_sdk.models.dashboard as dashboard
+from grafana_foundation_sdk.cog import builder as cogbuilder
+from grafana_foundation_sdk.builders.table import Panel as TableBuilder
+from grafana_foundation_sdk.models.common import FieldTextAlignment, TableAutoCellOptions, TableCellHeight
+from grafana_foundation_sdk.builders.common import TableFooterOptions
 from .common import default_timeseries, basic_prometheus_query, table_prometheus_query
 
 

--- a/examples/python/raspberry/logs.py
+++ b/examples/python/raspberry/logs.py
@@ -1,5 +1,5 @@
-import generated.models.dashboard as dashboard
-from generated.cog import builder as cogbuilder
+import grafana_foundation_sdk.models.dashboard as dashboard
+from grafana_foundation_sdk.cog import builder as cogbuilder
 from .common import default_logs, basic_loki_query
 
 

--- a/examples/python/raspberry/memory.py
+++ b/examples/python/raspberry/memory.py
@@ -1,9 +1,9 @@
-import generated.models.dashboard as dashboard
-from generated.builders.dashboard import ThresholdsConfig as ThresholdsConfigBuilder
-from generated.cog import builder as cogbuilder
+import grafana_foundation_sdk.models.dashboard as dashboard
+from grafana_foundation_sdk.builders.dashboard import ThresholdsConfig as ThresholdsConfigBuilder
+from grafana_foundation_sdk.cog import builder as cogbuilder
 from .common import default_timeseries, basic_prometheus_query, default_gauge
-from generated.builders.common import StackingConfig as StackingConfigBuilder
-from generated.models.common import StackingMode
+from grafana_foundation_sdk.builders.common import StackingConfig as StackingConfigBuilder
+from grafana_foundation_sdk.models.common import StackingMode
 
 
 def memory_usage_timeseries() -> cogbuilder.Builder[dashboard.Panel]:

--- a/examples/python/raspberry/network.py
+++ b/examples/python/raspberry/network.py
@@ -1,5 +1,5 @@
-import generated.models.dashboard as dashboard
-from generated.cog import builder as cogbuilder
+import grafana_foundation_sdk.models.dashboard as dashboard
+from grafana_foundation_sdk.cog import builder as cogbuilder
 from .common import default_timeseries, basic_prometheus_query
 
 

--- a/examples/typescript/common.ts
+++ b/examples/typescript/common.ts
@@ -1,6 +1,6 @@
-import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/src/timeseries";
-import {PanelBuilder as LogsPanelBuilder} from "../../generated/src/logs";
-import {PanelBuilder as GaugePanelBuilder} from "../../generated/src/gauge";
+import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/typescript/src/timeseries";
+import {PanelBuilder as LogsPanelBuilder} from "../../generated/typescript/src/logs";
+import {PanelBuilder as GaugePanelBuilder} from "../../generated/typescript/src/gauge";
 import {
     GraphDrawStyle,
     LegendDisplayMode,
@@ -10,10 +10,10 @@ import {
     VisibilityMode,
     VizLegendOptionsBuilder,
     VizOrientation
-} from "../../generated/src/common";
-import * as prometheus from "../../generated/src/prometheus";
-import * as loki from "../../generated/src/loki";
-import {PromQueryFormat} from "../../generated/src/prometheus";
+} from "../../generated/typescript/src/common";
+import * as prometheus from "../../generated/typescript/src/prometheus";
+import * as loki from "../../generated/typescript/src/loki";
+import {PromQueryFormat} from "../../generated/typescript/src/prometheus";
 
 export const basicPrometheusQuery = (query: string, legend: string): prometheus.DataqueryBuilder => {
     return new prometheus.DataqueryBuilder()

--- a/examples/typescript/cpu.ts
+++ b/examples/typescript/cpu.ts
@@ -1,8 +1,8 @@
-import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/src/timeseries";
-import {PanelBuilder as GaugePanelBuilder} from "../../generated/src/gauge";
+import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/typescript/src/timeseries";
+import {PanelBuilder as GaugePanelBuilder} from "../../generated/typescript/src/gauge";
 import {basicPrometheusQuery, defaultGauge, defaultTimeseries} from "./common";
-import {StackingConfigBuilder, StackingMode} from "../../generated/src/common";
-import {ThresholdsConfigBuilder, ThresholdsMode} from "../../generated/src/dashboard";
+import {StackingConfigBuilder, StackingMode} from "../../generated/typescript/src/common";
+import {ThresholdsConfigBuilder, ThresholdsMode} from "../../generated/typescript/src/dashboard";
 
 export const cpuUsageTimeseries = (): TimeseriesPanelBuilder => {
     const 	query = `(

--- a/examples/typescript/disk.ts
+++ b/examples/typescript/disk.ts
@@ -1,7 +1,7 @@
-import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/src/timeseries";
-import {PanelBuilder as TablePanelBuilder} from "../../generated/src/table";
+import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/typescript/src/timeseries";
+import {PanelBuilder as TablePanelBuilder} from "../../generated/typescript/src/table";
 import {basicPrometheusQuery, defaultTimeseries, tablePrometheusQuery} from "./common";
-import {FieldTextAlignment, TableCellHeight, TableFooterOptionsBuilder} from "../../generated/src/common";
+import {FieldTextAlignment, TableCellHeight, TableFooterOptionsBuilder} from "../../generated/typescript/src/common";
 
 export const diskIOTimeseries = (): TimeseriesPanelBuilder => {
     return defaultTimeseries()

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -8,7 +8,7 @@ import {
     VariableHide,
     VariableRefresh,
     VariableSort,
-} from "../../generated/src/dashboard";
+} from "../../generated/typescript/src/dashboard";
 import {cpuTemperatureGauge, cpuUsageTimeseries, loadAverageTimeseries} from "./cpu";
 import {memoryUsageGauge, memoryUsageTimeseries} from "./memory";
 import {diskIOTimeseries, diskSpaceUsageTable} from "./disk";

--- a/examples/typescript/logs.ts
+++ b/examples/typescript/logs.ts
@@ -1,4 +1,4 @@
-import {PanelBuilder as LogsPanelBuilder} from "../../generated/src/logs";
+import {PanelBuilder as LogsPanelBuilder} from "../../generated/typescript/src/logs";
 import {basicLokiQuery, defaultLogs} from "./common";
 
 export const errorsInSystemLogs = (): LogsPanelBuilder => {

--- a/examples/typescript/memory.ts
+++ b/examples/typescript/memory.ts
@@ -1,8 +1,8 @@
-import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/src/timeseries";
-import {PanelBuilder as GaugePanelBuilder} from "../../generated/src/gauge";
+import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/typescript/src/timeseries";
+import {PanelBuilder as GaugePanelBuilder} from "../../generated/typescript/src/gauge";
 import {basicPrometheusQuery, defaultGauge, defaultTimeseries} from "./common";
-import {StackingConfigBuilder, StackingMode} from "../../generated/src/common";
-import {ThresholdsConfigBuilder, ThresholdsMode} from "../../generated/src/dashboard";
+import {StackingConfigBuilder, StackingMode} from "../../generated/typescript/src/common";
+import {ThresholdsConfigBuilder, ThresholdsMode} from "../../generated/typescript/src/dashboard";
 
 export const memoryUsageTimeseries = (): TimeseriesPanelBuilder => {
     const 	memUsedQuery = `(

--- a/examples/typescript/network.ts
+++ b/examples/typescript/network.ts
@@ -1,4 +1,4 @@
-import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/src/timeseries";
+import {PanelBuilder as TimeseriesPanelBuilder} from "../../generated/typescript/src/timeseries";
 import {basicPrometheusQuery, defaultTimeseries} from "./common";
 
 export const networkReceivedTimeseries = (): TimeseriesPanelBuilder => {


### PR DESCRIPTION
Having every language generated under `./generated` in dev is cumbersome. 
This PR changes that to follow the `./generated/{{ language }}` convention that we use when releasing the Foundation SDK.