### PR TITLE
Do not generate a type assertion for dict values in Python builders nil-check guards

### DIFF
--- a/internal/jennies/python/templates/builders/nilcheck.tmpl
+++ b/internal/jennies/python/templates/builders/nilcheck.tmpl
@@ -1,5 +1,5 @@
 {{- define "nil_check" -}}
 if self._internal.{{ .Path|formatPath }} is None:
     self._internal.{{ .Path|formatPath }} = {{ .EmptyValueType|defaultForType }}
-{{ if not .EmptyValueType.IsArray }}assert isinstance(self._internal.{{ .Path|formatPath }}, {{.EmptyValueType|formatRawTypeNotNullable}}){{ end }}
+{{ if not (or .EmptyValueType.IsArray .EmptyValueType.IsMap) }}assert isinstance(self._internal.{{ .Path|formatPath }}, {{.EmptyValueType|formatRawTypeNotNullable}}){{ end }}
 {{- end }}

--- a/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
@@ -18,7 +18,7 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     def annotations(self, key: str, value: str) -> typing.Self:        
         if self._internal.annotations is None:
             self._internal.annotations = {}
-        assert isinstance(self._internal.annotations, dict[str, str])
+        
         self._internal.annotations[key] = value
     
         return self


### PR DESCRIPTION
These assertions aren't actually valid Python code :|