### PR TITLE
Fix empty values generated for maps and arrays in go

### DIFF
--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -129,7 +129,9 @@ func (jenny *Builder) emptyValueForGuard(context languages.Context, typeDef ast.
 		}
 
 		return jenny.emptyValueForGuard(context, resolvedType)
-	case ast.KindStruct, ast.KindArray, ast.KindMap:
+	case ast.KindArray, ast.KindMap:
+		return jenny.typeFormatter.doFormatType(typeDef, false) + "{}"
+	case ast.KindStruct:
 		return "&" + jenny.typeFormatter.doFormatType(typeDef, false) + "{}"
 	case ast.KindEnum:
 		jenny.typeImportMapper("cog")


### PR DESCRIPTION
Relates to #653

Builders sometimes need to perform initializations with _empty values_ before performing the "main" assignment(s).

See https://github.com/grafana/grafana-foundation-sdk/blob/2f6cab6e04b60c66f3bf4314f83e16fe5c8a06fa/go/timeseries/panel_builder_gen.go#L490

This PR ensures that we generate correct _empty values_ for arrays and maps (we don't actually have a schema that needs those... yet: dashboards v2 will).