### PR TITLE
Support user-defined packages mapping in TS

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -166,7 +166,7 @@ func (pipeline *SchemaToTypesPipeline) SchemaTransformations(passes ...compiler.
 // GoConfig defines a set of configuration options specific to Go outputs.
 type GoConfig struct {
 	// GenerateEqual controls the generation of `Equal()` methods on types.
-	GenerateEqual bool `yaml:"generate_equal"`
+	GenerateEqual bool
 }
 
 // Golang sets the output to Golang types.
@@ -184,15 +184,17 @@ func (pipeline *SchemaToTypesPipeline) Golang(config GoConfig) *SchemaToTypesPip
 
 // TypescriptConfig defines a set of configuration options specific to Go outputs.
 type TypescriptConfig struct {
-	// placeholder: to be able to define options later without breaking the API.
+	// ImportsMap associates package names to their import path.
+	ImportsMap map[string]string
 }
 
 // Typescript sets the output to Typescript types.
 func (pipeline *SchemaToTypesPipeline) Typescript(config TypescriptConfig) *SchemaToTypesPipeline {
 	pipeline.output = &codegen.OutputLanguage{
 		Typescript: &typescript.Config{
-			SkipRuntime: true,
-			SkipIndex:   true,
+			SkipRuntime:       true,
+			SkipIndex:         true,
+			PackagesImportMap: config.ImportsMap,
 		},
 	}
 	return pipeline

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Builder struct {
+	config          Config
 	tmpl            *template.Template
 	apiRefCollector *common.APIReferenceCollector
 
@@ -52,7 +53,7 @@ func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error)
 }
 
 func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
-	jenny.imports = NewImportMap()
+	jenny.imports = NewImportMap(jenny.config.PackagesImportMap)
 	jenny.imports.Add("cog", "../cog")
 	jenny.typeImportMapper = func(pkg string) string {
 		return jenny.imports.Add(pkg, fmt.Sprintf("../%s", pkg))

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -18,8 +18,10 @@ func TestBuilder_Generate(t *testing.T) {
 		},
 	}
 
-	language := New(Config{})
+	config := Config{}
+	language := New(config)
 	jenny := Builder{
+		config:          config,
 		tmpl:            initTemplates([]string{}),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}

--- a/internal/jennies/typescript/imports.go
+++ b/internal/jennies/typescript/imports.go
@@ -8,8 +8,9 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
-func NewImportMap() *common.DirectImportMap {
+func NewImportMap(packagesImportMap map[string]string) *common.DirectImportMap {
 	return common.NewDirectImportMap(
+		common.WithPackagesImportMap[common.DirectImportMap](packagesImportMap),
 		common.WithAliasSanitizer[common.DirectImportMap](formatPackageName),
 		common.WithImportPathSanitizer[common.DirectImportMap](func(importPath string) string {
 			parts := strings.Split(importPath, "/")

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -17,6 +17,7 @@ type raw string
 type pkgMapper func(string) string
 
 type RawTypes struct {
+	config        Config
 	typeFormatter *typeFormatter
 	schemas       ast.Schemas
 }
@@ -51,7 +52,7 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 	var buffer strings.Builder
 	var err error
 
-	imports := NewImportMap()
+	imports := NewImportMap(jenny.config.PackagesImportMap)
 	packageMapper := func(pkg string) string {
 		if imports.IsIdentical(pkg, schema.Package) {
 			return ""

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -15,8 +15,9 @@ func TestRawTypes_Generate(t *testing.T) {
 		Name:         "TypescriptRawTypes",
 	}
 
-	jenny := RawTypes{}
-	compilerPasses := New(Config{}).CompilerPasses()
+	config := Config{}
+	jenny := RawTypes{config: config}
+	compilerPasses := New(config).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -443,6 +443,13 @@
           },
           "type": "array",
           "description": "BuilderTemplatesDirectories holds a list of directories containing templates\nto be used to override parts of builders."
+        },
+        "packages_import_map": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "PackagesImportMap associates package names to their import path."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This is especially useful when generating code for a single schema that happens to have a dependency (ie: an import statement) on another, which is already generated.

Example:

```go
package main

import (
    "context"
    "os"

    "github.com/grafana/cog"
)

type codegenTargets struct {
    modulePath        string
    outputPath        string
    cueImportsMap     map[string]string
    packagesImportMap map[string]string
}

func main() {
    targets := []codegenTargets{
        {
            modulePath: "../packages/grafana-schema/src/schema/dashboard/v2alpha0/",
            outputPath: "../packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.gen.ts",
            cueImportsMap: map[string]string{
                "github.com/grafana/grafana/packages/grafana-schema/src/common": "../packages/grafana-schema/src/common",
            },
            packagesImportMap: map[string]string{
                "common": "@grafana/schema",
            },
        },
    }

    for _, target := range targets {
        codegenPipeline := cog.TypesFromSchema().
            CUEModule(
                target.modulePath,
                cog.CUEImports(target.cueImportsMap),
            ).
            Typescript(cog.TypescriptConfig{
                ImportsMap: target.packagesImportMap,
            })

        files, err := codegenPipeline.Run(context.Background())
        if err != nil {
            panic(err)
        }

        if err := os.WriteFile(target.outputPath, files[0].Data, 0644); err != nil {
            panic(err)
        }
    }
}
```

Note: we should support something similar for other languages too.