### PR TITLE
Make the ComposeDashboardPanel builder veneer configurable

### DIFF
--- a/config/veneers/dashboard.common.yaml
+++ b/config/veneers/dashboard.common.yaml
@@ -69,14 +69,21 @@ builders:
   # Panels composability
   - compose_dashboard_panel:
       panel_builder_name: dashboard.Panel
+      plugin_discriminator_field: type
+      composition_map:
+        Options: options
+        FieldConfig: fieldConfig.defaults.custom
       exclude_panel_options: &UnwantedPanelOptions [
-        "defaults",      # merged with another builder
-        "fieldConfig",   # merged with another builder
-        "options",       # comes from a panel plugin
-        "custom",        # comes from a panel plugin
-        "pluginVersion", # TODO: check if it's relevant or not
-        "repeatPanelId", # TODO: check if it's relevant or not
-        "tags",          # TODO: check if it's relevant or not
+        # merged with another builder
+        "defaults",
+        "fieldConfig",
+        # not needed anymore since we're defining these the composition map
+        "options",
+        "custom",
+        # TODO: check if it's relevant or not
+        "pluginVersion",
+        "repeatPanelId",
+        "tags",
       ]
 
   # remove builders that were previously merged into something else

--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -38,15 +38,7 @@ func ByName(pkg string, builderName string) Selector {
 // generated from a disjunction (see the Disjunction compiler pass).
 func StructGeneratedFromDisjunction() Selector {
 	return func(schemas ast.Schemas, builder ast.Builder) bool {
-		schema, found := schemas.Locate(builder.For.SelfRef.ReferredPkg)
-		if !found {
-			return false
-		}
-
-		resolved, found := schema.Resolve(builder.For.Type)
-		if !found {
-			return false
-		}
+		resolved := schemas.ResolveToType(builder.For.Type)
 
 		return resolved.IsStructGeneratedFromDisjunction()
 	}

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -109,15 +109,23 @@ func (rule MergeInto) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 }
 
 type ComposeDashboardPanel struct {
-	PanelBuilderName    string   `yaml:"panel_builder_name"`
-	ExcludePanelOptions []string `yaml:"exclude_panel_options"`
+	PanelBuilderName         string            `yaml:"panel_builder_name"`
+	PluginDiscriminatorField string            `yaml:"plugin_discriminator_field"`
+	ExcludePanelOptions      []string          `yaml:"exclude_panel_options"`
+	CompositionMap           map[string]string `yaml:"composition_map"`
+	ComposedBuilderName      string            `yaml:"composed_builder_name"`
 }
 
 func (rule ComposeDashboardPanel) AsRewriteRule() (builder.RewriteRule, error) {
 	return builder.ComposeDashboardPanel(
 		builder.ComposableDashboardPanel(),
-		rule.PanelBuilderName,
-		rule.ExcludePanelOptions,
+		builder.PanelCompositionConfig{
+			PanelBuilderName:         rule.PanelBuilderName,
+			PluginDiscriminatorField: rule.PluginDiscriminatorField,
+			ExcludePanelOptions:      rule.ExcludePanelOptions,
+			CompositionMap:           rule.CompositionMap,
+			ComposedBuilderName:      rule.ComposedBuilderName,
+		},
 	), nil
 }
 


### PR DESCRIPTION
Relates to #653

In order to properly support the Dashboard v2 schema in the Foundation SDK, we need to be able to configure how to compose the various "panel plugins" into self-contained panel builders.

This PR takes the builder veneer that we use today and makes it configurable enough to be used for Dashboard v2 as well.