### PR TITLE
Fix Go CI in foundation SDK

### DIFF
--- a/repository_templates/go/.github/workflows/go-ci.yaml
+++ b/repository_templates/go/.github/workflows/go-ci.yaml
@@ -29,6 +29,5 @@ jobs:
       - name: Go build
         run: |
           for d in */ ; do
-            echo "Building $d"
-            go build "./$d"
+            [[ "$d" != "docs/" ]] && (echo "Building $d"; go build "./$d")
           done


### PR DESCRIPTION
Surprisingly, `go build` does not, in fact, work on markdown files :shrug: 