### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  DEVBOX_VERSION: 0.13.1
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Restore go vendors
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-deps-${{ runner.os }}
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+        with:
+          enable-cache: 'true'
+          devbox-version: ${{ env.DEVBOX_VERSION }}
+
+      - name: Run GoReleaser
+        run: goreleaser release --clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Release
 
 on:
-  tags: ["v*"]
+  push:
+    tags: ['v*']
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 build/
 
 .idea
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,54 @@
+# Documentation at https://goreleaser.com
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+builds:
+  - id: cog
+    binary: cog
+    main: ./cmd/cli
+
+    ldflags:
+      - -X main.version={{ .Version }}
+
+    env:
+      - CGO_ENABLED=0
+
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - id: cog
+    builds: [cog]
+    format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^Merge pull request'

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,11 +8,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "SNAPSHOT"
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:          "cog <command>",
 		Short:        "A tool for working with Grafana objects from code",
 		SilenceUsage: true,
+		Version:      version,
 	}
 
 	rootCmd.AddCommand(generate.Command())

--- a/devbox.json
+++ b/devbox.json
@@ -11,7 +11,8 @@
     "nodejs-slim_18@18.20",
     "nodePackages.ts-node@10.9.2",
     "jre17_minimal@17",
-    "gradle@8.10"
+    "gradle@8.10",
+    "goreleaser@1.26"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.json
+++ b/devbox.json
@@ -12,7 +12,7 @@
     "nodePackages.ts-node@10.9.2",
     "jre17_minimal@17",
     "gradle@8.10",
-    "goreleaser@1.26"
+    "goreleaser@2.2"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -97,51 +97,51 @@
         }
       }
     },
-    "goreleaser@1.26": {
-      "last_modified": "2024-05-29T10:04:41Z",
-      "resolved": "github:NixOS/nixpkgs/ac82a513e55582291805d6f09d35b6d8b60637a1#goreleaser",
+    "goreleaser@2.2": {
+      "last_modified": "2024-10-13T23:44:06Z",
+      "resolved": "github:NixOS/nixpkgs/d4f247e89f6e10120f911e2e2d2254a050d0f732#goreleaser",
       "source": "devbox-search",
-      "version": "1.26.2",
+      "version": "2.2.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/3igms7180pkaki16zvfid4q7jp2g22b0-goreleaser-1.26.2",
+              "path": "/nix/store/mfwm9y5vhs3dzfbhmpqmgr2mx0p4kbnl-goreleaser-2.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/3igms7180pkaki16zvfid4q7jp2g22b0-goreleaser-1.26.2"
+          "store_path": "/nix/store/mfwm9y5vhs3dzfbhmpqmgr2mx0p4kbnl-goreleaser-2.2.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/k5cnmyfha51wygjalza3kf6kjwwds0lh-goreleaser-1.26.2",
+              "path": "/nix/store/gqpm92gd4lnbk2467cgypjxl8af4zv6p-goreleaser-2.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/k5cnmyfha51wygjalza3kf6kjwwds0lh-goreleaser-1.26.2"
+          "store_path": "/nix/store/gqpm92gd4lnbk2467cgypjxl8af4zv6p-goreleaser-2.2.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9xx7jd8hi5ff305kysnq7wylf92w69vh-goreleaser-1.26.2",
+              "path": "/nix/store/bk3fkkjqa4cxl23a1qz8s0w3dj5pi4zn-goreleaser-2.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/9xx7jd8hi5ff305kysnq7wylf92w69vh-goreleaser-1.26.2"
+          "store_path": "/nix/store/bk3fkkjqa4cxl23a1qz8s0w3dj5pi4zn-goreleaser-2.2.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lwgrhyjg21q6zd1akid2v1nxxnpsscz1-goreleaser-1.26.2",
+              "path": "/nix/store/pjh8k3pnrfaj7riis0s5addqx3v4jbrn-goreleaser-2.2.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/lwgrhyjg21q6zd1akid2v1nxxnpsscz1-goreleaser-1.26.2"
+          "store_path": "/nix/store/pjh8k3pnrfaj7riis0s5addqx3v4jbrn-goreleaser-2.2.0"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -97,6 +97,54 @@
         }
       }
     },
+    "goreleaser@1.26": {
+      "last_modified": "2024-05-29T10:04:41Z",
+      "resolved": "github:NixOS/nixpkgs/ac82a513e55582291805d6f09d35b6d8b60637a1#goreleaser",
+      "source": "devbox-search",
+      "version": "1.26.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3igms7180pkaki16zvfid4q7jp2g22b0-goreleaser-1.26.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3igms7180pkaki16zvfid4q7jp2g22b0-goreleaser-1.26.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/k5cnmyfha51wygjalza3kf6kjwwds0lh-goreleaser-1.26.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/k5cnmyfha51wygjalza3kf6kjwwds0lh-goreleaser-1.26.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9xx7jd8hi5ff305kysnq7wylf92w69vh-goreleaser-1.26.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9xx7jd8hi5ff305kysnq7wylf92w69vh-goreleaser-1.26.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lwgrhyjg21q6zd1akid2v1nxxnpsscz1-goreleaser-1.26.2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lwgrhyjg21q6zd1akid2v1nxxnpsscz1-goreleaser-1.26.2"
+        }
+      }
+    },
     "gradle@8.10": {
       "last_modified": "2024-09-12T02:28:40Z",
       "plugin_version": "0.0.1",


### PR DESCRIPTION
Cog really should start being versioned (even if we stay in v0.0.x for now).

This PR adds a goreleaser config + pipeline to build and publish cog binaries.