### PR TITLE
Ignore new dependecy updates for cuelang

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "cuelang.org/go"  # Schema are fixed to 0.8.0 and newer version includes breaking changes.


### PR DESCRIPTION
We don't want updates from cuelang since everything is fixed to `0.8.0` in Grafana.