### PR TITLE
Bump phpstan memory limit in Foundation SDK PHP CI

### DIFF
--- a/repository_templates/php/.github/workflows/php-ci.yaml
+++ b/repository_templates/php/.github/workflows/php-ci.yaml
@@ -29,7 +29,7 @@ jobs:
         run: composer install
 
       - name: Lint generated PHP code with phpstan
-        run: phpstan analyze --memory-limit 256M -c .config/ci/php/phpstan.neon
+        run: phpstan analyze --memory-limit 512M -c .config/ci/php/phpstan.neon
 
       - name: Lint generated PHP code with psalm
         run: psalm -c .config/ci/php/psalm.xml php


### PR DESCRIPTION
See: https://github.com/grafana/grafana-foundation-sdk/actions/runs/11704119766/job/32595882191?pr=354