### PR TITLE
Allow missing fields in strict unmarshal if they have a default value

### DIFF
--- a/internal/jennies/golang/templates/types/struct.strict.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/struct.strict.json_unmarshal.tmpl
@@ -31,7 +31,7 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) 
 		{{ end }}
 		}
 		delete(fields, {{ $field.Name|formatScalar }})
-	{{ if $field.Required -}} } else {
+	{{ if and $field.Required (eq $field.Type.Default nil) -}} } else {
 		{{- $errors := importStdPkg "errors" -}}
 		errs = append(errs, cog.MakeBuildErrors({{ $field.Name|formatScalar }}, errors.New("required field is missing from input"))...)
 	{{- end }}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -112,7 +112,7 @@ func (resource *Struct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "allFields")
-	} else {errs = append(errs, cog.MakeBuildErrors("allFields", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "partialFields"
 	if fields["partialFields"] != nil {
@@ -126,7 +126,7 @@ func (resource *Struct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "partialFields")
-	} else {errs = append(errs, cog.MakeBuildErrors("partialFields", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "emptyFields"
 	if fields["emptyFields"] != nil {
@@ -154,7 +154,7 @@ func (resource *Struct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "complexField")
-	} else {errs = append(errs, cog.MakeBuildErrors("complexField", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "partialComplexField"
 	if fields["partialComplexField"] != nil {
@@ -168,7 +168,7 @@ func (resource *Struct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "partialComplexField")
-	} else {errs = append(errs, cog.MakeBuildErrors("partialComplexField", errors.New("required field is missing from input"))...)
+	
 	}
 
 	for field := range fields {

--- a/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
+++ b/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
@@ -40,7 +40,7 @@ func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "fieldBool")
-	} else {errs = append(errs, cog.MakeBuildErrors("fieldBool", errors.New("required field is missing from input"))...)
+	
 	}
 
 	for field := range fields {

--- a/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -37,7 +37,7 @@ func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "fieldBool")
-	} else {errs = append(errs, cog.MakeBuildErrors("fieldBool", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "fieldString"
 	if fields["fieldString"] != nil {
@@ -49,7 +49,7 @@ func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "fieldString")
-	} else {errs = append(errs, cog.MakeBuildErrors("fieldString", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "FieldStringWithConstantValue"
 	if fields["FieldStringWithConstantValue"] != nil {
@@ -73,7 +73,7 @@ func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "FieldFloat32")
-	} else {errs = append(errs, cog.MakeBuildErrors("FieldFloat32", errors.New("required field is missing from input"))...)
+	
 	}
 	// Field "FieldInt32"
 	if fields["FieldInt32"] != nil {
@@ -85,7 +85,7 @@ func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
 		
 		}
 		delete(fields, "FieldInt32")
-	} else {errs = append(errs, cog.MakeBuildErrors("FieldInt32", errors.New("required field is missing from input"))...)
+	
 	}
 
 	for field := range fields {


### PR DESCRIPTION
The strict unmarshal functions in Go are a bit too strict: they return an error if a field is missing from the JSON input, even when that field has a default value.

This PR changes that behavior: required field that have a default value set in the schema can now be omitted.