### PR TITLE
Reduce the number of versions of kind-registry to generate in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        kind_version: [next, v11.3.x, v11.2.x, v11.1.x, v11.0.x, v10.4.x, v10.3.x, v10.2.x, v10.1.x]
+        kind_version: [next, v11.4.x, v11.0.x, v10.4.x]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2


### PR DESCRIPTION
Testing with more or all versions gives us very diminishing returns, so let's focus on a few