### PR TITLE
Add a page dedicated to examples in the Foundation SDK docs

### DIFF
--- a/package_templates/go/docs/Examples.md
+++ b/package_templates/go/docs/Examples.md
@@ -1,0 +1,32 @@
+---
+weight: 10
+---
+# Examples
+
+A collection of sample Grafana dashboards written in Go is available in the [grafana/grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk/) repository.
+
+Each example showcases different aspects of building dashboards as code:
+
+* [`custom-panel`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/go/custom-panel): definition and usage of a _custom_ Panel type
+* [`custom-query`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/go/custom-query): definition and usage of a _custom_ Query type
+* [`grafana-agent-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/go/grafana-agent-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Grafana Agent integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-grafana-agent/)
+      available in Grafana Cloud.
+    * dashboard variables
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`linux-node-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/go/linux-node-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Linux Server integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-linux-node/#dashboards)
+      available in Grafana Cloud.
+    * dashboard variables
+    * dashboard links
+    * `stat` panels
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`red-method`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/go/red-method):
+    * example of a dashboard following
+      the [RED method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/#the-red-method)

--- a/package_templates/java/docs/Examples.md
+++ b/package_templates/java/docs/Examples.md
@@ -1,0 +1,32 @@
+---
+weight: 10
+---
+# Examples
+
+A collection of sample Grafana dashboards written in Java is available in the [grafana/grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk/) repository.
+
+Each example showcases different aspects of building dashboards as code:
+
+* [`custom-panel`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/java/custom-panel): definition and usage of a _custom_ Panel type
+* [`custom-query`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/java/custom-query): definition and usage of a _custom_ Query type
+* [`grafana-agent-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/java/grafana-agent-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Grafana Agent integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-grafana-agent/)
+      available in Grafana Cloud.
+    * dashboard variables
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`linux-node-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/java/linux-node-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Linux Server integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-linux-node/#dashboards)
+      available in Grafana Cloud.
+    * dashboard variables
+    * dashboard links
+    * `stat` panels
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`red-method`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/java/red-method):
+    * example of a dashboard following
+      the [RED method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/#the-red-method)

--- a/package_templates/php/docs/Examples.md
+++ b/package_templates/php/docs/Examples.md
@@ -1,0 +1,32 @@
+---
+weight: 10
+---
+# Examples
+
+A collection of sample Grafana dashboards written in PHP is available in the [grafana/grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk/) repository.
+
+Each example showcases different aspects of building dashboards as code:
+
+* [`custom-panel`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/php/custom-panel): definition and usage of a _custom_ Panel type
+* [`custom-query`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/php/custom-query): definition and usage of a _custom_ Query type
+* [`grafana-agent-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/php/grafana-agent-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Grafana Agent integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-grafana-agent/)
+      available in Grafana Cloud.
+    * dashboard variables
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`linux-node-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/php/linux-node-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Linux Server integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-linux-node/#dashboards)
+      available in Grafana Cloud.
+    * dashboard variables
+    * dashboard links
+    * `stat` panels
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`red-method`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/php/red-method):
+    * example of a dashboard following
+      the [RED method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/#the-red-method)

--- a/package_templates/python/docs/Examples.md
+++ b/package_templates/python/docs/Examples.md
@@ -1,0 +1,32 @@
+---
+weight: 10
+---
+# Examples
+
+A collection of sample Grafana dashboards written in Python is available in the [grafana/grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk/) repository.
+
+Each example showcases different aspects of building dashboards as code:
+
+* [`custom-panel`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/python/custom-panel): definition and usage of a _custom_ Panel type
+* [`custom-query`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/python/custom-query): definition and usage of a _custom_ Query type
+* [`grafana-agent-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/python/grafana-agent-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Grafana Agent integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-grafana-agent/)
+      available in Grafana Cloud.
+    * dashboard variables
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`linux-node-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/python/linux-node-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Linux Server integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-linux-node/#dashboards)
+      available in Grafana Cloud.
+    * dashboard variables
+    * dashboard links
+    * `stat` panels
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`red-method`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/python/red-method):
+    * example of a dashboard following
+      the [RED method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/#the-red-method)

--- a/package_templates/typescript/docs/Examples.md
+++ b/package_templates/typescript/docs/Examples.md
@@ -1,0 +1,32 @@
+---
+weight: 10
+---
+# Examples
+
+A collection of sample Grafana dashboards written in TypeScript is available in the [grafana/grafana-foundation-sdk](https://github.com/grafana/grafana-foundation-sdk/) repository.
+
+Each example showcases different aspects of building dashboards as code:
+
+* [`custom-panel`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/typescript/custom-panel): definition and usage of a _custom_ Panel type
+* [`custom-query`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/typescript/custom-query): definition and usage of a _custom_ Query type
+* [`grafana-agent-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/typescript/grafana-agent-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Grafana Agent integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-grafana-agent/)
+      available in Grafana Cloud.
+    * dashboard variables
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`linux-node-overview`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/typescript/linux-node-overview):
+    * reproduction of the "Grafana Agent Overview" dashboard from
+      the [Linux Server integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-linux-node/#dashboards)
+      available in Grafana Cloud.
+    * dashboard variables
+    * dashboard links
+    * `stat` panels
+    * `table` panels
+    * `timeseries` panels
+    * `prometheus` queries
+* [`red-method`](https://github.com/grafana/grafana-foundation-sdk/blob/main/examples/typescript/red-method):
+    * example of a dashboard following
+      the [RED method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/#the-red-method)


### PR DESCRIPTION
To make these examples discoverable from the Foundation SDK website as well.