### PR TITLE
Make the ComposeDashboardPanel builder veneer fully generic

### DIFF
--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -44,8 +44,9 @@ func StructGeneratedFromDisjunction() Selector {
 	}
 }
 
-// ComposableDashboardPanel matches builders for Panel variants.
-func ComposableDashboardPanel() Selector {
+// ByVariant matches builders defined within a schema marked as "composable"
+// and implementing the given variant.
+func ByVariant(variant ast.SchemaVariant) Selector {
 	return func(schemas ast.Schemas, builder ast.Builder) bool {
 		schema, found := schemas.Locate(builder.For.SelfRef.ReferredPkg)
 		if !found {
@@ -53,7 +54,7 @@ func ComposableDashboardPanel() Selector {
 		}
 
 		return schema.Metadata.Kind == ast.SchemaKindComposable &&
-			schema.Metadata.Variant == ast.SchemaVariantPanel &&
+			schema.Metadata.Variant == variant &&
 			schema.Metadata.Identifier != ""
 	}
 }

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -388,6 +388,9 @@
         "by_name": {
           "type": "string"
         },
+        "by_variant": {
+          "type": "string"
+        },
         "generated_from_disjunction": {
           "type": "boolean",
           "description": "noop?"
@@ -427,8 +430,8 @@
         "merge_into": {
           "$ref": "#/$defs/YamlMergeInto"
         },
-        "compose_dashboard_panel": {
-          "$ref": "#/$defs/YamlComposeDashboardPanel"
+        "compose": {
+          "$ref": "#/$defs/YamlComposeBuilders"
         },
         "properties": {
           "$ref": "#/$defs/YamlProperties"
@@ -460,6 +463,9 @@
         "by_name": {
           "type": "string"
         },
+        "by_variant": {
+          "type": "string"
+        },
         "generated_from_disjunction": {
           "type": "boolean",
           "description": "noop?"
@@ -483,15 +489,28 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "YamlComposeDashboardPanel": {
+    "YamlComposeBuilders": {
       "properties": {
-        "panel_builder_name": {
+        "by_object": {
+          "type": "string"
+        },
+        "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
+          "type": "string"
+        },
+        "generated_from_disjunction": {
+          "type": "boolean",
+          "description": "noop?"
+        },
+        "source_builder_name": {
           "type": "string"
         },
         "plugin_discriminator_field": {
           "type": "string"
         },
-        "exclude_panel_options": {
+        "exclude_options": {
           "items": {
             "type": "string"
           },
@@ -516,6 +535,9 @@
           "type": "string"
         },
         "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
           "type": "string"
         },
         "generated_from_disjunction": {
@@ -555,6 +577,9 @@
           "type": "string"
         },
         "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
           "type": "string"
         },
         "generated_from_disjunction": {
@@ -610,6 +635,9 @@
           "type": "string"
         },
         "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
           "type": "string"
         },
         "generated_from_disjunction": {
@@ -734,6 +762,9 @@
         "by_name": {
           "type": "string"
         },
+        "by_variant": {
+          "type": "string"
+        },
         "generated_from_disjunction": {
           "type": "boolean",
           "description": "noop?"
@@ -754,6 +785,9 @@
           "type": "string"
         },
         "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
           "type": "string"
         },
         "generated_from_disjunction": {
@@ -799,6 +833,9 @@
           "type": "string"
         },
         "by_name": {
+          "type": "string"
+        },
+        "by_variant": {
           "type": "string"
         },
         "generated_from_disjunction": {


### PR DESCRIPTION
This veneer was usable only for dashboard panels. With the dashboard v2 schema, it is very likely that we'll need to use it for queries too.

This PR turns the `ComposeDashboardPanel` veneer into a fully generic `Compose` one.