### PR TITLE
Support customizing how enums should be generated in Typescript

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -186,6 +186,23 @@ func (pipeline *SchemaToTypesPipeline) Golang(config GoConfig) *SchemaToTypesPip
 type TypescriptConfig struct {
 	// ImportsMap associates package names to their import path.
 	ImportsMap map[string]string
+
+	// EnumsAsUnionTypes generates enums as a union of values instead of using
+	// an actual `enum` declaration.
+	// If EnumsAsUnionTypes is false, an enum will be generated as:
+	// ```ts
+	// enum Direction {
+	//   Up = "up",
+	//   Down = "down",
+	//   Left = "left",
+	//   Right = "right",
+	// }
+	// ```
+	// If EnumsAsUnionTypes is true, the same enum will be generated as:
+	// ```ts
+	// type Direction = "up" | "down" | "left" | "right";
+	// ```
+	EnumsAsUnionTypes bool `yaml:"enums_as_union_types"`
 }
 
 // Typescript sets the output to Typescript types.
@@ -195,6 +212,7 @@ func (pipeline *SchemaToTypesPipeline) Typescript(config TypescriptConfig) *Sche
 			SkipRuntime:       true,
 			SkipIndex:         true,
 			PackagesImportMap: config.ImportsMap,
+			EnumsAsUnionTypes: config.EnumsAsUnionTypes,
 		},
 	}
 	return pipeline

--- a/internal/jennies/typescript/apiref.go
+++ b/internal/jennies/typescript/apiref.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/cog/internal/tools"
 )
 
-func apiReferenceFormatter() common.APIReferenceFormatter {
+func apiReferenceFormatter(config Config) common.APIReferenceFormatter {
 	return common.APIReferenceFormatter{
 		KindName: func(kind ast.Kind) string {
 			if kind == ast.KindStruct {
@@ -31,7 +31,7 @@ func apiReferenceFormatter() common.APIReferenceFormatter {
 			return tools.CleanupNames(object.Name)
 		},
 		ObjectDefinition: func(context languages.Context, object ast.Object) string {
-			typesFormatter := defaultTypeFormatter(context, func(pkg string) string {
+			typesFormatter := defaultTypeFormatter(config, context, func(pkg string) string {
 				return pkg
 			})
 
@@ -53,7 +53,7 @@ func apiReferenceFormatter() common.APIReferenceFormatter {
 			return tools.UpperCamelCase(builder.Name) + "Builder"
 		},
 		ConstructorSignature: func(context languages.Context, builder ast.Builder) string {
-			typesFormatter := builderTypeFormatter(context, func(pkg string) string {
+			typesFormatter := builderTypeFormatter(config, context, func(pkg string) string {
 				return pkg
 			})
 			args := tools.Map(builder.Constructor.Args, func(arg ast.Argument) string {
@@ -66,7 +66,7 @@ func apiReferenceFormatter() common.APIReferenceFormatter {
 			return formatIdentifier(option.Name)
 		},
 		OptionSignature: func(context languages.Context, builder ast.Builder, option ast.Option) string {
-			typesFormatter := builderTypeFormatter(context, func(pkg string) string {
+			typesFormatter := builderTypeFormatter(config, context, func(pkg string) string {
 				return pkg
 			})
 

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -58,7 +58,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 	jenny.typeImportMapper = func(pkg string) string {
 		return jenny.imports.Add(pkg, fmt.Sprintf("../%s", pkg))
 	}
-	jenny.typeFormatter = builderTypeFormatter(context, jenny.typeImportMapper)
+	jenny.typeFormatter = builderTypeFormatter(jenny.config, context, jenny.typeImportMapper)
 
 	buildObjectSignature := formatPackageName(builder.For.SelfRef.ReferredPkg) + "." + tools.CleanupNames(builder.For.Name)
 	if builder.For.Type.ImplementsVariant() {
@@ -89,7 +89,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 				if destinationType.IsRef() {
 					referredObj, found := context.LocateObject(destinationType.AsRef().ReferredPkg, destinationType.AsRef().ReferredType)
 					if found && referredObj.Type.IsEnum() {
-						return jenny.typeFormatter.formatEnumValue(referredObj, value)
+						return jenny.typeFormatter.enums.formatValue(referredObj, value)
 					}
 				}
 

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -450,6 +450,10 @@
           },
           "type": "object",
           "description": "PackagesImportMap associates package names to their import path."
+        },
+        "enums_as_union_types": {
+          "type": "boolean",
+          "description": "EnumsAsUnionTypes generates enums as a union of values instead of using\nan actual `enum` declaration.\nIf EnumsAsUnionTypes is false, an enum will be generated as:\n```ts\nenum Direction {\n  Up = \"up\",\n  Down = \"down\",\n  Left = \"left\",\n  Right = \"right\",\n}\n```\nIf EnumsAsUnionTypes is true, the same enum will be generated as:\n```ts\ntype Direction = \"up\" | \"down\" | \"left\" | \"right\";\n```"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
A `EnumsAsUnionTypes` configuration option is introduced, to generate enums as a union of values instead of using an actual `enum` declaration.

If it is false, an enum will be generated as:

```ts
enum Direction {
  Up = "up",
  Down = "down",
  Left = "left",
  Right = "right",
}
```

If it is true, the same enum will be generated as:

```ts
type Direction = "up" | "down" | "left" | "right";
```

This option will be useful in the context of the dashboard V2 schema in grafana/grafana, where enums as disjunctions of concrete values are preferable to actual `enum` declarations.