### PR TITLE
Java: Fix deserializers NPE

### DIFF
--- a/internal/jennies/java/builders.go
+++ b/internal/jennies/java/builders.go
@@ -55,7 +55,7 @@ func (b Builders) genBuilders(pkg string, name string) ([]Builder, bool) {
 			Package:              b.typeFormatter.formatPackage(pkg),
 			ObjectName:           tools.UpperCamelCase(object.Name),
 			BuilderName:          builder.Name,
-			BuilderSignatureType: b.getBuilderSignature(builder, object),
+			BuilderSignatureType: b.getBuilderSignature(object),
 			Constructor:          builder.Constructor,
 			Options:              builder.Options,
 			Properties:           builder.Properties,
@@ -89,12 +89,12 @@ func (b Builders) getBuilders(pkg string, name string) ast.Builders {
 	return builderMap[name]
 }
 
-func (b Builders) getBuilderSignature(builder ast.Builder, obj ast.Object) string {
-	if builder.Name != obj.Type.ImplementedVariant() {
+func (b Builders) getBuilderSignature(obj ast.Object) string {
+	if !obj.Type.IsDataqueryVariant() {
 		return obj.Name
 	}
 
-	return fmt.Sprintf("%s.%s", b.typeFormatter.formatPackage("cog.variants"), tools.UpperCamelCase(obj.Name))
+	return fmt.Sprintf("%s.%s", b.typeFormatter.formatPackage("cog.variants"), tools.UpperCamelCase(obj.Type.ImplementedVariant()))
 }
 
 func (b Builders) genDefaults(options []ast.Option) []OptionCall {

--- a/internal/jennies/java/templates/marshalling/unmarshalling.tmpl
+++ b/internal/jennies/java/templates/marshalling/unmarshalling.tmpl
@@ -76,20 +76,22 @@ public class {{ .Name }}Deserializer extends JsonDeserializer<{{ .Name }}> {
        
        {{- if .IsArray }}
        List<Dataquery> targets = new ArrayList<>();
-       for (JsonNode node : root.get({{ printf "%#v" .FieldName }})) {
-            Class<? extends Dataquery> clazz = Registry.getDataquery(datasourceType);
-            if (clazz != null) {
-                Dataquery dataquery = mapper.treeToValue(node, clazz);
-                {{ .FieldName | lowerCamelCase}}.add(dataquery);
-            } else {
-              UnknownDataquery unknownDataquery = new UnknownDataquery();
-              Iterator<Map.Entry<String, JsonNode>> fieldsIterator = node.fields();
-              while (fieldsIterator.hasNext()) {
-                  Map.Entry<String, JsonNode> field = fieldsIterator.next();
-                  unknownDataquery.genericFields.put(field.getKey(), mapper.treeToValue(field.getValue(), Object.class));
-              }
-              {{ .FieldName | lowerCamelCase}}.add(unknownDataquery);
-            }
+       if (root.has({{ printf "%#v" .FieldName }})) {
+           for (JsonNode node : root.get({{ printf "%#v" .FieldName }})) {
+                Class<? extends Dataquery> clazz = Registry.getDataquery(datasourceType);
+                if (clazz != null) {
+                    Dataquery dataquery = mapper.treeToValue(node, clazz);
+                    {{ .FieldName | lowerCamelCase}}.add(dataquery);
+                } else {
+                  UnknownDataquery unknownDataquery = new UnknownDataquery();
+                  Iterator<Map.Entry<String, JsonNode>> fieldsIterator = node.fields();
+                  while (fieldsIterator.hasNext()) {
+                      Map.Entry<String, JsonNode> field = fieldsIterator.next();
+                      unknownDataquery.genericFields.put(field.getKey(), mapper.treeToValue(field.getValue(), Object.class));
+                  }
+                  {{ .FieldName | lowerCamelCase}}.add(unknownDataquery);
+                }
+          }
       }
       {{ $.Name | lowerCamelCase }}.{{ .FieldName }} = targets;
       {{- else }}

--- a/internal/jennies/java/templates/runtime/registry.tmpl
+++ b/internal/jennies/java/templates/runtime/registry.tmpl
@@ -23,7 +23,12 @@ public class Registry {
     }
 
     public static Class<? extends Dataquery> getDataquery(String type) {
-        return dataqueryRegistry.get(type).getDataquery();
+        DataqueryConfig config = dataqueryRegistry.get(type);
+        if (config != null) {
+            return config.getDataquery();
+        }
+
+        return null;
     }
     
     public static void registerPanel(String type, Class<?> options, Class<?> fieldConfig) {

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilders/dataquery_variant_builder/Loki.java
@@ -18,7 +18,7 @@ public class Loki implements cog.variants.Dataquery {
     }
 
     
-    public static class Builder implements cog.Builder<Loki> {
+    public static class Builder implements cog.Builder<cog.variants.Dataquery> {
         protected final Loki internal;
         
         public Builder() {


### PR DESCRIPTION
It adds null checks for deserialiser templates. The code was assuming that `targets` in panels always exist and Registry wasn't checking that DataqueryConfig could be null too.

Apart of this, I found that some dataquery Builders type was using the class name instead the Dataquery interface. So some of them couldn't be used. I add this fix in this PR because its a small change...

To give you a bit of context: If we have a class `Builder<MyDataquery>` and `MyDataquery` implements `Dataquery` interface, Java doesn't detect it 🤡. So we cannot use it `withTarget` function.