### PR TITLE
Don't sort entries in changelogs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ snapshot:
 
 changelog:
   use: github
-  sort: asc
+  sort: '' # use the output of `git log` as is
   filters:
     exclude:
       - '^docs:'


### PR DESCRIPTION
A changelog sorted alphabetically doesn't make much sense, let's use the order of the commits instead.