### PR TITLE
Support fine-grained configuration of Validate()/Equal()/UnmarshalJSO…

### DIFF
--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -97,6 +97,9 @@ output:
         package_root: '%go_package_root%'
         builder_templates:
           - '%__config_dir%/templates/go'
+        generate_strict_unmarshaller: true
+        generate_equal: true
+        generate_validate: true
     - jsonschema: {}
     - openapi: {}
     - php:

--- a/config/foundation_sdk.tests.yaml
+++ b/config/foundation_sdk.tests.yaml
@@ -22,3 +22,6 @@ output:
   languages:
     - go:
         package_root: '%go_package_root%'
+        generate_strict_unmarshaller: true
+        generate_equal: true
+        generate_validate: true

--- a/config/foundation_sdk.yaml
+++ b/config/foundation_sdk.yaml
@@ -100,6 +100,9 @@ output:
         package_root: '%go_package_root%'
         builder_templates:
           - '%__config_dir%/templates/go'
+        generate_strict_unmarshaller: true
+        generate_equal: true
+        generate_validate: true
     - jsonschema: {}
     - openapi: {}
     - php:

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -23,6 +23,16 @@ type Config struct {
 	// If enabled, PackageRoot is used as module path.
 	GenerateGoMod bool `yaml:"go_mod"`
 
+	// GenerateStrictUnmarshaller controls the generation of
+	// `UnmarshalJSONStrict()` methods on types.
+	GenerateStrictUnmarshaller bool `yaml:"generate_strict_unmarshaller"`
+
+	// GenerateEqual controls the generation of `Equal()` methods on types.
+	GenerateEqual bool `yaml:"generate_equal"`
+
+	// GenerateValidate controls the generation of `Validate()` methods on types.
+	GenerateValidate bool `yaml:"generate_validate"`
+
 	// SkipRuntime disables runtime-related code generation when enabled.
 	// Note: builders can NOT be generated with this flag turned on, as they
 	// rely on the runtime to function.

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -76,22 +76,28 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 			return
 		}
 
-		innerErr = strictUnmarshallerGenerator.generateForObject(&buffer, context, object)
-		if innerErr != nil {
-			err = innerErr
-			return
+		if !jenny.Config.SkipRuntime && jenny.Config.GenerateStrictUnmarshaller {
+			innerErr = strictUnmarshallerGenerator.generateForObject(&buffer, context, object)
+			if innerErr != nil {
+				err = innerErr
+				return
+			}
 		}
 
-		innerErr = equalityMethodsGenerator.generateForObject(&buffer, context, object, imports)
-		if innerErr != nil {
-			err = innerErr
-			return
+		if jenny.Config.GenerateEqual {
+			innerErr = equalityMethodsGenerator.generateForObject(&buffer, context, object, imports)
+			if innerErr != nil {
+				err = innerErr
+				return
+			}
 		}
 
-		innerErr = validationMethodsGenerator.generateForObject(&buffer, context, object, imports)
-		if innerErr != nil {
-			err = innerErr
-			return
+		if !jenny.Config.SkipRuntime && (jenny.Config.generateBuilders || jenny.Config.GenerateValidate) {
+			innerErr = validationMethodsGenerator.generateForObject(&buffer, context, object, imports)
+			if innerErr != nil {
+				err = innerErr
+				return
+			}
 		}
 	})
 	if err != nil {

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -17,7 +17,10 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	config := Config{
-		PackageRoot: "github.com/grafana/cog/generated",
+		PackageRoot:                "github.com/grafana/cog/generated",
+		GenerateEqual:              true,
+		GenerateStrictUnmarshaller: true,
+		GenerateValidate:           true,
 	}
 	jenny := RawTypes{
 		Config:          config,

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -208,6 +208,9 @@
         "converters": {
           "type": "boolean"
         },
+        "api_reference": {
+          "type": "boolean"
+        },
         "languages": {
           "items": {
             "$ref": "#/$defs/CodegenOutputLanguage"
@@ -312,6 +315,18 @@
         "go_mod": {
           "type": "boolean",
           "description": "GenerateGoMod indicates whether a go.mod file should be generated.\nIf enabled, PackageRoot is used as module path."
+        },
+        "generate_strict_unmarshaller": {
+          "type": "boolean",
+          "description": "GenerateStrictUnmarshaller controls the generation of\n`UnmarshalJSONStrict()` methods on types."
+        },
+        "generate_equal": {
+          "type": "boolean",
+          "description": "GenerateEqual controls the generation of `Equal()` methods on types."
+        },
+        "generate_validate": {
+          "type": "boolean",
+          "description": "GenerateValidate controls the generation of `Validate()` methods on types."
         },
         "skip_runtime": {
           "type": "boolean",


### PR DESCRIPTION
…NStrict() functions generation in Go

Since cog is going to be used in more contexts than just to generate the Foundation SDK, it now makes sense to be able to configure exactly what should be generated.

Starting with Go and its `Validate()`, `Equal()` and `UnmarshalJSONStrict()` functions on types.

**Question:** how do we want to handle this type of configuration?
Do we prefer having to explicitly enable these features (like this PR does, and like the `GenerateGoMod` option), or explicitly disable them? (see the `SkipRuntime` option)