### PR TITLE
fix: expose a "data links" option in panel builders

### DIFF
--- a/config/compiler/kind_registry.yaml
+++ b/config/compiler/kind_registry.yaml
@@ -69,6 +69,16 @@ passes:
             kind: composable_slot
             composable_slot: { variant: dataquery }
 
+  # typed as `links?: [...]` in the original schema
+  - retype_field:
+      field: dashboard.FieldConfig.links
+      as:
+        kind: array
+        array:
+          value_type:
+            kind: ref
+            ref: { referred_pkg: dashboard, referred_type: DashboardLink }
+
   - dashboard_panels: {}
 
   # Add a few missing fields.

--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -53,13 +53,14 @@ builders:
       under_path: fieldConfig.defaults
       exclude_options: [
         # don't copy these over as they clash with a similarly named options from Panel
-        "description", "links",
+        "description",
 
         # TODO: check if these are actually relevant
         "displayNameFromDS", "filterable", "path", "writeable"
       ]
       rename_options:
         color: colorScheme
+        links: dataLinks
   - merge_into:
       source: FieldConfigSource
       destination: Panel


### PR DESCRIPTION
Fixes grafana/grafana-foundation-sdk#352

There were two problems causing this issue:

* the option that would allow setting data links was omitted when generating builders (I guess I got confused when I saw two `links` fields on panels :shrug:)
* the `links` field is [defined as `[]any` in the original schema](https://github.com/grafana/kind-registry/blob/2aebf33e52bbfb07a94c44b2359f2b00c630a840/grafana/next/core/dashboard/dashboard.cue#L722)