### PR TITLE
Ast/assignment path indices

### DIFF
--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -50,6 +50,7 @@ jobs:
         env:
           WORKSPACE_PATH: /tmp/foundation-workspace-current
           CLEANUP_WORKSPACE: 'no'
+          SKIP_VALIDATION: 'yes'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
 
@@ -74,6 +75,7 @@ jobs:
         env:
           WORKSPACE_PATH: /tmp/foundation-workspace-main
           CLEANUP_WORKSPACE: 'no'
+          SKIP_VALIDATION: 'yes'
           LOG_LEVEL: '7' # debug
           GOGC: 'off'
 

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -157,6 +157,10 @@ func (builders Builders) LocateAllByObject(pkg string, name string) Builders {
 	return results
 }
 
+func (builders Builders) LocateAllByRef(ref RefType) Builders {
+	return builders.LocateAllByObject(ref.ReferredPkg, ref.ReferredType)
+}
+
 func (builders Builders) HaveConstantConstructorAssignment() bool {
 	for _, builder := range builders {
 		constantAssignmentFound := false

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -225,8 +225,27 @@ func (arg *Argument) DeepCopy() Argument {
 	}
 }
 
+type PathIndex struct {
+	Argument *Argument
+	Constant any // string or int
+}
+
+func (index PathIndex) DeepCopy() PathIndex {
+	clone := PathIndex{
+		Constant: index.Constant,
+	}
+
+	if index.Argument != nil {
+		arg := index.Argument.DeepCopy()
+		clone.Argument = &arg
+	}
+
+	return clone
+}
+
 type PathItem struct {
 	Identifier string
+	Index      *PathIndex
 	Type       Type // any
 	// useful mostly for composability purposes, when a field Type is "any"
 	// and we're trying to "compose in" something of a known type.
@@ -240,6 +259,11 @@ func (item PathItem) DeepCopy() PathItem {
 		Identifier: item.Identifier,
 		Type:       item.Type.DeepCopy(),
 		Root:       item.Root,
+	}
+
+	if item.Index != nil {
+		index := item.Index.DeepCopy()
+		clone.Index = &index
 	}
 
 	if item.TypeHint != nil {
@@ -352,6 +376,7 @@ type AssignmentMethod string
 const (
 	DirectAssignment AssignmentMethod = "direct" // `foo = bar`
 	AppendAssignment AssignmentMethod = "append" // `foo = append(foo, bar)`
+	IndexAssignment  AssignmentMethod = "index"  // `foo[key] = bar`
 )
 
 type AssignmentNilCheck struct {

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -88,13 +88,6 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			"formatTypeNoBuilder": defaultTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
 			"formatPath":          makePathFormatter(formatter),
 			"formatRawRef":        formatRawRef,
-			"maybeUnptr": func(variableName string, intoType ast.Type) string {
-				if !intoType.Nullable || intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot() {
-					return variableName
-				}
-				typeImportMapper("cog")
-				return "cog.Unptr(" + variableName + ")"
-			},
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
 			"Imports":   imports,

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -101,6 +101,9 @@
 {{- end }}
 
 {{- define "assignment_method" }}
-    {{ if eq .Method "direct" }}builder.internal.{{ .Path|formatPath }} = {{ .Value }}{{ end -}}
-    {{ if eq .Method "append" }}builder.internal.{{ .Path|formatPath }} = append(builder.internal.{{ .Path|formatPath }}, {{ .Value }}){{ end -}}
+    {{ if eq .Method "append" -}}
+        builder.internal.{{ .Path|formatPath }} = append(builder.internal.{{ .Path|formatPath }}, {{ .Value }})
+    {{- else -}}
+        builder.internal.{{ .Path|formatPath }} = {{ .Value }}
+    {{- end -}}
 {{- end }}

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -105,7 +105,7 @@ package {{ .Converter.Package | formatPackageName }}
 {{- define "conversion_mapping" -}}
     {{- $firstOpt := .Options | first }}
     {{- with $firstOpt.Guards -}}if {{ template "guards" . }} { {{- end }}
-    {{- if ne .RepeatFor nil -}}for _, {{ .RepeatAs }} := range {{ .RepeatFor | formatPath }} { {{- end }}
+    {{- if ne .RepeatFor nil -}}for {{ .RepeatIndex | default "_" }}, {{ .RepeatAs }} := range {{ .RepeatFor | formatPath }} { {{- end }}
     {{- range $optMapping := .Options }}
         {{ template "option_mapping" $optMapping }}
     {{- end }}

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -30,7 +30,7 @@ package {{ .Converter.Package | formatPackageName }}
         cog.Dump({{ .Path | formatPath }})
     {{- else if .Type.IsScalar -}}
         {{- $reflect := importStdPkg "fmt" -}}
-        fmt.Sprintf("%#v", {{ maybeUnptr (.Path | formatPath) .Type }})
+        fmt.Sprintf("%#v", {{ .Type | maybeDereference }}{{ .Path | formatPath }})
     {{- else -}}
         {{- $cog := importPkg "cog" -}}
         cog.Dump({{ .Type | maybeDereference }}{{ .Path | formatPath }})
@@ -76,7 +76,7 @@ package {{ .Converter.Package | formatPackageName }}
     {{- end -}}
     {{- with .Arg.Runtime -}}
         {{- $cog := importPkg "cog" -}}
-        {{ $.IntoVar }} := cog.{{ .FuncName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}{{ $runtimeArg.ValuePath | formatPath }}{{ else }}{{ maybeUnptr ($runtimeArg.ValuePath | formatPath) $runtimeArg.ValueType }}{{ end }}, {{ end }})
+        {{ $.IntoVar }} := cog.{{ .FuncName }}({{ range $i, $runtimeArg := .Args }}{{ if eq $i 0}}{{ $runtimeArg.ValuePath | formatPath }}{{ else }}{{ $runtimeArg.ValueType | maybeDereference }} {{ $runtimeArg.ValuePath | formatPath }}{{ end }}, {{ end }})
     {{- end -}}
     {{- with .Arg.Direct -}}
         {{ $.IntoVar }} := {{- template "value_formatter" (dict "Type" .ValueType "Path" .ValuePath) -}}

--- a/internal/jennies/golang/templates/runtime/tools.tmpl
+++ b/internal/jennies/golang/templates/runtime/tools.tmpl
@@ -48,14 +48,6 @@ func MakeBuildErrors(rootPath string, err error) BuildErrors {
 	}}
 }
 
-func Unptr[T any](v *T) T {
-	var val T
-	if v == nil {
-		return val
-	}
-	return *v
-}
-
 func ToPtr[T any](v T) *T {
   return &v
 }

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -39,9 +39,6 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"importPkg": func(_ string) string {
 				panic("importPkg() needs to be overridden by a jenny")
 			},
-			"maybeUnptr": func(variableName string, intoType ast.Type) string {
-				panic("maybeUnptr() needs to be overridden by a jenny")
-			},
 			"emptyValueForGuard": func(_ ast.Type) string {
 				panic("emptyValueForGuard() needs to be overridden by a jenny")
 			},
@@ -73,14 +70,14 @@ func initTemplates(extraTemplatesDirectories []string) *template.Template {
 			"formatFunctionName": formatFunctionName,
 			"formatScalar":       formatScalar,
 			"maybeAsPointer": func(intoType ast.Type, variableName string) string {
-				if intoType.Nullable && !(intoType.IsArray() || intoType.IsMap() || intoType.IsComposableSlot()) {
+				if intoType.Nullable && !intoType.IsAnyOf(ast.KindArray, ast.KindMap, ast.KindComposableSlot) {
 					return "&" + variableName
 				}
 
 				return variableName
 			},
 			"maybeDereference": func(typeDef ast.Type) string {
-				if typeDef.Nullable && !typeDef.IsAnyOf(ast.KindArray, ast.KindMap) {
+				if typeDef.Nullable && !typeDef.IsAnyOf(ast.KindArray, ast.KindMap, ast.KindComposableSlot) {
 					return "*"
 				}
 

--- a/internal/jennies/java/templates/converters/converter.tmpl
+++ b/internal/jennies/java/templates/converters/converter.tmpl
@@ -56,11 +56,11 @@ package {{ .Converter.Package | formatPackageName }};
         {{- .Path | formatGuardPath }} + "{{ formatIntegerLetter .Type }}"
         {{- end }}
     {{- else if resolvesToEnum .Type -}}
-        {{- $reflect := importStdPkg "cog" "Runtime" -}}
+        {{- $runtime := importStdPkg "cog" "Runtime" -}}
         {{- $reflect := importStdPkg .Type.AsRef.ReferredPkg .Type.AsRef.ReferredType -}}
         Runtime.formatEnum({{ .Type.AsRef.ReferredType }}.class, {{- .Path | formatGuardPath }})
     {{- else }}
-        {{- $reflect := importStdPkg "cog" "Runtime" -}}
+        {{- $runtime := importStdPkg "cog" "Runtime" -}}
         Runtime.dump({{ .Path | formatGuardPath }})
     {{- end }}
 {{- end }}
@@ -144,8 +144,16 @@ package {{ .Converter.Package | formatPackageName }};
     {{- $firstOpt := .Options | first }}
     {{- with $firstOpt.Guards -}}if ({{ template "guards" . }}) { {{- end }}
     {{- if ne .RepeatFor nil -}}
+        {{- if .RepeatFor.Last.Type.IsArray -}}
         {{ $repeatFor := .RepeatFor.Last.Type.AsArray.ValueType | formatType }}
-        for ({{ $repeatFor }} item : {{ .RepeatFor }}) { 
+        for ({{ $repeatFor }} {{ .RepeatAs }} : {{ .RepeatFor }}) {
+        {{- else -}}
+        for (var entry : {{ .RepeatFor }}.entrySet()) {
+            var {{ .RepeatAs }} = entry.getValue();
+            {{- if ne .RepeatIndex "" }}
+            var {{ .RepeatIndex }} = entry.getKey();
+            {{- end -}}
+        {{- end -}}
     {{ end }}
     {{- range $optMapping := .Options }}
         {{ template "option_mapping" $optMapping }}

--- a/internal/jennies/java/templates/types/assigments.tmpl
+++ b/internal/jennies/java/templates/types/assigments.tmpl
@@ -73,5 +73,6 @@
 {{- define "assignment_method" }}
     {{ $path := formatAssignmentPath .Path }}
         {{- if eq .Method "direct" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "index" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
         {{- if eq .Method "append" }}this.internal.{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -305,6 +305,17 @@ func (tf *typeFormatter) formatAssignmentPath(fieldPath ast.Path) string {
 	}
 
 	for i, p := range fieldPath[1:] {
+		if p.Index != nil {
+			path += "["
+			if p.Index.Constant != nil {
+				path += fmt.Sprintf("%#v", p.Index.Constant)
+			} else {
+				path += tools.LowerCamelCase(p.Index.Argument.Name)
+			}
+			path += "]"
+			continue
+		}
+
 		if fieldPath[i].Type.IsAny() && i != len(fieldPath)-1 {
 			return path
 		}

--- a/internal/jennies/php/templates/builders/assignment.tmpl
+++ b/internal/jennies/php/templates/builders/assignment.tmpl
@@ -92,5 +92,6 @@
 
 {{- define "assignment_method" }}
     {{ if eq .Method "direct" }}$this->internal->{{ .Path|formatPath }} = {{ .Value }};{{ end -}}
+    {{ if eq .Method "index" }}$this->internal->{{ .Path|formatPath }} = {{ .Value }};{{ end -}}
     {{ if eq .Method "append" }}$this->internal->{{ .Path|formatPath }}[] = {{ .Value }};{{ end -}}
 {{- end }}

--- a/internal/jennies/php/templates/converters/converter.tmpl
+++ b/internal/jennies/php/templates/converters/converter.tmpl
@@ -126,7 +126,7 @@ namespace {{ .NamespaceRoot }}\{{ .Converter.Package | formatPackageName }};
 {{- define "conversion_mapping" -}}
     {{- $firstOpt := .Options | first }}
     {{- with $firstOpt.Guards -}}if ({{ template "guards" . }}) { {{- end }}
-    {{ if ne .RepeatFor nil -}}foreach (${{ .RepeatFor | formatPath }} as ${{ .RepeatAs }}) { {{- end }}
+    {{ if ne .RepeatFor nil -}}foreach (${{ .RepeatFor | formatPath }} as {{if ne .RepeatIndex "" }}${{ .RepeatIndex }} => {{ end }}${{ .RepeatAs }}) { {{- end }}
     {{- range $optMapping := .Options }}
         {{ template "option_mapping" $optMapping }}
     {{- end }}

--- a/internal/jennies/php/tools.go
+++ b/internal/jennies/php/tools.go
@@ -63,9 +63,29 @@ func formatCommentsBlock(comments []string) string {
 }
 
 func formatFieldPath(fieldPath ast.Path) string {
-	return strings.Join(tools.Map(fieldPath, func(item ast.PathItem) string {
-		return formatFieldName(item.Identifier)
-	}), "->")
+	path := ""
+
+	for i, chunk := range fieldPath {
+		last := i == len(fieldPath)-1
+		output := formatFieldName(chunk.Identifier)
+
+		if chunk.Index != nil {
+			output += "["
+			if chunk.Index.Constant != nil {
+				output += formatValue(chunk.Index.Constant)
+			} else {
+				output += "$" + formatArgName(chunk.Index.Argument.Name)
+			}
+			output += "]"
+		}
+
+		path += output
+		if !last && fieldPath[i+1].Index == nil {
+			path += "->"
+		}
+	}
+
+	return path
 }
 
 func formatValue(val any) string {

--- a/internal/jennies/python/templates/builders/assignment.tmpl
+++ b/internal/jennies/python/templates/builders/assignment.tmpl
@@ -66,5 +66,6 @@
 
 {{- define "assignment_method" }}
 {{ if eq .Method "direct" }}self._internal.{{ .Path|formatPath }} = {{ .Value }}{{ end -}}
+{{ if eq .Method "index" }}self._internal.{{ .Path|formatPath }} = {{ .Value }}{{ end -}}
 {{ if eq .Method "append" }}self._internal.{{ .Path|formatPath }}.append({{ .Value }}){{ end -}}
 {{- end }}

--- a/internal/jennies/python/tools.go
+++ b/internal/jennies/python/tools.go
@@ -42,11 +42,29 @@ func formatValue(val any) string {
 }
 
 func formatFieldPath(fieldPath ast.Path) string {
-	parts := tools.Map(fieldPath, func(part ast.PathItem) string {
-		return formatIdentifier(part.Identifier)
-	})
+	path := ""
 
-	return strings.Join(parts, ".")
+	for i, chunk := range fieldPath {
+		last := i == len(fieldPath)-1
+		output := formatIdentifier(chunk.Identifier)
+
+		if chunk.Index != nil {
+			output += "["
+			if chunk.Index.Constant != nil {
+				output += formatValue(chunk.Index.Constant)
+			} else {
+				output += formatIdentifier(chunk.Index.Argument.Name)
+			}
+			output += "]"
+		}
+
+		path += output
+		if !last && fieldPath[i+1].Index == nil {
+			path += "."
+		}
+	}
+
+	return path
 }
 
 func formatIdentifier(name string) string {

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -3,7 +3,6 @@ package typescript
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
@@ -120,7 +119,27 @@ func (jenny *Builder) importType(typeRef ast.RefType) string {
 }
 
 func (jenny *Builder) formatFieldPath(fieldPath ast.Path) string {
-	return strings.Join(tools.Map(fieldPath, func(chunk ast.PathItem) string {
-		return chunk.Identifier
-	}), ".")
+	path := ""
+
+	for i, chunk := range fieldPath {
+		last := i == len(fieldPath)-1
+		output := chunk.Identifier
+
+		if chunk.Index != nil {
+			output += "["
+			if chunk.Index.Constant != nil {
+				output += formatValue(chunk.Index.Constant)
+			} else {
+				output += formatIdentifier(chunk.Index.Argument.Name)
+			}
+			output += "]"
+		}
+
+		path += output
+		if !last && fieldPath[i+1].Index == nil {
+			path += "."
+		}
+	}
+
+	return path
 }

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -93,6 +93,7 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
 {{- end }}
 
 {{- define "assignment_method" }}
-        {{ if eq .Method "direct" }}this.internal.{{ .Path }} = {{ .Value }};{{ end -}}
-        {{ if eq .Method "append" }}this.internal.{{ .Path }}.push({{ .Value }});{{ end -}}
+        {{ if eq .Method "direct" }}this.internal.{{ .Path|formatPath }} = {{ .Value }};{{ end -}}
+        {{ if eq .Method "index" }}this.internal.{{ .Path|formatPath }} = {{ .Value }};{{ end -}}
+        {{ if eq .Method "append" }}this.internal.{{ .Path|formatPath }}.push({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -83,9 +83,10 @@ type ArgumentMapping struct {
 }
 
 type ConversionMapping struct {
-	// for _, panel := range input.Panels { WithPanel(panel) }
-	RepeatFor ast.Path // `input.Panels`
-	RepeatAs  string   // `panel`
+	// for i, panel := range input.Panels { WithPanel(panel) }
+	RepeatFor   ast.Path // `input.Panels`
+	RepeatAs    string   // `panel`
+	RepeatIndex string   // `i`
 
 	Options []OptionMapping
 }
@@ -227,6 +228,13 @@ func (generator *ConverterGenerator) convertOption(context Context, converter Co
 		mapping.RepeatAs = "item"
 	}
 
+	if len(assignments) == 1 && assignments[0].Method == ast.IndexAssignment {
+		assignmentPath := assignments[0].Path
+		mapping.RepeatFor = converter.inputRootPath().Append(assignmentPath[:len(assignmentPath)-1])
+		mapping.RepeatAs = "value"
+		mapping.RepeatIndex = "key"
+	}
+
 	// if the option appends one possible branch of a disjunction to a list,
 	// we need to treat it differently
 	if mapping.RepeatFor != nil && generator.isAssignmentFromDisjunctionStruct(context, assignments[0]) {
@@ -273,11 +281,27 @@ func (generator *ConverterGenerator) mappingForOption(context Context, converter
 		argName := fmt.Sprintf("arg%d", i)
 		valueType := assignment.Path.Last().Type
 		valuePath := converter.inputRootPath().Append(assignment.Path)
-		if mapping.RepeatFor != nil {
+		if mapping.RepeatFor != nil && valueType.IsArray() {
 			valueType = valueType.AsArray().ValueType
 			valuePath = ast.Path{
 				{Identifier: mapping.RepeatAs, Type: valueType, Root: true},
 			}
+		} else if mapping.RepeatFor != nil && assignment.Method == ast.IndexAssignment {
+			// index
+			indexPath := ast.Path{
+				{Identifier: mapping.RepeatIndex, Type: valueType, Root: true},
+			}
+			indexType := assignment.Path.Last().Index.Argument.Type
+			argument := generator.argumentForType(context, converter, mapping.RepeatIndex, indexPath, indexType)
+			optMapping.Args = append(optMapping.Args, argument)
+
+			// value
+			valuePath = ast.Path{
+				{Identifier: mapping.RepeatAs, Type: valueType, Root: true},
+			}
+			argument = generator.argumentForType(context, converter, argName, valuePath, valueType)
+			optMapping.Args = append(optMapping.Args, argument)
+			continue
 		}
 
 		if argument, ok := generator.argumentFromDisjunctionStruct(context, converter, argName, valuePath, assignment); ok {
@@ -472,6 +496,10 @@ func (generator *ConverterGenerator) guardForAssignments(valuesRootPath ast.Path
 		nullPathChunksGuards := generator.pathNotNullGuards(valuesRootPath, assignment.Path)
 		for _, guard := range nullPathChunksGuards {
 			guards.Set(guard.String(), guard)
+		}
+
+		if assignment.Method == ast.IndexAssignment {
+			continue
 		}
 
 		if assignment.Value.Constant != nil {

--- a/internal/veneers/option/rules.go
+++ b/internal/veneers/option/rules.go
@@ -23,6 +23,13 @@ func ArrayToAppend(selector Selector) RewriteRule {
 	}
 }
 
+func MapToIndex(selector Selector) RewriteRule {
+	return RewriteRule{
+		Selector: selector,
+		Action:   MapToIndexAction(),
+	}
+}
+
 func RenameArguments(selector Selector, newNames []string) RewriteRule {
 	return RewriteRule{
 		Selector: selector,

--- a/internal/yaml/option.go
+++ b/internal/yaml/option.go
@@ -20,6 +20,7 @@ type OptionRule struct {
 	StructFieldsAsArguments *StructFieldsAsArguments `yaml:"struct_fields_as_arguments"`
 	StructFieldsAsOptions   *StructFieldsAsOptions   `yaml:"struct_fields_as_options"`
 	ArrayToAppend           *ArrayToAppend           `yaml:"array_to_append"`
+	MapToIndex              *MapToIndex              `yaml:"map_to_index"`
 	DisjunctionAsOptions    *DisjunctionAsOptions    `yaml:"disjunction_as_options"`
 	Duplicate               *DuplicateOption         `yaml:"duplicate"`
 	AddAssignment           *AddAssignment           `yaml:"add_assignment"`
@@ -57,6 +58,10 @@ func (rule OptionRule) AsRewriteRule(pkg string) (option.RewriteRule, error) {
 
 	if rule.ArrayToAppend != nil {
 		return rule.ArrayToAppend.AsRewriteRule(pkg)
+	}
+
+	if rule.MapToIndex != nil {
+		return rule.MapToIndex.AsRewriteRule(pkg)
 	}
 
 	if rule.DisjunctionAsOptions != nil {
@@ -162,6 +167,19 @@ func (rule ArrayToAppend) AsRewriteRule(pkg string) (option.RewriteRule, error) 
 	}
 
 	return option.ArrayToAppend(selector), nil
+}
+
+type MapToIndex struct {
+	OptionSelector `yaml:",inline"`
+}
+
+func (rule MapToIndex) AsRewriteRule(pkg string) (option.RewriteRule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return option.RewriteRule{}, err
+	}
+
+	return option.MapToIndex(selector), nil
 }
 
 type DisjunctionAsOptions struct {

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -155,10 +155,25 @@
       },
       "type": "array"
     },
+    "AstPathIndex": {
+      "properties": {
+        "argument": {
+          "$ref": "#/$defs/AstArgument"
+        },
+        "constant": {
+          "description": "string or int"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "AstPathItem": {
       "properties": {
         "identifier": {
           "type": "string"
+        },
+        "index": {
+          "$ref": "#/$defs/AstPathIndex"
         },
         "type": {
           "$ref": "#/$defs/AstType",
@@ -473,11 +488,23 @@
         "panel_builder_name": {
           "type": "string"
         },
+        "plugin_discriminator_field": {
+          "type": "string"
+        },
         "exclude_panel_options": {
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "composition_map": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "composed_builder_name": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -599,6 +626,23 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "YamlMapToIndex": {
+      "properties": {
+        "by_name": {
+          "type": "string",
+          "description": "objectName.optionName"
+        },
+        "by_builder": {
+          "type": "string",
+          "description": "builderName.optionName\nTODO: ByName should be called ByObject\nand ByBuilder should be called ByName"
+        },
+        "by_names": {
+          "$ref": "#/$defs/YamlByNamesSelector"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "YamlMergeInto": {
       "properties": {
         "destination": {
@@ -648,6 +692,9 @@
         },
         "array_to_append": {
           "$ref": "#/$defs/YamlArrayToAppend"
+        },
+        "map_to_index": {
+          "$ref": "#/$defs/YamlMapToIndex"
         },
         "disjunction_as_options": {
           "$ref": "#/$defs/YamlDisjunctionAsOptions"

--- a/testdata/generated/cog/errors.go
+++ b/testdata/generated/cog/errors.go
@@ -53,14 +53,6 @@ func MakeBuildErrors(rootPath string, err error) BuildErrors {
 	}}
 }
 
-func Unptr[T any](v *T) T {
-	var val T
-	if v == nil {
-		return val
-	}
-	return *v
-}
-
 func ToPtr[T any](v T) *T {
 	return &v
 }

--- a/testdata/generated/cog/errors.go
+++ b/testdata/generated/cog/errors.go
@@ -60,3 +60,7 @@ func Unptr[T any](v *T) T {
 	}
 	return *v
 }
+
+func ToPtr[T any](v T) *T {
+	return &v
+}

--- a/testdata/generated/cog/plugins/variants.go
+++ b/testdata/generated/cog/plugins/variants.go
@@ -5,10 +5,6 @@
 
 package plugins
 
-import (
-	cog "github.com/grafana/cog/testdata/generated/cog"
-)
-
 func RegisterDefaultPlugins() {
 
 	// Panelcfg variants

--- a/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -1,0 +1,40 @@
+package sandbox
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
+
+type SomeStructBuilder struct {
+    internal *SomeStruct
+    errors map[string]cog.BuildErrors
+}
+
+func NewSomeStructBuilder() *SomeStructBuilder {
+	resource := NewSomeStruct()
+	builder := &SomeStructBuilder{
+		internal: resource,
+		errors: make(map[string]cog.BuildErrors),
+	}
+
+	return builder
+}
+
+func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return SomeStruct{}, err
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *SomeStructBuilder) Annotations(key string,value string) *SomeStructBuilder {
+if builder.internal.Annotations == nil {
+    builder.internal.Annotations = map[string]string{}
+}
+    builder.internal.Annotations[key] = value
+
+    return builder
+}
+

--- a/testdata/jennies/builders/map_index_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/map_index_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -13,18 +13,21 @@ func SomeStructConverter(input SomeStruct) string {
     `sandbox.NewSomeStructBuilder()`,
     }
     var buffer strings.Builder
-        if input.Annotations != nil && input.Annotations[key] != "" {
+        if input.Annotations != nil {for key, value := range input.Annotations {
         
     buffer.WriteString(`Annotations(`)
-        arg0 :=fmt.Sprintf("%#v", input.Annotations[key])
+        arg0 :=fmt.Sprintf("%#v", key)
         buffer.WriteString(arg0)
+        buffer.WriteString(", ")
+        arg1 :=fmt.Sprintf("%#v", value)
+        buffer.WriteString(arg1)
         
     buffer.WriteString(")")
 
     calls = append(calls, buffer.String())
     buffer.Reset()
     
-    }
+    }}
 
     return strings.Join(calls, ".\t\n")
 }

--- a/testdata/jennies/builders/map_index_assignment/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/map_index_assignment/GoConverter/sandbox/somestruct_converter_gen.go
@@ -1,0 +1,30 @@
+package sandbox
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// SomeStructConverter accepts a `SomeStruct` object and generates the Go code to build this object using builders.
+func SomeStructConverter(input SomeStruct) string {
+    calls := []string{
+    `sandbox.NewSomeStructBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Annotations != nil && input.Annotations[key] != "" {
+        
+    buffer.WriteString(`Annotations(`)
+        arg0 :=fmt.Sprintf("%#v", input.Annotations[key])
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_index_assignment/JavaBuilders/sandbox/SomeStruct.java
+++ b/testdata/jennies/builders/map_index_assignment/JavaBuilders/sandbox/SomeStruct.java
@@ -1,0 +1,40 @@
+package sandbox;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import java.util.Map;
+import java.util.HashMap;
+
+public class SomeStruct {
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    @JsonProperty("annotations")
+    public Map<String, String> annotations;
+    
+    public String toJSON() throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(this);
+    }
+
+    
+    public static class Builder implements cog.Builder<SomeStruct> {
+        protected final SomeStruct internal;
+        
+        public Builder() {
+            this.internal = new SomeStruct();
+        }
+    public Builder annotations(String key,String value) {
+		if (this.internal.annotations == null) {
+			this.internal.annotations = new Hashmap<>();
+		}
+    this.internal.annotations[key] = value;
+        return this;
+    }
+    public SomeStruct build() {
+            return this.internal;
+        }
+    }
+}

--- a/testdata/jennies/builders/map_index_assignment/PHPBuilder/src/Sandbox/SomeStructBuilder.php
+++ b/testdata/jennies/builders/map_index_assignment/PHPBuilder/src/Sandbox/SomeStructBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\Sandbox\SomeStruct>
+ */
+class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\Sandbox\SomeStruct $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\Sandbox\SomeStruct();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\Sandbox\SomeStruct
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    public function annotations(string $key,string $value): static
+    {
+        $this->internal->annotations[$key] = $value;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_index_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/map_index_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -10,19 +10,22 @@ final class SomeStructConverter
         $calls = [
             '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
         ];
-            if ($input->annotations[$key] !== "") {
-    
-        
+            
+    foreach ($input->annotations as $key => $value) {
+        {
     $buffer = 'annotations(';
-        $arg0 =\var_export($input->annotations[$key], true);
+        $arg0 =\var_export($key, true);
         $buffer .= $arg0;
+        $buffer .= ', ';
+        $arg1 =\var_export($value, true);
+        $buffer .= $arg1;
         
     $buffer .= ')';
 
     $calls[] = $buffer;
-    
-    
     }
+    }
+    
 
         return \implode("\n\t->", $calls);
     }

--- a/testdata/jennies/builders/map_index_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/map_index_assignment/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
+        ];
+            if ($input->annotations[$key] !== "") {
+    
+        
+    $buffer = 'annotations(';
+        $arg0 =\var_export($input->annotations[$key], true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
@@ -1,0 +1,25 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import sandbox
+
+
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+    _internal: sandbox.SomeStruct
+
+    def __init__(self):
+        self._internal = sandbox.SomeStruct()
+
+    def build(self) -> sandbox.SomeStruct:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def annotations(self, key: str, value: str) -> typing.Self:        
+        if self._internal.annotations is None:
+            self._internal.annotations = {}
+        assert isinstance(self._internal.annotations, dict[str, str])
+        self._internal.annotations[key] = value
+    
+        return self
+    

--- a/testdata/jennies/builders/map_index_assignment/TypescriptBuilder/src/sandbox/someStructBuilder.gen.ts
+++ b/testdata/jennies/builders/map_index_assignment/TypescriptBuilder/src/sandbox/someStructBuilder.gen.ts
@@ -1,0 +1,25 @@
+import * as cog from '../cog';
+import * as sandbox from '../sandbox';
+
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
+    protected readonly internal: sandbox.SomeStruct;
+
+    constructor() {
+        this.internal = sandbox.defaultSomeStruct();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): sandbox.SomeStruct {
+        return this.internal;
+    }
+
+    annotations(key: string,value: string): this {
+        if (!this.internal.annotations) {
+            this.internal.annotations = {};
+        }
+        this.internal.annotations[key] = value;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_index_assignment/builders_context.json
+++ b/testdata/jennies/builders/map_index_assignment/builders_context.json
@@ -1,0 +1,184 @@
+{
+  "Schemas": [
+    {
+      "Package": "sandbox",
+      "Metadata": {},
+      "Objects": {
+        "SomeStruct": {
+          "Name": "SomeStruct",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "annotations",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "sandbox",
+            "ReferredType": "SomeStruct"
+          }
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "For": {
+        "Name": "SomeStruct",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "annotations",
+                "Type": {
+                  "Kind": "map",
+                  "Nullable": false,
+                  "Map": {
+                    "IndexType": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "ValueType": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "sandbox",
+          "ReferredType": "SomeStruct"
+        }
+      },
+      "Package": "sandbox",
+      "Name": "SomeStruct",
+      "Options": [
+        {
+          "Name": "annotations",
+          "Args": [
+            {
+              "Name": "key",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            },
+            {
+              "Name": "value",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "annotations",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "Index": {
+                    "Argument": {
+                      "Name": "key",
+                      "Type": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      }
+                    }
+                  },
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "value",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "index"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
With the dashboard v2 schema panels are stored in a map and indexed by name.
To support adding panels one by one in the dashboard builder, we need to support "indexed assignments". ie: assignments into a map with a given key/index.

See: https://github.com/grafana/cog/pull/664/files#diff-e33cfe95610b6014e8ee22c6901ba79bc610857a0e6b54c6579188363a4973faR25

This PR extends the builders intermediate representation to support these assignments, and updates the jennies to generate correct code in builders and converters.