### PR TITLE
Go/consistent format helpers

### DIFF
--- a/internal/jennies/golang/apiref.go
+++ b/internal/jennies/golang/apiref.go
@@ -26,13 +26,13 @@ func apiReferenceFormatter(config Config) common.APIReferenceFormatter {
 
 		var receiverName, objectName string
 		if method.ReceiverObject != nil {
-			receiverName = tools.LowerCamelCase(method.ReceiverObject.Name)
-			objectName = tools.UpperCamelCase(method.ReceiverObject.Name)
+			receiverName = formatArgName(method.ReceiverObject.Name)
+			objectName = formatObjectName(method.ReceiverObject.Name)
 		} else {
 			receiverName = "builder"
 			objectName = builderName(*method.ReceiverBuilder)
 		}
-		methodName := tools.UpperCamelCase(method.Name)
+		methodName := formatFunctionName(method.Name)
 
 		return fmt.Sprintf("func (%[1]s *%[2]s) %[3]s(%[4]s)%[5]s", receiverName, objectName, methodName, strings.Join(args, ", "), returnType)
 	}
@@ -47,7 +47,7 @@ func apiReferenceFormatter(config Config) common.APIReferenceFormatter {
 			returnType = " " + function.Return
 		}
 
-		return fmt.Sprintf("func %[1]s(%[2]s)%[3]s", tools.UpperCamelCase(function.Name), strings.Join(args, ", "), returnType)
+		return fmt.Sprintf("func %[1]s(%[2]s)%[3]s", formatFunctionName(function.Name), strings.Join(args, ", "), returnType)
 	}
 
 	return common.APIReferenceFormatter{
@@ -58,7 +58,7 @@ func apiReferenceFormatter(config Config) common.APIReferenceFormatter {
 		FunctionSignature: functionSignature,
 
 		ObjectName: func(object ast.Object) string {
-			return tools.UpperCamelCase(object.Name)
+			return formatObjectName(object.Name)
 		},
 		ObjectDefinition: func(context languages.Context, object ast.Object) string {
 			dummyImports := NewImportMap("")
@@ -69,7 +69,7 @@ func apiReferenceFormatter(config Config) common.APIReferenceFormatter {
 		},
 
 		MethodName: func(method common.MethodReference) string {
-			return tools.UpperCamelCase(method.Name)
+			return formatFunctionName(method.Name)
 		},
 		MethodSignature: methodSignature,
 

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -3,14 +3,12 @@ package golang
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type Builder struct {
@@ -38,7 +36,7 @@ func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error)
 
 		filename := filepath.Join(
 			formatPackageName(builder.Package),
-			fmt.Sprintf("%s_builder_gen.go", strings.ToLower(builder.Name)),
+			fmt.Sprintf("%s_builder_gen.go", formatFileName(builder.Name)),
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))
@@ -102,7 +100,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 			"Package":              builder.Package,
 			"BuilderSignatureType": buildObjectSignature,
 			"Imports":              imports,
-			"BuilderName":          tools.UpperCamelCase(builder.Name),
+			"BuilderName":          formatObjectName(builder.Name),
 			"ObjectName":           fullObjectName,
 			"Comments":             builder.For.Comments,
 			"ConstructorName":      constructorName,

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -3,14 +3,12 @@ package golang
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type Converter struct {
@@ -35,7 +33,7 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 
 		filename := filepath.Join(
 			formatPackageName(builder.Package),
-			fmt.Sprintf("%s_converter_gen.go", strings.ToLower(builder.Name)),
+			fmt.Sprintf("%s_converter_gen.go", formatFileName(builder.Name)),
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))
@@ -67,7 +65,7 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 	}
 
 	jenny.apiRefCollector.RegisterFunction(builder.Package, common.FunctionReference{
-		Name: fmt.Sprintf("%sConverter", tools.UpperCamelCase(converter.BuilderName)),
+		Name: formatFunctionName(converter.BuilderName + "Converter"),
 		Arguments: []common.ArgumentReference{
 			{
 				Name: "input",
@@ -75,7 +73,7 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			},
 		},
 		Comments: []string{
-			fmt.Sprintf("%[1]sConverter accepts a `%[1]s` object and generates the Go code to build this object using builders.", tools.UpperCamelCase(converter.BuilderName)),
+			fmt.Sprintf("%[1]sConverter accepts a `%[1]s` object and generates the Go code to build this object using builders.", formatObjectName(converter.BuilderName)),
 		},
 		Return: "string",
 	})

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -33,7 +33,7 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 
 		filename := filepath.Join(
 			formatPackageName(builder.Package),
-			fmt.Sprintf("%s_converter_gen.go", formatFileName(builder.Name)),
+			formatFileName(builder.Name)+"_converter_gen.go",
 		)
 
 		files = append(files, *codejen.NewFile(filename, output, jenny))

--- a/internal/jennies/golang/equality.go
+++ b/internal/jennies/golang/equality.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type equalityMethods struct {
@@ -31,10 +30,10 @@ func (jenny equalityMethods) generateForObject(buffer *strings.Builder, context 
 	jenny.apiRefCollector.ObjectMethod(object, common.MethodReference{
 		Name: "Equals",
 		Arguments: []common.ArgumentReference{
-			{Name: "other", Type: tools.UpperCamelCase(object.Name)},
+			{Name: "other", Type: formatObjectName(object.Name)},
 		},
 		Comments: []string{
-			fmt.Sprintf("Equals tests the equality of two `%s` objects.", tools.UpperCamelCase(object.Name)),
+			fmt.Sprintf("Equals tests the equality of two `%s` objects.", formatObjectName(object.Name)),
 		},
 		Return: "bool",
 	})

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -103,7 +103,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 			Tmpl:      tmpl,
 		}),
 	)
-	jenny.AddPostprocessors(PostProcessFile, common.GeneratedCommentHeader(globalConfig))
+	jenny.AddPostprocessors(formatGoFiles, common.GeneratedCommentHeader(globalConfig))
 
 	return jenny
 }

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type JSONMarshalling struct {
@@ -92,7 +91,7 @@ func (jenny JSONMarshalling) renderCustomMarshal(obj ast.Object) (string, error)
 	jenny.apiRefCollector.ObjectMethod(obj, common.MethodReference{
 		Name: "MarshalJSON",
 		Comments: []string{
-			fmt.Sprintf("MarshalJSON implements a custom JSON marshalling logic to encode `%s` as JSON.", tools.UpperCamelCase(obj.Name)),
+			fmt.Sprintf("MarshalJSON implements a custom JSON marshalling logic to encode `%s` as JSON.", formatObjectName(obj.Name)),
 		},
 		Return: "([]byte, error)",
 	})
@@ -152,7 +151,7 @@ func (jenny JSONMarshalling) renderCustomUnmarshal(context languages.Context, ob
 			{Name: "raw", Type: "[]byte"},
 		},
 		Comments: []string{
-			fmt.Sprintf("UnmarshalJSON implements a custom JSON unmarshalling logic to decode `%s` from JSON.", tools.UpperCamelCase(obj.Name)),
+			fmt.Sprintf("UnmarshalJSON implements a custom JSON unmarshalling logic to decode `%s` from JSON.", formatObjectName(obj.Name)),
 		},
 		Return: "error",
 	})
@@ -199,7 +198,7 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 			return fmt.Errorf("error decoding field '%[1]s': %%w", err)
 		}
 	}
-`, field.Name, tools.UpperCamelCase(field.Name)))
+`, field.Name, formatFieldName(field.Name)))
 	}
 
 	// unmarshal "composable slot" fields
@@ -234,7 +233,7 @@ func (resource *%[1]s) UnmarshalJSON(raw []byte) error {
 	%[2]s
 	return nil
 }
-`, tools.UpperCamelCase(obj.Name), buffer.String()), nil
+`, formatObjectName(obj.Name), buffer.String()), nil
 }
 
 func (jenny JSONMarshalling) renderUnmarshalDataqueryField(parentStruct ast.Object, field ast.StructField) string {
@@ -260,7 +259,7 @@ func (jenny JSONMarshalling) renderUnmarshalDataqueryField(parentStruct ast.Obje
 		hintValue += fmt.Sprintf(`if resource.%[1]s != nil && resource.%[1]s.Type != nil {
 dataqueryTypeHint = *resource.%[1]s.Type
 }
-`, tools.UpperCamelCase(hintField.Name))
+`, formatFieldName(hintField.Name))
 	}
 
 	jenny.packageMapper("cog")
@@ -276,7 +275,7 @@ dataqueryTypeHint = *resource.%[1]s.Type
 		}
 		resource.%[1]s = %[2]s
 	}
-`, tools.UpperCamelCase(field.Name), field.Name, hintValue)
+`, formatFieldName(field.Name), field.Name, hintValue)
 	}
 
 	return fmt.Sprintf(`
@@ -288,7 +287,7 @@ dataqueryTypeHint = *resource.%[1]s.Type
 		}
 		resource.%[1]s = %[2]s
 	}
-`, tools.UpperCamelCase(field.Name), field.Name, hintValue)
+`, formatFieldName(field.Name), field.Name, hintValue)
 }
 
 func (jenny JSONMarshalling) renderPanelcfgVariantUnmarshal(schema *ast.Schema) (string, error) {

--- a/internal/jennies/golang/postprocessor.go
+++ b/internal/jennies/golang/postprocessor.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/imports"
 )
 
-func PostProcessFile(file codejen.File) (codejen.File, error) {
+func formatGoFiles(file codejen.File) (codejen.File, error) {
 	if !strings.HasSuffix(file.RelativePath, ".go") {
 		return file, nil
 	}

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -196,10 +196,10 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 	objectName := formatObjectName(objectRef.ReferredType)
 	referredPkg := jenny.packageMapper(objectRef.ReferredPkg)
 	if referredPkg != "" {
-		objectName = fmt.Sprintf("%s.%s", referredPkg, objectName)
+		objectName = referredPkg + "." + objectName
 	}
 
-	buffer.WriteString(fmt.Sprintf("%s{\n", objectName))
+	buffer.WriteString(objectName + "{\n")
 
 	extraDefaults := map[string]any{}
 	if val, ok := maybeExtraDefaults.(map[string]any); ok {
@@ -239,11 +239,11 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 				defaultValue = "&" + defaultValue
 			}
 		} else if field.Type.IsRef() && resolvedFieldType.IsStruct() {
-			defaultValue = fmt.Sprintf("New%s()", formatObjectName(field.Type.Ref.ReferredType))
+			defaultValue = "New" + formatObjectName(field.Type.Ref.ReferredType) + "()"
 
 			referredPkg = jenny.packageMapper(field.Type.Ref.ReferredPkg)
 			if referredPkg != "" {
-				defaultValue = fmt.Sprintf("%s.%s", referredPkg, defaultValue)
+				defaultValue = referredPkg + "." + defaultValue
 			}
 
 			if !field.Type.Nullable {
@@ -262,12 +262,12 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 
 			referredPkg = jenny.packageMapper(field.Type.Ref.ReferredPkg)
 			if referredPkg != "" {
-				defaultValue = fmt.Sprintf("%s.%s", referredPkg, defaultValue)
+				defaultValue = referredPkg + "." + defaultValue
 			}
 
 			if field.Type.Nullable {
 				jenny.packageMapper("cog")
-				defaultValue = fmt.Sprintf("cog.ToPtr(%s)", defaultValue)
+				defaultValue = "cog.ToPtr(" + defaultValue + ")"
 			}
 		} else {
 			defaultValue = "\"unsupported default value case: this is likely a bug in cog\""

--- a/internal/jennies/golang/strictjson.go
+++ b/internal/jennies/golang/strictjson.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type strictJSONUnmarshal struct {
@@ -62,7 +61,7 @@ func (jenny strictJSONUnmarshal) renderUnmarshal(context languages.Context, obj 
 			{Name: "raw", Type: "[]byte"},
 		},
 		Comments: []string{
-			fmt.Sprintf("UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `%s` from JSON.", tools.UpperCamelCase(obj.Name)),
+			fmt.Sprintf("UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `%s` from JSON.", formatObjectName(obj.Name)),
 			"Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …",
 		},
 		Return: "error",
@@ -82,7 +81,7 @@ func (jenny strictJSONUnmarshal) renderUnmarshal(context languages.Context, obj 
 			},
 		})
 
-	customUnmarshalTmpl := jenny.customObjectUnmarshalBlock(obj)
+	customUnmarshalTmpl := template.CustomObjectStrictUnmarshalBlock(obj)
 	if tmpl.Exists(customUnmarshalTmpl) {
 		return tmpl.Render(customUnmarshalTmpl, map[string]any{
 			"Object": obj,
@@ -105,8 +104,4 @@ func (jenny strictJSONUnmarshal) renderUnmarshal(context languages.Context, obj 
 	return jenny.tmpl.Render("types/struct.strict.json_unmarshal.tmpl", map[string]any{
 		"def": obj,
 	})
-}
-
-func (jenny strictJSONUnmarshal) customObjectUnmarshalBlock(obj ast.Object) string {
-	return fmt.Sprintf("object_%s_%s_custom_strict_unmarshal", obj.SelfRef.ReferredPkg, obj.SelfRef.ReferredType)
 }

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -95,7 +95,7 @@
         {{- range .Envelope.Values }}
         {{- $value := include "assignment_value" (dict "Assignment" $.Assignment "Value" .Value) }}
         {{- $value = maybeAsPointer (.Path.Last.Type) $value }}
-        {{ (index .Path 0).Identifier | upperCamelCase }}: {{ $value }},
+        {{ (index .Path 0).Identifier | formatFieldName }}: {{ $value }},
         {{- end }}
     }
 {{- end }}

--- a/internal/jennies/golang/templates/builders/options.tmpl
+++ b/internal/jennies/golang/templates/builders/options.tmpl
@@ -5,7 +5,7 @@
 {{- range .Comments }}
 // {{ . }}
 {{- end }}
-func (builder *{{ $builder.BuilderName }}Builder) {{ .Name|upperCamelCase }}({{- template "args" .Args }}) *{{ $builder.BuilderName }}Builder {
+func (builder *{{ $builder.BuilderName }}Builder) {{ .Name|formatFunctionName }}({{- template "args" .Args }}) *{{ $builder.BuilderName }}Builder {
     {{- range .Assignments }}
         {{- template "assignment" (dict "Assignment" . "Builder" $builder "Option" $option) }}
     {{- end }}

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -87,7 +87,7 @@ package {{ .Converter.Package | formatPackageName }}
     {{- $argsCount := sub1 (len .Args) -}}
     {{- with .ArgumentGuards -}}if {{ template "guards" . }} { {{- end }}
     {{- if and (eq (len .Guards) 0) (eq (len .ArgumentGuards) 0) -}} { {{- end }}
-    buffer.WriteString(`{{ .Option.Name | upperCamelCase }}(`)
+    buffer.WriteString(`{{ .Option.Name | formatFunctionName }}(`)
     {{- range $i, $arg := .Args }}
         {{- $intoVar := print "arg" $i }}
         {{ template "prepare_arg" (dict "IntoVar" $intoVar "Arg" $arg) }}
@@ -115,11 +115,11 @@ package {{ .Converter.Package | formatPackageName }}
 
 {{- define "converter" -}}
 {{- $reflect := importStdPkg "strings" -}}
-// {{ .Converter.BuilderName | upperCamelCase }}Converter accepts a `{{ .Converter.BuilderName | upperCamelCase }}` object and generates the Go code to build this object using builders.
-func {{ .Converter.BuilderName | upperCamelCase }}Converter(input {{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType  }}) string {
+// {{ .Converter.BuilderName | formatFunctionName }}Converter accepts a `{{ .Converter.BuilderName | formatObjectName }}` object and generates the Go code to build this object using builders.
+func {{ .Converter.BuilderName | formatFunctionName }}Converter(input {{ formatRawRef .Converter.Input.TypeRef.ReferredPkg .Converter.Input.TypeRef.ReferredType  }}) string {
     {{- $constructorArgsCount := sub1 (len .Converter.ConstructorArgs) }}
     calls := []string{
-    `{{ .Converter.Package | formatPackageName }}.New{{ .Converter.BuilderName | upperCamelCase }}Builder({{ with .Converter.ConstructorArgs}}`+{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} + ", " +{{ end }}{{ end }}+`{{ end }})`,
+    `{{ .Converter.Package | formatPackageName }}.New{{ .Converter.BuilderName | formatFunctionName }}Builder({{ with .Converter.ConstructorArgs}}`+{{ range $i, $arg := . }}{{- template "value_formatter" (dict "Type" $arg.ValueType "Path" $arg.ValuePath ) -}}{{- if ne $i $constructorArgsCount }} + ", " +{{ end }}{{ end }}+`{{ end }})`,
     }
     var buffer strings.Builder
 

--- a/internal/jennies/golang/templates/types/dataquery_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/dataquery_equality_method.tmpl
@@ -1,10 +1,10 @@
 // Equals tests the equality of two dataqueries.
-func (resource {{ .def.Name|upperCamelCase }}) Equals(otherCandidate variants.Dataquery) bool {
+func (resource {{ .def.Name|formatObjectName }}) Equals(otherCandidate variants.Dataquery) bool {
 	if otherCandidate == nil {
 		return false
 	}
 
-	other, ok := otherCandidate.({{ .def.Name|upperCamelCase }})
+	other, ok := otherCandidate.({{ .def.Name|formatObjectName }})
 	if !ok {
 		return false
 	}

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -1,10 +1,10 @@
 // MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|upperCamelCase }}` as JSON.
-func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
+func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $fmt := importStdPkg "fmt" -}}
 {{- range .def.Type.Struct.Fields }}
-	if resource.{{ .Name|upperCamelCase }} != nil {
-		return json.Marshal(resource.{{ .Name|upperCamelCase }})
+	if resource.{{ .Name|formatFieldName }} != nil {
+		return json.Marshal(resource.{{ .Name|formatFieldName }})
 	}
 {{- end }}
 

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -1,4 +1,4 @@
-// MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|upperCamelCase }}` as JSON.
+// MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
 func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $fmt := importStdPkg "fmt" -}}

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
@@ -1,8 +1,8 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $errors := importStdPkg "errors" -}}
 {{- $fmt := importStdPkg "fmt" -}}
-// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `{{ .def.Name|upperCamelCase }}` from JSON.
-func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
+func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) error {
 	if raw == nil {
 		return nil
 	}
@@ -25,12 +25,12 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error 
     {{- else }}
 	case "{{ $discriminatorValue }}":
 	{{- end }}
-		var {{ $typeName|lowerCamelCase }} {{ $typeName|upperCamelCase }}
-		if err := json.Unmarshal(raw, &{{ $typeName|lowerCamelCase }}); err != nil {
+		var {{ $typeName|formatVarName }} {{ $typeName|formatObjectName }}
+		if err := json.Unmarshal(raw, &{{ $typeName|formatVarName }}); err != nil {
 			return err
 		}
 
-		resource.{{ $typeName|upperCamelCase }} = &{{ $typeName|lowerCamelCase }}
+		resource.{{ $typeName|formatFieldName }} = &{{ $typeName|formatVarName }}
 		return nil
 {{- end }}
 	}

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.strict.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.strict.json_unmarshal.tmpl
@@ -1,8 +1,8 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $fmt := importStdPkg "fmt" -}}
-// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|upperCamelCase }}` from JSON.
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
-func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) error {
+func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSONStrict(raw []byte) error {
 	if raw == nil {
 		return nil
 	}
@@ -26,12 +26,12 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) 
 		{{- else }}
 		case "{{ $discriminatorValue }}":
 		{{- end }}
-		{{ $typeName|lowerCamelCase }} := &{{ $typeName|upperCamelCase }}{}
-		if err := {{ $typeName|lowerCamelCase }}.UnmarshalJSONStrict(raw); err != nil {
+		{{ $typeName|formatVarName }} := &{{ $typeName|formatObjectName }}{}
+		if err := {{ $typeName|formatVarName }}.UnmarshalJSONStrict(raw); err != nil {
 			return err
 		}
 
-		resource.{{ $typeName|upperCamelCase }} = {{ $typeName|lowerCamelCase }}
+		resource.{{ $typeName|formatFieldName }} = {{ $typeName|formatVarName }}
 		return nil
 	{{- end }}
 	}

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
@@ -1,10 +1,10 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $fmt := importStdPkg "fmt" -}}
-// MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|upperCamelCase }}` as JSON.
-func (resource {{ .def.Name|upperCamelCase }}) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
+func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- range .def.Type.Struct.Fields }}
-	if resource.{{ .Name|upperCamelCase }} != nil {
-		return json.Marshal(resource.{{ .Name|upperCamelCase }})
+	if resource.{{ .Name|formatFieldName }} != nil {
+		return json.Marshal(resource.{{ .Name|formatFieldName }})
 	}
 {{ end }}
 	return nil, fmt.Errorf("no value for disjunction of scalars")

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_unmarshal.tmpl
@@ -1,7 +1,7 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $errors := importStdPkg "errors" -}}
-// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `{{ .def.Name|upperCamelCase }}` from JSON.
-func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error {
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
+func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) error {
 	if raw == nil {
 		return nil
 	}
@@ -12,9 +12,9 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSON(raw []byte) error 
 	var {{ .Name }} {{ trimPrefix "*" (.Type | formatType) }}
 	if err := json.Unmarshal(raw, &{{ .Name }}); err != nil {
 		errList = append(errList, err)
-		resource.{{ .Name|upperCamelCase }} = nil
+		resource.{{ .Name|formatFieldName }} = nil
 	} else {
-		resource.{{ .Name|upperCamelCase }} = {{ if and (ne .Type.Kind "array") (ne .Type.Kind "map") }}&{{ end }}{{ .Name }}
+		resource.{{ .Name|formatFieldName }} = {{ if and (ne .Type.Kind "array") (ne .Type.Kind "map") }}&{{ end }}{{ .Name }}
 		return nil
 	}
 {{ end }}

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.strict.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.strict.json_unmarshal.tmpl
@@ -1,8 +1,8 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $errors := importStdPkg "errors" -}}
-// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|upperCamelCase }}` from JSON.
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
-func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) error {
+func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSONStrict(raw []byte) error {
 	if raw == nil {
 		return nil
 	}
@@ -17,13 +17,13 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) 
 	if err := json.Unmarshal(raw, &{{ .Name }}); err != nil {
 		errList = append(errList, err)
 	} else {
-		resource.{{ .Name|upperCamelCase }} = {{ if and (ne .Type.Kind "array") (ne .Type.Kind "map") }}&{{ end }}{{ .Name }}
+		resource.{{ .Name|formatFieldName }} = {{ if and (ne .Type.Kind "array") (ne .Type.Kind "map") }}&{{ end }}{{ .Name }}
 		return nil
 	}
 {{ end }}
 
 	if len(errList) != 0 {
-		errs = append(errs, cog.MakeBuildErrors("{{ .def.Name|upperCamelCase }}", errors.Join(errList...))...)
+		errs = append(errs, cog.MakeBuildErrors("{{ .def.Name }}", errors.Join(errList...))...)
 	}
 
 	if len(errs) == 0 {

--- a/internal/jennies/golang/templates/types/struct.strict.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/struct.strict.json_unmarshal.tmpl
@@ -1,7 +1,7 @@
 {{- $json := importStdPkg "encoding/json" -}}
-// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|upperCamelCase }}` from JSON.
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
-func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) error {
+func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSONStrict(raw []byte) error {
 	if raw == nil {
 		return nil
 	}
@@ -22,7 +22,7 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) 
 		{{ include $customFieldBlockName (dict "Object" $.def "Field" $field) }}
 	{{- else }}
 	{{- $inputRef := print "fields[" ($field.Name|formatScalar) "]" }}
-	{{- $unmarshalInto := print "resource." ($field.Name|upperCamelCase) }}
+	{{- $unmarshalInto := print "resource." ($field.Name|formatFieldName) }}
 			{{ template "strict_unmarshal_field_type" (dict "RawInputRef" $inputRef "InputType" $field.Type "UnmarshalInto" $unmarshalInto "ErrorBreadcrumb" $field.Name "Depth" 1) }}
 	{{- end }}
 		{{ if and $field.Required (not $field.Type.Nullable) -}} } else {
@@ -40,7 +40,7 @@ func (resource *{{ .def.Name|upperCamelCase }}) UnmarshalJSONStrict(raw []byte) 
 
 	{{ $fmt := importStdPkg "fmt" -}}
 	for field := range fields {
-		errs = append(errs, cog.MakeBuildErrors("{{ .def.Name|upperCamelCase }}", fmt.Errorf("unexpected field '%s'", field))...)
+		errs = append(errs, cog.MakeBuildErrors("{{ .def.Name|formatObjectName }}", fmt.Errorf("unexpected field '%s'", field))...)
 	}
 
 	if len(errs) == 0 {

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -1,5 +1,5 @@
-// Equals tests the equality of two `{{ .def.Name|upperCamelCase }}` objects.
-func (resource {{ .def.Name|upperCamelCase }}) Equals(other {{ .def.Name|upperCamelCase }}) bool {
+// Equals tests the equality of two `{{ .def.Name|formatObjectName }}` objects.
+func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|formatObjectName }}) bool {
 	{{- template "type_equality_check" (dict "Type" .def.Type "Nullable" .def.Type.Nullable "Dereference" false "SelfName" "resource" "OtherName" "other" "Depth" 0) }}
 
 	return true
@@ -68,7 +68,7 @@ func (resource {{ .def.Name|upperCamelCase }}) Equals(other {{ .def.Name|upperCa
 		}
 	{{- else if .Type.IsStruct }}
 		{{- range $field := .Type.Struct.Fields }}
-			{{- $fieldName := $field.Name|upperCamelCase -}}
+			{{- $fieldName := $field.Name|formatFieldName -}}
 			{{- $selfKey := print $.SelfName "." $fieldName }}
 			{{- $otherKey := print $.OtherName "." $fieldName }}
 

--- a/internal/jennies/golang/templates/types/struct_validation_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_validation_method.tmpl
@@ -1,5 +1,5 @@
-// Validate checks all the validation constraints that may be defined on `{{ .def.Name|upperCamelCase }}` fields for violations and returns them.
-func (resource {{ .def.Name|upperCamelCase }}) Validate() error {
+// Validate checks all the validation constraints that may be defined on `{{ .def.Name|formatObjectName }}` fields for violations and returns them.
+func (resource {{ .def.Name|formatObjectName }}) Validate() error {
 	{{- if resolvesToConstraints .def.Type }}
 	{{- $cog := importPkg "cog" }}
 	var errs cog.BuildErrors
@@ -60,7 +60,7 @@ func (resource {{ .def.Name|upperCamelCase }}) Validate() error {
 	{{- else if .Type.IsStruct }}
 		{{- range $field := .Type.Struct.Fields }}
 			{{- if resolvesToConstraints $field.Type -}}
-				{{- $fieldName := $field.Name|upperCamelCase -}}
+				{{- $fieldName := $field.Name|formatFieldName -}}
 				{{- $selfKey := print $.SelfName "." $fieldName }}
 				{{- $constraintPath := $field.Name }}
 				{{- if ne $.ConstraintPath "" -}}

--- a/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/variant_dataquery.json_unmarshal.tmpl
@@ -5,7 +5,7 @@ func VariantConfig() variants.DataqueryConfig {
 	return variants.DataqueryConfig{
 		Identifier: "{{ .schema.Metadata.Identifier|lower }}",
 	    DataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
-            dataquery := &{{ .object.Name|upperCamelCase }}{}
+            dataquery := &{{ .object.Name|formatObjectName }}{}
 
             if err := json.Unmarshal(raw, dataquery); err != nil {
                 return nil, err
@@ -14,7 +14,7 @@ func VariantConfig() variants.DataqueryConfig {
             return dataquery, nil
        },
 	    StrictDataqueryUnmarshaler: func (raw []byte) (variants.Dataquery, error) {
-            dataquery := &{{ .object.Name|upperCamelCase }}{}
+            dataquery := &{{ .object.Name|formatObjectName }}{}
 
             if err := dataquery.UnmarshalJSONStrict(raw); err != nil {
                 return nil, err
@@ -24,22 +24,22 @@ func VariantConfig() variants.DataqueryConfig {
        },
         {{- if .hasConverter }}
         GoConverter: func(input any) string {
-            var dataquery {{ .object.Name | upperCamelCase }}
-            if cast, ok := input.(*{{ .object.Name | upperCamelCase }}); ok {
+            var dataquery {{ .object.Name|formatObjectName }}
+            if cast, ok := input.(*{{ .object.Name|formatObjectName }}); ok {
                 dataquery = *cast
             } else {
-                dataquery = input.({{ .object.Name | upperCamelCase }})
+                dataquery = input.({{ .object.Name|formatObjectName }})
             }
             {{ if ne .disjunctionStruct nil -}}
                 {{- range $field := .disjunctionStruct.Fields }}
-                    if dataquery.{{ $field.Name | upperCamelCase }} != nil {
-                        return {{ $field.Type.Ref.ReferredType | upperCamelCase }}Converter(*dataquery.{{ $field.Name | upperCamelCase }})
+                    if dataquery.{{ $field.Name|formatFieldName }} != nil {
+                        return {{ $field.Type.Ref.ReferredType|formatObjectName }}Converter(*dataquery.{{ $field.Name|formatFieldName }})
                     }
                 {{- end }}
 
                 return ""
             {{- else -}}
-                return {{ .object.Name | upperCamelCase }}Converter(dataquery)
+                return {{ .object.Name|formatObjectName }}Converter(dataquery)
             {{- end }}
         },
         {{- end }}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -64,8 +64,10 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 		template.Funcs(map[string]any{
 			"formatPackageName": formatPackageName,
 			"formatObjectName":  formatObjectName,
-			"formatScalar":      formatScalar,
+			"formatFieldName":   formatFieldName,
 			"formatArgName":     formatArgName,
+			"formatVarName":     formatVarName,
+			"formatScalar":      formatScalar,
 			"maybeAsPointer": func(intoType ast.Type, variableName string) string {
 				if intoType.Nullable && !(intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot()) {
 					return "&" + variableName

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -62,12 +62,13 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			},
 		}),
 		template.Funcs(map[string]any{
-			"formatPackageName": formatPackageName,
-			"formatObjectName":  formatObjectName,
-			"formatFieldName":   formatFieldName,
-			"formatArgName":     formatArgName,
-			"formatVarName":     formatVarName,
-			"formatScalar":      formatScalar,
+			"formatPackageName":  formatPackageName,
+			"formatObjectName":   formatObjectName,
+			"formatFieldName":    formatFieldName,
+			"formatArgName":      formatArgName,
+			"formatVarName":      formatVarName,
+			"formatFunctionName": formatFunctionName,
+			"formatScalar":       formatScalar,
 			"maybeAsPointer": func(intoType ast.Type, variableName string) string {
 				if intoType.Nullable && !(intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot()) {
 					return "&" + variableName

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -17,11 +17,19 @@ func formatPackageName(pkg string) string {
 	return strings.ToLower(rgx.ReplaceAllString(pkg, ""))
 }
 
+func formatFileName(name string) string {
+	return strings.ToLower(name)
+}
+
 func formatArgName(name string) string {
 	return escapeVarName(tools.LowerCamelCase(name))
 }
 
 func formatObjectName(name string) string {
+	return tools.UpperCamelCase(name)
+}
+
+func formatFunctionName(name string) string {
 	return tools.UpperCamelCase(name)
 }
 

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -25,6 +25,10 @@ func formatArgName(name string) string {
 	return escapeVarName(tools.LowerCamelCase(name))
 }
 
+func formatVarName(name string) string {
+	return escapeVarName(tools.LowerCamelCase(name))
+}
+
 func formatObjectName(name string) string {
 	return tools.UpperCamelCase(name)
 }

--- a/internal/jennies/golang/validation.go
+++ b/internal/jennies/golang/validation.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
-	"github.com/grafana/cog/internal/tools"
 )
 
 type validationMethods struct {
@@ -86,7 +85,7 @@ func (jenny validationMethods) generateForObject(buffer *strings.Builder, contex
 	jenny.apiRefCollector.ObjectMethod(object, common.MethodReference{
 		Name: "Validate",
 		Comments: []string{
-			fmt.Sprintf("Validate checks all the validation constraints that may be defined on `%s` fields for violations and returns them.", tools.UpperCamelCase(object.Name)),
+			fmt.Sprintf("Validate checks all the validation constraints that may be defined on `%s` fields for violations and returns them.", formatObjectName(object.Name)),
 		},
 		Return: "error",
 	})

--- a/internal/jennies/template/blocks.go
+++ b/internal/jennies/template/blocks.go
@@ -10,6 +10,10 @@ func CustomObjectUnmarshalBlock(obj ast.Object) string {
 	return fmt.Sprintf("object_%s_%s_custom_unmarshal", obj.SelfRef.ReferredPkg, obj.SelfRef.ReferredType)
 }
 
+func CustomObjectStrictUnmarshalBlock(obj ast.Object) string {
+	return fmt.Sprintf("object_%s_%s_custom_strict_unmarshal", obj.SelfRef.ReferredPkg, obj.SelfRef.ReferredType)
+}
+
 func ExtraPackageDocsBlock(schema *ast.Schema) string {
 	return fmt.Sprintf("api_reference_package_%s_extra", schema.Package)
 }


### PR DESCRIPTION
Use `format*()` functions to consistently format object/variable/field names across Go jennies and templates.