### PR TITLE
Go/constructors defaults

### DIFF
--- a/config/templates/go/assignment_Dashboard_withPanel.tmpl
+++ b/config/templates/go/assignment_Dashboard_withPanel.tmpl
@@ -1,7 +1,7 @@
 {{- define "pre_assignment_Dashboard_withPanel" }}
 
 	if panelResource.GridPos == nil {
-		panelResource.GridPos = &GridPos{}
+		panelResource.GridPos = NewGridPos()
 	}
 	// The panel either has no position set, or it is the first panel of the dashboard.
 	// In that case, we position it on the grid

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -120,7 +120,7 @@ func (jenny *Builder) emptyValueForGuard(context languages.Context, typeDef ast.
 	case ast.KindRef:
 		resolvedType := context.ResolveRefs(typeDef)
 		if resolvedType.IsStruct() {
-			constructor := fmt.Sprintf("New%s()", typeDef.Ref.ReferredType)
+			constructor := "New" + typeDef.Ref.ReferredType + "()"
 
 			referredPkg := jenny.typeImportMapper(typeDef.Ref.ReferredPkg)
 			if referredPkg != "" {

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -68,7 +68,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 		buildObjectSignature = jenny.typeFormatter.variantInterface(builder.For.Type.ImplementedVariant())
 	}
 
-	constructorName := fmt.Sprintf("New%s", formatObjectName(builder.For.SelfRef.ReferredType))
+	constructorName := "New" + formatObjectName(builder.For.SelfRef.ReferredType)
 	constructorPkg := jenny.typeImportMapper(builder.For.SelfRef.ReferredPkg)
 	if constructorPkg != "" {
 		constructorName = constructorPkg + "." + constructorName

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -124,7 +124,7 @@ func (jenny *Builder) emptyValueForGuard(context languages.Context, typeDef ast.
 
 			referredPkg := jenny.typeImportMapper(typeDef.Ref.ReferredPkg)
 			if referredPkg != "" {
-				constructor = fmt.Sprintf("%s.%s", referredPkg, constructor)
+				constructor = referredPkg + "." + constructor
 			}
 
 			return constructor

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -19,6 +19,7 @@ type RawTypes struct {
 	apiRefCollector *common.APIReferenceCollector
 
 	typeFormatter *typeFormatter
+	packageMapper func(pkg string) string
 }
 
 func (jenny RawTypes) JennyName() string {
@@ -50,30 +51,26 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 	var err error
 
 	imports := NewImportMap(jenny.Config.PackageRoot)
-	packageMapper := func(pkg string) string {
+	jenny.packageMapper = func(pkg string) string {
 		if imports.IsIdentical(pkg, schema.Package) {
 			return ""
 		}
 
 		return imports.Add(pkg, jenny.Config.importPath(pkg))
 	}
-	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, imports, packageMapper)
-	unmarshallerGenerator := NewJSONMarshalling(jenny.Config, jenny.Tmpl, imports, packageMapper, jenny.typeFormatter, jenny.apiRefCollector)
-	strictUnmarshallerGenerator := newStrictJSONUnmarshal(jenny.Tmpl, imports, packageMapper, jenny.typeFormatter, jenny.apiRefCollector)
+	jenny.typeFormatter = defaultTypeFormatter(jenny.Config, context, imports, jenny.packageMapper)
+	unmarshallerGenerator := NewJSONMarshalling(jenny.Config, jenny.Tmpl, imports, jenny.packageMapper, jenny.typeFormatter, jenny.apiRefCollector)
+	strictUnmarshallerGenerator := newStrictJSONUnmarshal(jenny.Tmpl, imports, jenny.packageMapper, jenny.typeFormatter, jenny.apiRefCollector)
 	equalityMethodsGenerator := newEqualityMethods(jenny.Tmpl, jenny.apiRefCollector)
-	validationMethodsGenerator := newValidationMethods(jenny.Tmpl, packageMapper, jenny.apiRefCollector)
+	validationMethodsGenerator := newValidationMethods(jenny.Tmpl, jenny.packageMapper, jenny.apiRefCollector)
 
 	schema.Objects.Iterate(func(_ string, object ast.Object) {
-		objectOutput, innerErr := jenny.formatObject(schema, object)
-		if innerErr != nil {
-			err = innerErr
-			return
-		}
-
-		buffer.Write(objectOutput)
+		jenny.formatObject(&buffer, schema, object)
 		buffer.WriteString("\n")
 
-		innerErr = unmarshallerGenerator.generateForObject(&buffer, context, schema, object)
+		jenny.generateConstructor(&buffer, context, object)
+
+		innerErr := unmarshallerGenerator.generateForObject(&buffer, context, schema, object)
 		if innerErr != nil {
 			err = innerErr
 			return
@@ -115,10 +112,8 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 %[2]s%[3]s`, formatPackageName(schema.Package), importStatements, buffer.String())), nil
 }
 
-func (jenny RawTypes) formatObject(schema *ast.Schema, def ast.Object) ([]byte, error) {
-	var buffer strings.Builder
-
-	defName := tools.UpperCamelCase(def.Name)
+func (jenny RawTypes) formatObject(buffer *strings.Builder, schema *ast.Schema, def ast.Object) {
+	defName := formatObjectName(def.Name)
 
 	comments := def.Comments
 	if jenny.Config.debug {
@@ -147,6 +142,154 @@ func (jenny RawTypes) formatObject(schema *ast.Schema, def ast.Object) ([]byte, 
 			buffer.WriteString("}\n")
 		}
 	}
+}
 
-	return []byte(buffer.String()), nil
+func (jenny RawTypes) generateConstructor(buffer *strings.Builder, context languages.Context, object ast.Object) {
+	defName := formatObjectName(object.Name)
+	constructorName := "New" + defName
+
+	declareConstructor := func() {
+		jenny.apiRefCollector.RegisterFunction(object.SelfRef.ReferredPkg, common.FunctionReference{
+			Name: constructorName,
+			Comments: []string{
+				fmt.Sprintf("%[1]s creates a new %[2]s object.", constructorName, defName),
+			},
+			Return: "*" + defName,
+		})
+	}
+
+	if object.Type.IsRef() {
+		referredObj, found := context.LocateObjectByRef(*object.Type.Ref)
+		if !found || !referredObj.Type.IsStruct() {
+			return
+		}
+
+		declareConstructor()
+		buffer.WriteString(fmt.Sprintf("// %[1]s creates a new %[2]s object.\n", constructorName, defName))
+		buffer.WriteString(fmt.Sprintf("func %[1]s() *%[2]s {\n", constructorName, defName))
+
+		delegatedConstructorName := fmt.Sprintf("New%s", formatObjectName(referredObj.Name))
+		referredPkg := jenny.packageMapper(referredObj.SelfRef.ReferredPkg)
+		if referredPkg != "" {
+			delegatedConstructorName = fmt.Sprintf("%s.%s", referredPkg, delegatedConstructorName)
+		}
+
+		buffer.WriteString(fmt.Sprintf("\treturn %s()", delegatedConstructorName))
+		buffer.WriteString("\n}\n")
+		return
+	}
+
+	if !object.Type.IsStruct() {
+		return
+	}
+
+	declareConstructor()
+	buffer.WriteString(fmt.Sprintf("// %[1]s creates a new %[2]s object.\n", constructorName, defName))
+	buffer.WriteString(fmt.Sprintf("func %[1]s() *%[2]s {\n", constructorName, defName))
+	buffer.WriteString(fmt.Sprintf("\treturn &%s", jenny.defaultsForStruct(context, object.SelfRef, object.Type, nil)))
+	buffer.WriteString("\n}\n")
+}
+
+func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast.RefType, objectType ast.Type, maybeExtraDefaults any) string {
+	var buffer strings.Builder
+
+	defName := formatObjectName(objectRef.ReferredType)
+	referredPkg := jenny.packageMapper(objectRef.ReferredPkg)
+	if referredPkg != "" {
+		defName = fmt.Sprintf("%s.%s", referredPkg, defName)
+	}
+
+	buffer.WriteString(fmt.Sprintf("%s{\n", defName))
+
+	extraDefaults := map[string]any{}
+	if val, ok := maybeExtraDefaults.(map[string]any); ok {
+		extraDefaults = val
+	}
+
+	for _, field := range objectType.Struct.Fields {
+		resolvedFieldType := context.ResolveRefs(field.Type)
+
+		needsExplicitDefault := field.Type.Default != nil ||
+			extraDefaults[field.Name] != nil ||
+			(field.Required && field.Type.IsRef() && resolvedFieldType.IsStruct()) ||
+			field.Type.IsConcreteScalar()
+		if !needsExplicitDefault {
+			continue
+		}
+
+		fieldName := formatFieldName(field.Name)
+		defaultValue := ""
+
+		// nolint:gocritic
+		if extraDefault, ok := extraDefaults[field.Name]; ok {
+			defaultValue = formatScalar(extraDefault)
+
+			defaultValue = jenny.maybeScalarValueAsPointer(defaultValue, field.Type.Nullable, resolvedFieldType)
+		} else if field.Type.IsConcreteScalar() {
+			defaultValue = formatScalar(field.Type.Scalar.Value)
+
+			defaultValue = jenny.maybeScalarValueAsPointer(defaultValue, field.Type.Nullable, resolvedFieldType)
+		} else if resolvedFieldType.IsAnyOf(ast.KindScalar, ast.KindMap, ast.KindArray) && field.Type.Default != nil {
+			defaultValue = formatScalar(field.Type.Default)
+
+			defaultValue = jenny.maybeScalarValueAsPointer(defaultValue, field.Type.Nullable, resolvedFieldType)
+		} else if field.Type.IsRef() && resolvedFieldType.IsStruct() && field.Type.Default != nil {
+			defaultValue = jenny.defaultsForStruct(context, *field.Type.Ref, resolvedFieldType, field.Type.Default)
+			if field.Type.Nullable {
+				defaultValue = "&" + defaultValue
+			}
+		} else if field.Type.IsRef() && resolvedFieldType.IsStruct() {
+			defaultValue = fmt.Sprintf("New%s()", formatObjectName(field.Type.Ref.ReferredType))
+
+			referredPkg = jenny.packageMapper(field.Type.Ref.ReferredPkg)
+			if referredPkg != "" {
+				defaultValue = fmt.Sprintf("%s.%s", referredPkg, defaultValue)
+			}
+
+			if !field.Type.Nullable {
+				defaultValue = "*" + defaultValue
+			}
+		} else if field.Type.IsRef() && resolvedFieldType.IsEnum() {
+			memberName := resolvedFieldType.Enum.Values[0].Name
+			for _, member := range resolvedFieldType.Enum.Values {
+				if member.Value == field.Type.Default {
+					memberName = member.Name
+					break
+				}
+			}
+
+			defaultValue = memberName
+
+			referredPkg = jenny.packageMapper(field.Type.Ref.ReferredPkg)
+			if referredPkg != "" {
+				defaultValue = fmt.Sprintf("%s.%s", referredPkg, defaultValue)
+			}
+
+			if field.Type.Nullable {
+				jenny.packageMapper("cog")
+				defaultValue = fmt.Sprintf("cog.ToPtr(%s)", defaultValue)
+			}
+		} else {
+			defaultValue = "\"unsupported default value case: this is likely a bug in cog\""
+		}
+
+		buffer.WriteString(fmt.Sprintf("\t\t%s: %s,\n", fieldName, defaultValue))
+	}
+
+	buffer.WriteString("}")
+
+	return buffer.String()
+}
+
+func (jenny RawTypes) maybeScalarValueAsPointer(value string, nullable bool, typeDef ast.Type) string {
+	if nullable && typeDef.IsScalar() {
+		nonNullableField := typeDef.DeepCopy()
+		nonNullableField.Nullable = false
+		typeHint := jenny.typeFormatter.formatType(nonNullableField)
+
+		jenny.packageMapper("cog")
+		return fmt.Sprintf("cog.ToPtr[%s](%s)", typeHint, value)
+	}
+
+	return value
 }

--- a/internal/jennies/golang/templates/builders/builder.tmpl
+++ b/internal/jennies/golang/templates/builders/builder.tmpl
@@ -16,13 +16,11 @@ type {{ .BuilderName }}Builder struct {
 }
 
 func New{{ .BuilderName }}Builder({{- template "args" .Constructor.Args }}) *{{ .BuilderName }}Builder {
-	resource := &{{ .ObjectName }}{}
+	resource := {{ .ConstructorName }}()
 	builder := &{{ .BuilderName }}Builder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
     {{- range .Constructor.Assignments }}
         {{- template "assignment" (dict "Assignment" . "Builder" $ "Option" (dict "Name" "")) }}
@@ -39,8 +37,3 @@ func (builder *{{ .BuilderName }}Builder) Build() ({{ .BuilderSignatureType }}, 
 	return *builder.internal, nil
 }
 {{- $options }}
-func (builder *{{ .BuilderName }}Builder) applyDefaults() {
-    {{- range .Defaults }}
-    builder.{{ .OptionName|upperCamelCase }}({{ .Args|join ", " }})
-    {{- end }}
-}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -63,6 +63,7 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 		}),
 		template.Funcs(map[string]any{
 			"formatPackageName": formatPackageName,
+			"formatObjectName":  formatObjectName,
 			"formatScalar":      formatScalar,
 			"formatArgName":     formatArgName,
 			"maybeAsPointer": func(intoType ast.Type, variableName string) string {

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -21,6 +21,14 @@ func formatArgName(name string) string {
 	return escapeVarName(tools.LowerCamelCase(name))
 }
 
+func formatObjectName(name string) string {
+	return tools.UpperCamelCase(name)
+}
+
+func formatFieldName(name string) string {
+	return tools.UpperCamelCase(name)
+}
+
 func escapeVarName(varName string) string {
 	if isReservedGoKeyword(varName) {
 		return varName + "Arg"

--- a/testdata/generated/equality/types_gen.go
+++ b/testdata/generated/equality/types_gen.go
@@ -29,6 +29,11 @@ type Variable struct {
 	Name string `json:"name"`
 }
 
+// NewVariable creates a new Variable object.
+func NewVariable() *Variable {
+	return &Variable{}
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Variable` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Variable) UnmarshalJSONStrict(raw []byte) error {
@@ -86,6 +91,13 @@ type Container struct {
 	IntField    int64     `json:"intField"`
 	EnumField   Direction `json:"enumField"`
 	RefField    Variable  `json:"refField"`
+}
+
+// NewContainer creates a new Container object.
+func NewContainer() *Container {
+	return &Container{
+		RefField: *NewVariable(),
+	}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Container` from JSON.
@@ -211,6 +223,11 @@ type Optionals struct {
 	RefField *Variable `json:"refField,omitempty"`
 }
 
+// NewOptionals creates a new Optionals object.
+func NewOptionals() *Optionals {
+	return &Optionals{}
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Optionals` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Optionals) UnmarshalJSONStrict(raw []byte) error {
@@ -326,6 +343,11 @@ type Arrays struct {
 	Refs             []Variable                       `json:"refs"`
 	AnonymousStructs []EqualityArraysAnonymousStructs `json:"anonymousStructs"`
 	ArrayOfAny       []any                            `json:"arrayOfAny"`
+}
+
+// NewArrays creates a new Arrays object.
+func NewArrays() *Arrays {
+	return &Arrays{}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Arrays` from JSON.
@@ -569,6 +591,11 @@ type Maps struct {
 	StringToAny      map[string]any                          `json:"stringToAny"`
 }
 
+// NewMaps creates a new Maps object.
+func NewMaps() *Maps {
+	return &Maps{}
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Maps` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Maps) UnmarshalJSONStrict(raw []byte) error {
@@ -777,6 +804,11 @@ type EqualityArraysAnonymousStructs struct {
 	Inner string `json:"inner"`
 }
 
+// NewEqualityArraysAnonymousStructs creates a new EqualityArraysAnonymousStructs object.
+func NewEqualityArraysAnonymousStructs() *EqualityArraysAnonymousStructs {
+	return &EqualityArraysAnonymousStructs{}
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `EqualityArraysAnonymousStructs` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *EqualityArraysAnonymousStructs) UnmarshalJSONStrict(raw []byte) error {
@@ -832,6 +864,11 @@ func (resource EqualityArraysAnonymousStructs) Validate() error {
 // Modified by compiler pass 'AnonymousStructsToNamed'
 type EqualityMapsAnonymousStructs struct {
 	Inner string `json:"inner"`
+}
+
+// NewEqualityMapsAnonymousStructs creates a new EqualityMapsAnonymousStructs object.
+func NewEqualityMapsAnonymousStructs() *EqualityMapsAnonymousStructs {
+	return &EqualityMapsAnonymousStructs{}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `EqualityMapsAnonymousStructs` from JSON.

--- a/testdata/generated/validation/types_gen.go
+++ b/testdata/generated/validation/types_gen.go
@@ -25,6 +25,11 @@ type Dashboard struct {
 	Panels []Panel           `json:"panels"`
 }
 
+// NewDashboard creates a new Dashboard object.
+func NewDashboard() *Dashboard {
+	return &Dashboard{}
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Dashboard` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Dashboard) UnmarshalJSONStrict(raw []byte) error {
@@ -257,6 +262,11 @@ func (resource Dashboard) Validate() error {
 
 type Panel struct {
 	Title string `json:"title"`
+}
+
+// NewPanel creates a new Panel object.
+func NewPanel() *Panel {
+	return &Panel{}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Panel` from JSON.

--- a/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -40,5 +38,3 @@ func (builder *SomeStructBuilder) Time(time struct {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -37,5 +35,3 @@ func (builder *SomeStructBuilder) Tags(tags string) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
@@ -13,13 +13,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -59,5 +57,3 @@ func (builder *SomeStructBuilder) LiveNow(liveNow bool) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -55,9 +53,3 @@ func (builder *SomeStructBuilder) LiveNow(liveNow bool) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-    builder.Id(42)
-    builder.Uid("default-uid")
-    builder.Tags([]string{"generated", "cog"})
-    builder.LiveNow(true)
-}

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
@@ -12,13 +12,11 @@ type DashboardBuilder struct {
 }
 
 func NewDashboardBuilder() *DashboardBuilder {
-	resource := &Dashboard{}
+	resource := NewDashboard()
 	builder := &DashboardBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -92,5 +90,3 @@ func (builder *DashboardBuilder) SingleLink(singleLink cog.Builder[DashboardLink
     return builder
 }
 
-func (builder *DashboardBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
@@ -12,13 +12,11 @@ type DashboardLinkBuilder struct {
 }
 
 func NewDashboardLinkBuilder() *DashboardLinkBuilder {
-	resource := &DashboardLink{}
+	resource := NewDashboardLink()
 	builder := &DashboardLinkBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -43,5 +41,3 @@ func (builder *DashboardLinkBuilder) Url(url string) *DashboardLinkBuilder {
     return builder
 }
 
-func (builder *DashboardLinkBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
@@ -13,13 +13,11 @@ type LokiBuilderBuilder struct {
 }
 
 func NewLokiBuilderBuilder() *LokiBuilderBuilder {
-	resource := &Dashboard{}
+	resource := NewDashboard()
 	builder := &LokiBuilderBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -58,5 +56,3 @@ func (builder *LokiBuilderBuilder) Targets(targets []cog.Builder[variants.Dataqu
     return builder
 }
 
-func (builder *LokiBuilderBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -57,5 +55,3 @@ func (builder *SomeStructBuilder) NoAutoRefresh() *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -43,5 +41,3 @@ func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder(title string) *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
     builder.internal.Title = title
 
 	return builder
@@ -38,5 +36,3 @@ func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
@@ -12,13 +12,11 @@ type SomePanelBuilder struct {
 }
 
 func NewSomePanelBuilder() *SomePanelBuilder {
-	resource := &SomePanel{}
+	resource := NewSomePanel()
 	builder := &SomePanelBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
     builder.internal.Type = "panel_type"
     builder.internal.Cursor = "tooltip"
 
@@ -39,5 +37,3 @@ func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {
     return builder
 }
 
-func (builder *SomePanelBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
@@ -13,13 +13,11 @@ type LokiBuilderBuilder struct {
 }
 
 func NewLokiBuilderBuilder() *LokiBuilderBuilder {
-	resource := &Loki{}
+	resource := NewLoki()
 	builder := &LokiBuilderBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -38,5 +36,3 @@ func (builder *LokiBuilderBuilder) Expr(expr string) *LokiBuilderBuilder {
     return builder
 }
 
-func (builder *LokiBuilderBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
@@ -12,13 +12,11 @@ type DashboardBuilder struct {
 }
 
 func NewDashboardBuilder() *DashboardBuilder {
-	resource := &Dashboard{}
+	resource := NewDashboard()
 	builder := &DashboardBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -40,5 +38,3 @@ func (builder *DashboardBuilder) WithVariable(name string,value string) *Dashboa
     return builder
 }
 
-func (builder *DashboardBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
@@ -13,13 +13,11 @@ type SomeNiceBuilderBuilder struct {
 }
 
 func NewSomeNiceBuilderBuilder() *SomeNiceBuilderBuilder {
-	resource := &some_pkg.SomeStruct{}
+	resource := some_pkg.NewSomeStruct()
 	builder := &SomeNiceBuilderBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -38,5 +36,3 @@ func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuild
     return builder
 }
 
-func (builder *SomeNiceBuilderBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
@@ -12,13 +12,11 @@ type SomePanelBuilder struct {
 }
 
 func NewSomePanelBuilder() *SomePanelBuilder {
-	resource := &SomePanel{}
+	resource := NewSomePanel()
 	builder := &SomePanelBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -39,12 +37,10 @@ func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {
 
 func (builder *SomePanelBuilder) ShowLegend(show bool) *SomePanelBuilder {
 if builder.internal.Options == nil {
-    builder.internal.Options = &Options{}
+    builder.internal.Options = NewOptions()
 }
     builder.internal.Options.Legend.Show = show
 
     return builder
 }
 
-func (builder *SomePanelBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -33,12 +31,10 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 
 func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {
 if builder.internal.Config == nil {
-    builder.internal.Config = &Config{}
+    builder.internal.Config = NewConfig()
 }
     builder.internal.Config.(*Config).Title = title
 
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -37,5 +35,3 @@ func (builder *SomeStructBuilder) Config(config map[string]string) *SomeStructBu
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
@@ -13,13 +13,11 @@ type SomeNiceBuilderBuilder struct {
 }
 
 func NewSomeNiceBuilderBuilder() *SomeNiceBuilderBuilder {
-	resource := &withdashes.SomeStruct{}
+	resource := withdashes.NewSomeStruct()
 	builder := &SomeNiceBuilderBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -38,5 +36,3 @@ func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuild
     return builder
 }
 
-func (builder *SomeNiceBuilderBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
@@ -12,13 +12,11 @@ type PanelBuilder struct {
 }
 
 func NewPanelBuilder() *PanelBuilder {
-	resource := &Panel{}
+	resource := NewPanel()
 	builder := &PanelBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -91,14 +89,3 @@ func (builder *PanelBuilder) NavigateAfter(navigateAfter string) *PanelBuilder {
     return builder
 }
 
-func (builder *PanelBuilder) applyDefaults() {
-    builder.OnlyFromThisDashboard(false)
-    builder.OnlyInTimeRange(false)
-    builder.Limit(10)
-    builder.ShowUser(true)
-    builder.ShowTime(true)
-    builder.ShowTags(true)
-    builder.NavigateToPanel(true)
-    builder.NavigateBefore("10m")
-    builder.NavigateAfter("10m")
-}

--- a/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
@@ -13,13 +13,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -38,5 +36,3 @@ func (builder *SomeStructBuilder) Id(id int64) *SomeStructBuilder {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
+++ b/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
@@ -13,13 +13,11 @@ type PersonBuilder struct {
 }
 
 func NewPersonBuilder() *PersonBuilder {
-	resource := &Person{}
+	resource := NewPerson()
 	builder := &PersonBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -38,5 +36,3 @@ func (builder *PersonBuilder) Name(name other_pkg.Name) *PersonBuilder {
     return builder
 }
 
-func (builder *PersonBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -12,13 +12,11 @@ type SomeStructBuilder struct {
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
-	resource := &SomeStruct{}
+	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -44,5 +42,3 @@ if builder.internal.Time == nil {
     return builder
 }
 
-func (builder *SomeStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
@@ -12,13 +12,11 @@ type NestedStructBuilder struct {
 }
 
 func NewNestedStructBuilder() *NestedStructBuilder {
-	resource := &NestedStruct{}
+	resource := NewNestedStruct()
 	builder := &NestedStructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -43,5 +41,3 @@ func (builder *NestedStructBuilder) IntVal(intVal int64) *NestedStructBuilder {
     return builder
 }
 
-func (builder *NestedStructBuilder) applyDefaults() {
-}

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
@@ -12,13 +12,11 @@ type StructBuilder struct {
 }
 
 func NewStructBuilder() *StructBuilder {
-	resource := &Struct{}
+	resource := NewStruct()
 	builder := &StructBuilder{
 		internal: resource,
 		errors: make(map[string]cog.BuildErrors),
 	}
-
-	builder.applyDefaults()
 
 	return builder
 }
@@ -85,33 +83,3 @@ func (builder *StructBuilder) PartialComplexField(partialComplexField struct {
     return builder
 }
 
-func (builder *StructBuilder) applyDefaults() {
-    builder.AllFields(NewNestedStructBuilder().
-IntVal(3).
-StringVal("hello"),
-)
-    builder.PartialFields(NewNestedStructBuilder().
-IntVal(4),
-)
-    builder.ComplexField(struct {
- Uid string `json:"uid"`
-Nested struct {
- NestedVal string `json:"nestedVal"`
- } `json:"nested"`
-Array []string `json:"array"`
- } {
- Array: []string{"hello"},
-Nested: struct {
- NestedVal string `json:"nestedVal"`
- } {
- NestedVal: "nested",
-},
-Uid: "myUID",
- })
-    builder.PartialComplexField(struct {
- Uid string `json:"uid"`
-IntVal int64 `json:"intVal"`
- } {
- Xxxx: "myUID",
- })
-}

--- a/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
+++ b/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
@@ -15,6 +15,11 @@ type SomeStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
+++ b/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
@@ -15,6 +15,11 @@ type SomeStruct struct {
     RefStruct *RefStruct `json:"refStruct,omitempty"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -173,6 +178,11 @@ type RefStruct struct {
     Tags []string `json:"tags"`
 }
 
+// NewRefStruct creates a new RefStruct object.
+func NewRefStruct() *RefStruct {
+	return &RefStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RefStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *RefStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -15,6 +15,11 @@ type Dashboard struct {
     Panels []Panel `json:"panels,omitempty"`
 }
 
+// NewDashboard creates a new Dashboard object.
+func NewDashboard() *Dashboard {
+	return &Dashboard{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Dashboard` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Dashboard) UnmarshalJSONStrict(raw []byte) error {
@@ -118,6 +123,11 @@ type DataSourceRef struct {
     Uid *string `json:"uid,omitempty"`
 }
 
+// NewDataSourceRef creates a new DataSourceRef object.
+func NewDataSourceRef() *DataSourceRef {
+	return &DataSourceRef{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `DataSourceRef` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *DataSourceRef) UnmarshalJSONStrict(raw []byte) error {
@@ -200,6 +210,11 @@ type FieldConfigSource struct {
     Defaults *FieldConfig `json:"defaults,omitempty"`
 }
 
+// NewFieldConfigSource creates a new FieldConfigSource object.
+func NewFieldConfigSource() *FieldConfigSource {
+	return &FieldConfigSource{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `FieldConfigSource` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *FieldConfigSource) UnmarshalJSONStrict(raw []byte) error {
@@ -276,6 +291,11 @@ type FieldConfig struct {
     Custom any `json:"custom,omitempty"`
 }
 
+// NewFieldConfig creates a new FieldConfig object.
+func NewFieldConfig() *FieldConfig {
+	return &FieldConfig{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `FieldConfig` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *FieldConfig) UnmarshalJSONStrict(raw []byte) error {
@@ -358,6 +378,11 @@ type Panel struct {
     FieldConfig *FieldConfigSource `json:"fieldConfig,omitempty"`
 }
 
+// NewPanel creates a new Panel object.
+func NewPanel() *Panel {
+	return &Panel{
+}
+}
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode Panel from JSON.
 func (resource *Panel) UnmarshalJSON(raw []byte) error {
 	if raw == nil {

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -11,6 +11,10 @@ import (
 // Refresh rate or disabled.
 type RefreshRate = StringOrBool
 
+// NewRefreshRate creates a new RefreshRate object.
+func NewRefreshRate() *RefreshRate {
+	return NewStringOrBool()
+}
 type StringOrNull *string
 
 type SomeStruct struct {
@@ -18,6 +22,12 @@ type SomeStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+		Type: "some-struct",
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -89,11 +99,21 @@ func (resource SomeStruct) Validate() error {
 
 type BoolOrRef = BoolOrSomeStruct
 
+// NewBoolOrRef creates a new BoolOrRef object.
+func NewBoolOrRef() *BoolOrRef {
+	return NewBoolOrSomeStruct()
+}
 type SomeOtherStruct struct {
     Type string `json:"Type"`
     Foo []byte `json:"Foo"`
 }
 
+// NewSomeOtherStruct creates a new SomeOtherStruct object.
+func NewSomeOtherStruct() *SomeOtherStruct {
+	return &SomeOtherStruct{
+		Type: "some-other-struct",
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeOtherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeOtherStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -167,6 +187,12 @@ type YetAnotherStruct struct {
     Bar uint8 `json:"Bar"`
 }
 
+// NewYetAnotherStruct creates a new YetAnotherStruct object.
+func NewYetAnotherStruct() *YetAnotherStruct {
+	return &YetAnotherStruct{
+		Type: "yet-another-struct",
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `YetAnotherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *YetAnotherStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -237,11 +263,20 @@ func (resource YetAnotherStruct) Validate() error {
 
 type SeveralRefs = SomeStructOrSomeOtherStructOrYetAnotherStruct
 
+// NewSeveralRefs creates a new SeveralRefs object.
+func NewSeveralRefs() *SeveralRefs {
+	return NewSomeStructOrSomeOtherStructOrYetAnotherStruct()
+}
 type StringOrBool struct {
     String *string `json:"String,omitempty"`
     Bool *bool `json:"Bool,omitempty"`
 }
 
+// NewStringOrBool creates a new StringOrBool object.
+func NewStringOrBool() *StringOrBool {
+	return &StringOrBool{
+}
+}
 // MarshalJSON implements a custom JSON marshalling logic to encode `StringOrBool` as JSON.
 func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {
@@ -365,6 +400,11 @@ type BoolOrSomeStruct struct {
     SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
 }
 
+// NewBoolOrSomeStruct creates a new BoolOrSomeStruct object.
+func NewBoolOrSomeStruct() *BoolOrSomeStruct {
+	return &BoolOrSomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `BoolOrSomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *BoolOrSomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -462,6 +502,11 @@ type SomeStructOrSomeOtherStructOrYetAnotherStruct struct {
     YetAnotherStruct *YetAnotherStruct `json:"YetAnotherStruct,omitempty"`
 }
 
+// NewSomeStructOrSomeOtherStructOrYetAnotherStruct creates a new SomeStructOrSomeOtherStructOrYetAnotherStruct object.
+func NewSomeStructOrSomeOtherStructOrYetAnotherStruct() *SomeStructOrSomeOtherStructOrYetAnotherStruct {
+	return &SomeStructOrSomeOtherStructOrYetAnotherStruct{
+}
+}
 // MarshalJSON implements a custom JSON marshalling logic to encode `SomeStructOrSomeOtherStructOrYetAnotherStruct` as JSON.
 func (resource SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]byte, error) {
 	if resource.SomeStruct != nil {

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -12,6 +12,11 @@ type NestedStruct struct {
     IntVal int64 `json:"intVal"`
 }
 
+// NewNestedStruct creates a new NestedStruct object.
+func NewNestedStruct() *NestedStruct {
+	return &NestedStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `NestedStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *NestedStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -88,6 +93,26 @@ type Struct struct {
     PartialComplexField DefaultsStructPartialComplexField `json:"partialComplexField"`
 }
 
+// NewStruct creates a new Struct object.
+func NewStruct() *Struct {
+	return &Struct{
+		AllFields: NestedStruct{
+		StringVal: "hello",
+		IntVal: 3,
+},
+		PartialFields: NestedStruct{
+		IntVal: 3,
+},
+		EmptyFields: *NewNestedStruct(),
+		ComplexField: DefaultsStructComplexField{
+		Uid: "myUID",
+		Nested: map[string]interface {}{"nestedVal":"nested"},
+		Array: []string{"hello"},
+},
+		PartialComplexField: DefaultsStructPartialComplexField{
+},
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Struct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Struct) UnmarshalJSONStrict(raw []byte) error {
@@ -236,6 +261,11 @@ type DefaultsStructComplexFieldNested struct {
     NestedVal string `json:"nestedVal"`
 }
 
+// NewDefaultsStructComplexFieldNested creates a new DefaultsStructComplexFieldNested object.
+func NewDefaultsStructComplexFieldNested() *DefaultsStructComplexFieldNested {
+	return &DefaultsStructComplexFieldNested{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `DefaultsStructComplexFieldNested` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *DefaultsStructComplexFieldNested) UnmarshalJSONStrict(raw []byte) error {
@@ -295,6 +325,12 @@ type DefaultsStructComplexField struct {
     Array []string `json:"array"`
 }
 
+// NewDefaultsStructComplexField creates a new DefaultsStructComplexField object.
+func NewDefaultsStructComplexField() *DefaultsStructComplexField {
+	return &DefaultsStructComplexField{
+		Nested: *NewDefaultsStructComplexFieldNested(),
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `DefaultsStructComplexField` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *DefaultsStructComplexField) UnmarshalJSONStrict(raw []byte) error {
@@ -402,6 +438,11 @@ type DefaultsStructPartialComplexField struct {
     IntVal int64 `json:"intVal"`
 }
 
+// NewDefaultsStructPartialComplexField creates a new DefaultsStructPartialComplexField object.
+func NewDefaultsStructPartialComplexField() *DefaultsStructPartialComplexField {
+	return &DefaultsStructPartialComplexField{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `DefaultsStructPartialComplexField` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *DefaultsStructPartialComplexField) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
+++ b/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
@@ -20,6 +20,12 @@ type SomeStruct struct {
     FieldBool bool `json:"fieldBool"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+		FieldBool: true,
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
+++ b/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
@@ -17,6 +17,11 @@ type SomeStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -12,6 +12,11 @@ type SomeStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -69,11 +74,20 @@ func (resource SomeStruct) Validate() error {
 // Refresh rate or disabled.
 type RefreshRate = StringOrBool
 
+// NewRefreshRate creates a new RefreshRate object.
+func NewRefreshRate() *RefreshRate {
+	return NewStringOrBool()
+}
 type StringOrBool struct {
     String *string `json:"String,omitempty"`
     Bool *bool `json:"Bool,omitempty"`
 }
 
+// NewStringOrBool creates a new StringOrBool object.
+func NewStringOrBool() *StringOrBool {
+	return &StringOrBool{
+}
+}
 // MarshalJSON implements a custom JSON marshalling logic to encode `StringOrBool` as JSON.
 func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {

--- a/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
@@ -13,6 +13,11 @@ type SomeStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -69,5 +74,9 @@ func (resource SomeStruct) Validate() error {
 
 type RefToSomeStruct = SomeStruct
 
+// NewRefToSomeStruct creates a new RefToSomeStruct object.
+func NewRefToSomeStruct() *RefToSomeStruct {
+	return NewSomeStruct()
+}
 type RefToSomeStructFromOtherPackage = otherpkg.SomeDistantStruct
 

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -21,6 +21,15 @@ type SomeStruct struct {
     FieldRefToConstant string `json:"fieldRefToConstant"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+		FieldRef: *NewSomeOtherStruct(),
+		FieldDisjunctionOfScalars: *NewStringOrBool(),
+		FieldMixedDisjunction: *NewStringOrSomeOtherStruct(),
+		FieldAnonymousStruct: *NewStructComplexFieldsSomeStructFieldAnonymousStruct(),
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -247,6 +256,11 @@ type SomeOtherStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeOtherStruct creates a new SomeOtherStruct object.
+func NewSomeOtherStruct() *SomeOtherStruct {
+	return &SomeOtherStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeOtherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeOtherStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -312,6 +326,11 @@ type StructComplexFieldsSomeStructFieldAnonymousStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewStructComplexFieldsSomeStructFieldAnonymousStruct creates a new StructComplexFieldsSomeStructFieldAnonymousStruct object.
+func NewStructComplexFieldsSomeStructFieldAnonymousStruct() *StructComplexFieldsSomeStructFieldAnonymousStruct {
+	return &StructComplexFieldsSomeStructFieldAnonymousStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `StructComplexFieldsSomeStructFieldAnonymousStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *StructComplexFieldsSomeStructFieldAnonymousStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -371,6 +390,11 @@ type StringOrBool struct {
     Bool *bool `json:"Bool,omitempty"`
 }
 
+// NewStringOrBool creates a new StringOrBool object.
+func NewStringOrBool() *StringOrBool {
+	return &StringOrBool{
+}
+}
 // MarshalJSON implements a custom JSON marshalling logic to encode `StringOrBool` as JSON.
 func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 	if resource.String != nil {
@@ -494,6 +518,11 @@ type StringOrSomeOtherStruct struct {
     SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
 }
 
+// NewStringOrSomeOtherStruct creates a new StringOrSomeOtherStruct object.
+func NewStringOrSomeOtherStruct() *StringOrSomeOtherStruct {
+	return &StringOrSomeOtherStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `StringOrSomeOtherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *StringOrSomeOtherStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -15,6 +15,16 @@ type SomeStruct struct {
     FieldInt32 int32 `json:"FieldInt32"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+		FieldBool: true,
+		FieldString: "foo",
+		FieldStringWithConstantValue: "auto",
+		FieldFloat32: 42.42,
+		FieldInt32: 42,
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
@@ -16,6 +16,11 @@ type SomeStruct struct {
     FieldAnonymousStruct *StructOptionalFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct,omitempty"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -180,6 +185,11 @@ type SomeOtherStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewSomeOtherStruct creates a new SomeOtherStruct object.
+func NewSomeOtherStruct() *SomeOtherStruct {
+	return &SomeOtherStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeOtherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeOtherStruct) UnmarshalJSONStrict(raw []byte) error {
@@ -245,6 +255,11 @@ type StructOptionalFieldsSomeStructFieldAnonymousStruct struct {
     FieldAny any `json:"FieldAny"`
 }
 
+// NewStructOptionalFieldsSomeStructFieldAnonymousStruct creates a new StructOptionalFieldsSomeStructFieldAnonymousStruct object.
+func NewStructOptionalFieldsSomeStructFieldAnonymousStruct() *StructOptionalFieldsSomeStructFieldAnonymousStruct {
+	return &StructOptionalFieldsSomeStructFieldAnonymousStruct{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `StructOptionalFieldsSomeStructFieldAnonymousStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *StructOptionalFieldsSomeStructFieldAnonymousStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
@@ -32,6 +32,12 @@ type SomeStruct struct {
     FieldInt64 int64 `json:"FieldInt64"`
 }
 
+// NewSomeStruct creates a new SomeStruct object.
+func NewSomeStruct() *SomeStruct {
+	return &SomeStruct{
+		FieldStringWithConstantValue: "auto",
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `SomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *SomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
@@ -14,6 +14,11 @@ type ObjWithTimeField struct {
     RegisteredAt time.Time `json:"registeredAt"`
 }
 
+// NewObjWithTimeField creates a new ObjWithTimeField object.
+func NewObjWithTimeField() *ObjWithTimeField {
+	return &ObjWithTimeField{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `ObjWithTimeField` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *ObjWithTimeField) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -18,6 +18,11 @@ func (resource Query) DataqueryType() string {
 	return "prometheus"
 }
 
+// NewQuery creates a new Query object.
+func NewQuery() *Query {
+	return &Query{
+}
+}
 // VariantConfig returns the configuration related to prometheus dataqueries.
 // This configuration describes how to unmarshal it, convert it to code, …
 func VariantConfig() variants.DataqueryConfig {

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -12,6 +12,11 @@ type Options struct {
     TimeseriesOption string `json:"timeseries_option"`
 }
 
+// NewOptions creates a new Options object.
+func NewOptions() *Options {
+	return &Options{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Options` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Options) UnmarshalJSONStrict(raw []byte) error {
@@ -69,6 +74,11 @@ type FieldConfig struct {
     TimeseriesFieldConfigOption string `json:"timeseries_field_config_option"`
 }
 
+// NewFieldConfig creates a new FieldConfig object.
+func NewFieldConfig() *FieldConfig {
+	return &FieldConfig{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `FieldConfig` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *FieldConfig) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -12,6 +12,11 @@ type Options struct {
     Content string `json:"content"`
 }
 
+// NewOptions creates a new Options object.
+func NewOptions() *Options {
+	return &Options{
+}
+}
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Options` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *Options) UnmarshalJSONStrict(raw []byte) error {


### PR DESCRIPTION
Relates to https://github.com/grafana/cog/issues/565

This PR changes the way default values are dealt with in Go.

Similarly to how these values are handled in PHP, Typescript and Python, defaults are now set in constructors generated for each object.

This change also has the added benefit of ensuring that default values will not be omitted if there is no builder option to set them (see https://github.com/grafana/cog/issues/527).