### PR TITLE
Maps of builders

### DIFF
--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -83,11 +83,10 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			"importStdPkg": func(pkg string) string {
 				return imports.Add(pkg, pkg)
 			},
-			"importPkg":           typeImportMapper,
-			"formatType":          builderTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
-			"formatTypeNoBuilder": defaultTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
-			"formatPath":          makePathFormatter(formatter),
-			"formatRawRef":        formatRawRef,
+			"importPkg":    typeImportMapper,
+			"formatType":   builderTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
+			"formatPath":   makePathFormatter(formatter),
+			"formatRawRef": formatRawRef,
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
 			"Imports":   imports,

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -81,6 +81,22 @@
                 {{ .ResultVar }} = append({{ .ResultVar}}, {{ .OriginalInputVar }}Depth{{ .Depth }})
             {{- end }}
         }
+    {{- else if .InputType.IsMap }}
+        {{ .ResultVar }} := make({{ .InputType | formatTypeNoBuilder }})
+        for key{{ .Depth }}, val{{ .Depth }} := range {{ .InputVar}} {
+            {{- if .InputType.Map.ValueType.IsArray }}
+                {{- template "unfold_builders" (dict "Depth" (add1 .Depth) "InputType" .InputType.Map.ValueType "OriginalInputVar" .OriginalInputVar "InputVar" (print "val" .Depth) "AssignmentPath" $.AssignmentPath "ResultVar" (print .OriginalInputVar "Depth" .Depth)) }}
+
+                {{ .ResultVar }}[key{{ .Depth }}] = {{ .OriginalInputVar }}Depth{{ .Depth }}
+            {{- else }}
+                {{ .OriginalInputVar }}Depth{{ .Depth }}, err := val{{ .Depth }}.Build()
+                if err != nil {
+                    builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                {{ .ResultVar }}[key{{ .Depth }}] = {{ .OriginalInputVar }}Depth{{ .Depth }}
+            {{- end }}
+        }
     {{- else }}
     {{ .ResultVar }}, err := {{ .InputVar}}.Build()
     if err != nil {

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -66,7 +66,7 @@ package {{ .Converter.Package | formatPackageName }}
     {{- end -}}
     {{- with .Arg.Map -}}
         {{- $reflect := importStdPkg "fmt" -}}
-        {{ $.IntoVar }} := "map[{{ .IndexType | formatType }}]{{ .ValueType | formatTypeNoBuilder }}{"
+        {{ $.IntoVar }} := "map[{{ .IndexType | formatType }}]{{ .ValueType | formatType }}{"
         for key, {{ .ValueAs | formatPath }} := range {{ .For | formatPath }} {
         {{- $subIntoVar := print "tmp" .For.Last.Identifier (.ValueAs | formatPath) }}
             {{ template "prepare_arg" (dict "IntoVar" $subIntoVar "Arg" .ForArg) }}

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -113,7 +113,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 		}
 
 		if def.IsMap() {
-			return formatter.formatMap(def.AsMap())
+			return formatter.formatMap(def.AsMap(), resolveBuilders)
 		}
 
 		if def.IsScalar() {
@@ -234,9 +234,9 @@ func (formatter *typeFormatter) formatArray(def ast.ArrayType, resolveBuilders b
 	return "[]" + subTypeString
 }
 
-func (formatter *typeFormatter) formatMap(def ast.MapType) string {
-	keyTypeString := formatter.doFormatType(def.IndexType, false)
-	valueTypeString := formatter.doFormatType(def.ValueType, false)
+func (formatter *typeFormatter) formatMap(def ast.MapType, resolveBuilders bool) string {
+	keyTypeString := formatter.doFormatType(def.IndexType, resolveBuilders)
+	valueTypeString := formatter.doFormatType(def.ValueType, resolveBuilders)
 
 	return fmt.Sprintf("map[%s]%s", keyTypeString, valueTypeString)
 }

--- a/internal/jennies/php/templates/builders/assignment.tmpl
+++ b/internal/jennies/php/templates/builders/assignment.tmpl
@@ -25,7 +25,7 @@
         {{- $argName := formatArgName .Name }}
 
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
-            {{- $argName = .Type.IsArray | ternary (print $argName "Resources") (print $argName "Resource") }}
+            {{- $argName = (or .Type.IsArray .Type.IsMap) | ternary (print $argName "Resources") (print $argName "Resource") }}
         {{- end }}
 
         {{- print "$" $argName }}
@@ -39,7 +39,7 @@
     {{- with .Value.Argument }}
         {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
         {{- $builtResultName := (print (formatArgName .Name) "Resource") }}
-        {{- if .Type.IsArray }}
+        {{- if or .Type.IsArray .Type.IsMap }}
         {{- $builtResultName = (print (formatArgName .Name) "Resources") }}
         ${{ $builtResultName }} = [];
         {{- end }}
@@ -68,6 +68,22 @@
                 ${{ .ResultVar }}[] = $r{{ .Depth }} instanceof {{ "Cog\\Builder" | fullNamespaceRef }} ? $r{{ .Depth }}->build() : $r{{ .Depth }};
                 {{- else }}
                 ${{ .ResultVar }}[] = $r{{ .Depth }}->build();
+                {{- end }}
+            {{- end }}
+        }
+    {{- else if .InputType.IsMap }}
+        foreach (${{ .InputVar }} as $key{{ .Depth }} => $val{{ .Depth }}) {
+            {{- if or .InputType.Map.ValueType.IsArray .InputType.Map.ValueType.IsMap }}
+                ${{ .OriginalInputVar }}Depth{{ .Depth }} = [];
+
+                {{- template "unfold_builders" (dict "Depth" (add1 .Depth) "InputType" .InputType.Map.ValueType "OriginalInputVar" .OriginalInputVar "InputVar" (print "val" .Depth) "AssignmentPath" $.AssignmentPath "ResultVar" (print .OriginalInputVar "Depth" .Depth)) }}
+
+                ${{ .ResultVar }}[$key{{ .Depth }}] = ${{ .OriginalInputVar }}Depth{{ .Depth }};
+            {{- else }}
+                {{- if and .InputType.Map.ValueType.IsDisjunction (not (isDisjunctionOfBuilders .InputType.Map.ValueType)) }}
+                ${{ .ResultVar }}[$key{{ .Depth }}] = $val{{ .Depth }} instanceof {{ "Cog\\Builder" | fullNamespaceRef }} ? $val{{ .Depth }}->build() : $val{{ .Depth }};
+                {{- else }}
+                ${{ .ResultVar }}[$key{{ .Depth }}] = $val{{ .Depth }}->build();
                 {{- end }}
             {{- end }}
         }

--- a/internal/jennies/php/typehints.go
+++ b/internal/jennies/php/typehints.go
@@ -52,7 +52,7 @@ func (generator *typehints) forType(def ast.Type, resolveBuilders bool) string {
 	case def.IsArray():
 		hint = generator.arrayHint(def, resolveBuilders)
 	case def.IsMap():
-		hint = generator.mapHint(def)
+		hint = generator.mapHint(def, resolveBuilders)
 	case def.IsScalar():
 		hint = scalarHint(def)
 	case def.IsRef():
@@ -80,9 +80,9 @@ func (generator *typehints) arrayHint(def ast.Type, resolveBuilders bool) string
 	return fmt.Sprintf("array<%s>", valueType)
 }
 
-func (generator *typehints) mapHint(def ast.Type) string {
-	indexType := generator.forType(def.Map.IndexType, false)
-	valueType := generator.forType(def.Map.ValueType, false)
+func (generator *typehints) mapHint(def ast.Type, resolveBuilders bool) string {
+	indexType := generator.forType(def.Map.IndexType, resolveBuilders)
+	valueType := generator.forType(def.Map.ValueType, resolveBuilders)
 
 	return fmt.Sprintf("array<%s, %s>", indexType, valueType)
 }

--- a/internal/jennies/python/templates/builders/assignment.tmpl
+++ b/internal/jennies/python/templates/builders/assignment.tmpl
@@ -20,7 +20,7 @@
 {{- define "assignment_setup" }}
 {{- with .Value.Argument }}
 {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
-{{- $builtResultSuffix := ternary "_resources" "_resource" .Type.IsArray }}
+{{- $builtResultSuffix := ternary "_resources" "_resource" (or .Type.IsArray .Type.IsMap) }}
 {{ .Name|formatIdentifier }}{{ $builtResultSuffix }} = {{ template "unfold_builders" (dict "InputType" .Type "InputVar" (formatIdentifier .Name) "Depth" 1) }}
 {{- end }}
 {{- end }}
@@ -34,6 +34,8 @@
 {{- define "unfold_builders" }}
 {{- if .InputType.IsArray -}}
 [{{ template "unfold_builders" (dict "InputType" .InputType.Array.ValueType "InputVar" (print "r" .Depth ) "Depth" (add1 .Depth)) }} for r{{ .Depth }} in {{ .InputVar }}]
+{{- else if .InputType.IsMap -}}
+{ key{{.Depth}}: {{ template "unfold_builders" (dict "InputType" .InputType.Map.ValueType "InputVar" (print "val" .Depth ) "Depth" (add1 .Depth)) }} for (key{{.Depth}}, val{{ .Depth }}) in {{ .InputVar }}.items() }
 {{- else -}}
 {{ .InputVar }}.build()
 {{- end -}}
@@ -45,7 +47,7 @@
 {{- end }}
 {{- with .Value.Argument }}
 {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
-{{- .Name|formatIdentifier }}{{- .Type.IsArray | ternary "_resources" "_resource" }}
+{{- .Name|formatIdentifier }}{{- (or .Type.IsArray .Type.IsMap) | ternary "_resources" "_resource" }}
 {{- else }}
 {{- .Name|formatIdentifier }}
 {{- end }}

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -58,6 +58,15 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
 {{- define "unfold_builders" }}
     {{- if .InputType.IsArray -}}
         {{ .InputVar }}.map(builder{{ .Depth }} => {{ template "unfold_builders" (dict "InputType" .InputType.Array.ValueType "InputVar" (print "builder" .Depth ) "Depth" (add1 .Depth)) }})
+    {{- else if .InputType.IsMap -}}
+        (function() {
+            let results{{ .Depth }} = {};
+            for (const key{{ .Depth }} in {{ .InputVar }}) {
+                const val{{ .Depth }} = {{ .InputVar }}[key{{ .Depth }}];
+                results{{ .Depth }}[key{{ .Depth }}] = {{ template "unfold_builders" (dict "InputType" .InputType.Map.ValueType "InputVar" (print "val" .Depth ) "Depth" (add1 .Depth)) }};
+            }
+            return results{{ .Depth }};
+        }())
     {{- else if typeIsDisjunctionOfBuilders .InputType -}}
         {{ .InputVar }}.build()
     {{- else if .InputType.IsDisjunction -}}

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -127,7 +127,7 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 	case ast.KindStruct:
 		return formatter.formatStructFields(def)
 	case ast.KindMap:
-		return formatter.formatMap(def.AsMap())
+		return formatter.formatMap(def.AsMap(), resolveBuilders)
 	case ast.KindEnum:
 		return formatter.formatAnonymousEnum(def.AsEnum())
 	case ast.KindScalar:
@@ -247,9 +247,9 @@ func (formatter *typeFormatter) formatDisjunction(def ast.DisjunctionType, resol
 	return strings.Join(subTypes, " | ")
 }
 
-func (formatter *typeFormatter) formatMap(def ast.MapType) string {
-	keyTypeString := formatter.doFormatType(def.IndexType, false)
-	valueTypeString := formatter.doFormatType(def.ValueType, false)
+func (formatter *typeFormatter) formatMap(def ast.MapType, resolveBuilders bool) string {
+	keyTypeString := formatter.doFormatType(def.IndexType, resolveBuilders)
+	valueTypeString := formatter.doFormatType(def.ValueType, resolveBuilders)
 
 	return fmt.Sprintf("Record<%s, %s>", keyTypeString, valueTypeString)
 }

--- a/internal/languages/context.go
+++ b/internal/languages/context.go
@@ -29,6 +29,10 @@ func (context *Context) ResolveAsBuilder(def ast.Type) (ast.Builder, bool) {
 		return context.ResolveAsBuilder(def.AsArray().ValueType)
 	}
 
+	if def.IsMap() {
+		return context.ResolveAsBuilder(def.AsMap().ValueType)
+	}
+
 	if def.IsDisjunction() {
 		for _, branch := range def.AsDisjunction().Branches {
 			if builder, found := context.ResolveAsBuilder(branch); found {

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
@@ -1,0 +1,46 @@
+package map_of_builders
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
+
+type DashboardBuilder struct {
+    internal *Dashboard
+    errors map[string]cog.BuildErrors
+}
+
+func NewDashboardBuilder() *DashboardBuilder {
+	resource := NewDashboard()
+	builder := &DashboardBuilder{
+		internal: resource,
+		errors: make(map[string]cog.BuildErrors),
+	}
+
+	return builder
+}
+
+func (builder *DashboardBuilder) Build() (Dashboard, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return Dashboard{}, err
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Panel]) *DashboardBuilder {
+        panelsResource := make(map[string]Panel)
+        for key1, val1 := range panels {
+                panelsDepth1, err := val1.Build()
+                if err != nil {
+                    builder.errors["panels"] = err.(cog.BuildErrors)
+                    return builder
+                }
+                panelsResource[key1] = panelsDepth1
+        }
+    builder.internal.Panels = panelsResource
+
+    return builder
+}
+

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
@@ -1,0 +1,37 @@
+package map_of_builders
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Panel] = (*PanelBuilder)(nil)
+
+type PanelBuilder struct {
+    internal *Panel
+    errors map[string]cog.BuildErrors
+}
+
+func NewPanelBuilder() *PanelBuilder {
+	resource := NewPanel()
+	builder := &PanelBuilder{
+		internal: resource,
+		errors: make(map[string]cog.BuildErrors),
+	}
+
+	return builder
+}
+
+func (builder *PanelBuilder) Build() (Panel, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return Panel{}, err
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *PanelBuilder) Title(title string) *PanelBuilder {
+    builder.internal.Title = title
+
+    return builder
+}
+

--- a/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/dashboard_converter_gen.go
@@ -1,0 +1,35 @@
+package map_of_builders
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// DashboardConverter accepts a `Dashboard` object and generates the Go code to build this object using builders.
+func DashboardConverter(input Dashboard) string {
+    calls := []string{
+    `map_of_builders.NewDashboardBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Panels != nil {
+        
+    buffer.WriteString(`Panels(`)
+        arg0 := "map[string]map_of_builders.Panel{"
+        for key, arg1 := range input.Panels {
+            tmppanelsarg1 := PanelConverter(arg1)
+            arg0 += "\t" + fmt.Sprintf("%#v", key) + ": " + tmppanelsarg1 +","
+        }
+        arg0 += "}"
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/dashboard_converter_gen.go
@@ -16,7 +16,7 @@ func DashboardConverter(input Dashboard) string {
         if input.Panels != nil {
         
     buffer.WriteString(`Panels(`)
-        arg0 := "map[string]map_of_builders.Panel{"
+        arg0 := "map[string]cog.Builder[map_of_builders.Panel]{"
         for key, arg1 := range input.Panels {
             tmppanelsarg1 := PanelConverter(arg1)
             arg0 += "\t" + fmt.Sprintf("%#v", key) + ": " + tmppanelsarg1 +","

--- a/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/panel_converter_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoConverter/map_of_builders/panel_converter_gen.go
@@ -1,0 +1,30 @@
+package map_of_builders
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// PanelConverter accepts a `Panel` object and generates the Go code to build this object using builders.
+func PanelConverter(input Panel) string {
+    calls := []string{
+    `map_of_builders.NewPanelBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Title != "" {
+        
+    buffer.WriteString(`Title(`)
+        arg0 :=fmt.Sprintf("%#v", input.Title)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_builders/JavaBuilders/map_of_builders/Dashboard.java
+++ b/testdata/jennies/builders/map_of_builders/JavaBuilders/map_of_builders/Dashboard.java
@@ -1,0 +1,36 @@
+package map_of_builders;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import java.util.Map;
+
+public class Dashboard {
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    @JsonProperty("panels")
+    public Map<String, Panel> panels;
+    
+    public String toJSON() throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(this);
+    }
+
+    
+    public static class Builder implements cog.Builder<Dashboard> {
+        protected final Dashboard internal;
+        
+        public Builder() {
+            this.internal = new Dashboard();
+        }
+    public Builder panels(cog.Builder<Map<String, Panel>> panels) {
+    this.internal.panels = panels.build();
+        return this;
+    }
+    public Dashboard build() {
+            return this.internal;
+        }
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/JavaBuilders/map_of_builders/Panel.java
+++ b/testdata/jennies/builders/map_of_builders/JavaBuilders/map_of_builders/Panel.java
@@ -1,0 +1,32 @@
+package map_of_builders;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+public class Panel {
+    @JsonProperty("title")
+    public String title;
+    
+    public String toJSON() throws JsonProcessingException {
+        ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(this);
+    }
+
+    
+    public static class Builder implements cog.Builder<Panel> {
+        protected final Panel internal;
+        
+        public Builder() {
+            this.internal = new Panel();
+        }
+    public Builder title(String title) {
+    this.internal.title = title;
+        return this;
+    }
+    public Panel build() {
+            return this.internal;
+        }
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/PHPBuilder/src/MapOfBuilders/DashboardBuilder.php
+++ b/testdata/jennies/builders/map_of_builders/PHPBuilder/src/MapOfBuilders/DashboardBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfBuilders\Dashboard>
+ */
+class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfBuilders\Dashboard $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfBuilders\Dashboard();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfBuilders\Dashboard
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    /**
+     * @param array<string, \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfBuilders\Panel>> $panels
+     */
+    public function panels(array $panels): static
+    {
+            $panelsResources = [];
+            foreach ($panels as $key1 => $val1) {
+                    $panelsResources[$key1] = $val1->build();
+            }
+        $this->internal->panels = $panelsResources;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_builders/PHPBuilder/src/MapOfBuilders/PanelBuilder.php
+++ b/testdata/jennies/builders/map_of_builders/PHPBuilder/src/MapOfBuilders/PanelBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfBuilders\Panel>
+ */
+class PanelBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfBuilders\Panel $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfBuilders\Panel();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfBuilders\Panel
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    public function title(string $title): static
+    {
+        $this->internal->title = $title;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_builders/PHPConverter/src/MapOfBuilders/DashboardConverter.php
+++ b/testdata/jennies/builders/map_of_builders/PHPConverter/src/MapOfBuilders/DashboardConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+final class DashboardConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfBuilders\Dashboard $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfBuilders\DashboardBuilder())',
+        ];
+            
+    
+        {
+    $buffer = 'panels(';
+        $arg0 = "[";
+        foreach ($input->panels as $key => $arg1) {
+            $tmppanelsarg1 = \Grafana\Foundation\MapOfBuilders\PanelConverter::convert($arg1);
+            $arg0 .= "\t".var_export($key, true)." => $tmppanelsarg1,";
+        }
+        $arg0 .= "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/map_of_builders/PHPConverter/src/MapOfBuilders/PanelConverter.php
+++ b/testdata/jennies/builders/map_of_builders/PHPConverter/src/MapOfBuilders/PanelConverter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+final class PanelConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfBuilders\Panel $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfBuilders\PanelBuilder())',
+        ];
+            if ($input->title !== "") {
+    
+        
+    $buffer = 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/map_of_builders/PythonBuilder/builders/map_of_builders.py
+++ b/testdata/jennies/builders/map_of_builders/PythonBuilder/builders/map_of_builders.py
@@ -1,0 +1,41 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import map_of_builders
+
+
+class Panel(cogbuilder.Builder[map_of_builders.Panel]):    
+    _internal: map_of_builders.Panel
+
+    def __init__(self):
+        self._internal = map_of_builders.Panel()
+
+    def build(self) -> map_of_builders.Panel:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def title(self, title: str) -> typing.Self:        
+        self._internal.title = title
+    
+        return self
+    
+
+class Dashboard(cogbuilder.Builder[map_of_builders.Dashboard]):    
+    _internal: map_of_builders.Dashboard
+
+    def __init__(self):
+        self._internal = map_of_builders.Dashboard()
+
+    def build(self) -> map_of_builders.Dashboard:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def panels(self, panels: dict[str, cogbuilder.Builder[map_of_builders.Panel]]) -> typing.Self:        
+        panels_resources = { key1: val1.build() for (key1, val1) in panels.items() }
+        self._internal.panels = panels_resources
+    
+        return self
+    

--- a/testdata/jennies/builders/map_of_builders/TypescriptBuilder/src/mapOfBuilders/dashboardBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_builders/TypescriptBuilder/src/mapOfBuilders/dashboardBuilder.gen.ts
@@ -1,0 +1,30 @@
+import * as cog from '../cog';
+import * as mapOfBuilders from '../mapOfBuilders';
+
+export class DashboardBuilder implements cog.Builder<mapOfBuilders.Dashboard> {
+    protected readonly internal: mapOfBuilders.Dashboard;
+
+    constructor() {
+        this.internal = mapOfBuilders.defaultDashboard();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfBuilders.Dashboard {
+        return this.internal;
+    }
+
+    panels(panels: Record<string, cog.Builder<mapOfBuilders.Panel>>): this {
+        const panelsResource = (function() {
+            let results1 = {};
+            for (const key1 in panels) {
+                const val1 = panels[key1];
+                results1[key1] = val1.build();
+            }
+            return results1;
+        }());
+        this.internal.panels = panelsResource;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/TypescriptBuilder/src/mapOfBuilders/panelBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_builders/TypescriptBuilder/src/mapOfBuilders/panelBuilder.gen.ts
@@ -1,0 +1,22 @@
+import * as cog from '../cog';
+import * as mapOfBuilders from '../mapOfBuilders';
+
+export class PanelBuilder implements cog.Builder<mapOfBuilders.Panel> {
+    protected readonly internal: mapOfBuilders.Panel;
+
+    constructor() {
+        this.internal = mapOfBuilders.defaultPanel();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfBuilders.Panel {
+        return this.internal;
+    }
+
+    title(title: string): this {
+        this.internal.title = title;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/builders_context.json
+++ b/testdata/jennies/builders/map_of_builders/builders_context.json
@@ -1,0 +1,296 @@
+{
+  "Schemas": [
+    {
+      "Package": "map_of_builders",
+      "Metadata": {
+        "Kind": "core"
+      },
+      "EntryPointType": {
+        "Kind": "",
+        "Nullable": false
+      },
+      "Objects": {
+        "Panel": {
+          "Name": "Panel",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_builders",
+            "ReferredType": "Panel"
+          }
+        },
+        "Dashboard": {
+          "Name": "Dashboard",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "panels",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_builders",
+                          "ReferredType": "Panel"
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_builders",
+            "ReferredType": "Dashboard"
+          }
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "For": {
+        "Name": "Panel",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_builders",
+          "ReferredType": "Panel"
+        }
+      },
+      "Package": "map_of_builders",
+      "Name": "Panel",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "title",
+          "Args": [
+            {
+              "Name": "title",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "For": {
+        "Name": "Dashboard",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "panels",
+                "Type": {
+                  "Kind": "map",
+                  "Nullable": false,
+                  "Map": {
+                    "IndexType": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "ValueType": {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "map_of_builders",
+                        "ReferredType": "Panel"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_builders",
+          "ReferredType": "Dashboard"
+        }
+      },
+      "Package": "map_of_builders",
+      "Name": "Dashboard",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "panels",
+          "Args": [
+            {
+              "Name": "panels",
+              "Type": {
+                "Kind": "map",
+                "Nullable": false,
+                "Map": {
+                  "IndexType": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "ValueType": {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "map_of_builders",
+                      "ReferredType": "Panel"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "panels",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_builders",
+                          "ReferredType": "Panel"
+                        }
+                      }
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "panels",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_builders",
+                          "ReferredType": "Panel"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/builders/map_of_builders/schema.cue
+++ b/testdata/jennies/builders/map_of_builders/schema.cue
@@ -1,0 +1,11 @@
+package map_of_builders
+
+Panel: {
+	title: string
+}
+
+Dashboard: {
+	panels: {
+		[string]: Panel
+	}
+}


### PR DESCRIPTION
Given the following schema:

```cue
Panel: {
  title: string
}

Dashboard: {
  panels: {
    [string]: Panel
  }
}
```

One would expect a DashboardBuilder to be generated with the following option:

```go
func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Panel]) {
  // …
}
```

Without this PR, the following option is generated:

```go
func (builder *DashboardBuilder) Panels(panels map[string]Panel) { // note: map of panels, not panel builders
  // …
}
```

ToDo:

* [x] ~java~ → https://github.com/grafana/cog/issues/684
* [x] update go converters
* [x] update PHP converters