### PR TITLE
Java: Move defaults from builder into default constructor

### DIFF
--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -62,14 +62,13 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 		Constructor:          builder.Constructor,
 		Options:              builder.Options,
 		Properties:           builder.Properties,
-		Defaults:             jenny.genDefaults(context, builder.Options),
 		ImportAlias:          jenny.config.PackagePath,
 		IsGenericPanel:       jenny.isGenericPanel(builder),
 	}
 
 	return jenny.tmpl.Funcs(map[string]any{
 		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
-		"emptyValueForType":        jenny.typeFormatter.defaultValueFor,
+		"emptyValueForType":        jenny.typeFormatter.emptyValueForType,
 		"shouldCastNilCheck":       jenny.typeFormatter.shouldCastNilCheck,
 		"formatCastValue":          jenny.typeFormatter.formatCastValue,
 		"typeHasBuilder":           jenny.typeFormatter.typeHasBuilder,
@@ -99,120 +98,4 @@ func (jenny Builder) isGenericPanel(builder ast.Builder) bool {
 	}
 
 	return builder.Name == "Panel"
-}
-
-func (jenny Builder) genDefaults(context languages.Context, options []ast.Option) []OptionCall {
-	calls := make([]OptionCall, 0)
-	for _, opt := range options {
-		if opt.Default == nil || len(opt.Args) == 0 {
-			continue
-		}
-
-		calls = append(calls, OptionCall{
-			Initializers: jenny.formatInitializers(context, opt.Args),
-			OptionName:   tools.UpperCamelCase(opt.Name),
-			Args:         jenny.formatDefaultValues(context, opt.Args),
-		})
-	}
-
-	return calls
-}
-
-// formatInitializers initialises objects with their defaults before set the value in the corresponding setter.
-// TODO: It could have conflicts if we have different fields with the same kind of argument.
-// TODO: It means that we need to initialize the objects with different names in that case.
-func (jenny Builder) formatInitializers(context languages.Context, args []ast.Argument) []string {
-	initializers := make([]string, 0)
-	for _, arg := range args {
-		if !arg.Type.IsRef() {
-			return nil
-		}
-
-		ref := arg.Type.AsRef()
-		object, _ := context.LocateObject(ref.ReferredPkg, ref.ReferredType)
-		if !object.Type.IsStruct() {
-			return nil
-		}
-
-		structType := object.Type.AsStruct()
-		defValues := arg.Type.Default.(map[string]interface{})
-
-		constructorFormat := "%s %sResource = new %s();"
-		setterFormat := "%sResource.%s = %s;"
-		fieldNameFunc := func(s string) string {
-			return s
-		}
-		if jenny.typeFormatter.typeHasBuilder(arg.Type) {
-			constructorFormat = "%sBuilder %sResource = new %sBuilder();"
-			setterFormat = "%sResource.%s(%s);"
-			fieldNameFunc = tools.LowerCamelCase
-		}
-
-		initializers = append(initializers, fmt.Sprintf(constructorFormat, ref.ReferredType, tools.LowerCamelCase(ref.ReferredType), ref.ReferredType))
-		for _, field := range structType.Fields {
-			if defVal, ok := defValues[field.Name]; ok {
-				if field.Type.IsScalar() {
-					initializers = append(initializers, fmt.Sprintf(setterFormat, tools.LowerCamelCase(ref.ReferredType), fieldNameFunc(field.Name), formatType(field.Type.AsScalar().ScalarKind, defVal)))
-				}
-				// TODO: Implement lists if needed
-			}
-		}
-	}
-
-	return initializers
-}
-
-func (jenny Builder) formatDefaultValues(context languages.Context, args []ast.Argument) []string {
-	argumentList := make([]string, 0, len(args))
-	for _, arg := range args {
-		switch arg.Type.Kind {
-		case ast.KindRef:
-			argumentList = append(argumentList, jenny.formatDefaultReference(context, arg.Type.AsRef(), arg.Type.Default))
-		case ast.KindScalar:
-			scalar := arg.Type.AsScalar()
-			argumentList = append(argumentList, formatType(scalar.ScalarKind, arg.Type.Default))
-		case ast.KindArray:
-			array := arg.Type.AsArray()
-			if array.IsArrayOfScalars() {
-				argumentList = append(argumentList, fmt.Sprintf("List.of(%s)", jenny.typeFormatter.formatScalar(arg.Type.Default)))
-			}
-		case ast.KindStruct:
-			// TODO: Java is using veneers to avoid anonymous structs but it should be detailed if we need it at any moment.
-			argumentList = append(argumentList, "new Object()")
-		}
-		// TODO: Implement the rest of types if any
-	}
-
-	return argumentList
-}
-
-func (jenny Builder) formatDefaultReference(context languages.Context, ref ast.RefType, defValue any) string {
-	object, _ := context.LocateObject(ref.ReferredPkg, ref.ReferredType)
-	switch object.Type.Kind {
-	case ast.KindEnum:
-		for _, v := range object.Type.AsEnum().Values {
-			if defValue == v.Value {
-				return fmt.Sprintf("%s.%s", object.Name, tools.UpperSnakeCase(v.Name))
-			}
-		}
-	case ast.KindStruct:
-		if jenny.typeFormatter.typeHasBuilder(object.Type) {
-			// TODO: Builder could have arguments 🙃
-			builder := fmt.Sprintf("new %sBuilder()", tools.UpperCamelCase(object.Name))
-			structType := object.Type.AsStruct()
-			defValues := defValue.(map[string]interface{})
-			for _, field := range structType.Fields {
-				if f, ok := defValues[field.Name]; ok {
-					builder = fmt.Sprintf("%s.%s(%#v)", builder, tools.LowerCamelCase(field.Name), f)
-				}
-			}
-			return builder + ".build()"
-		}
-
-		jenny.imports.Add(ref.ReferredType+"Builder", ref.ReferredPkg)
-
-		return fmt.Sprintf("%sResource", tools.LowerCamelCase(object.Name))
-	}
-
-	return ""
 }

--- a/internal/jennies/java/templates/builders/builder.tmpl
+++ b/internal/jennies/java/templates/builders/builder.tmpl
@@ -23,13 +23,6 @@ public class {{ .BuilderName }}Builder{{ if .IsGenericPanel }}<T extends {{ .Bui
     {{- range .Properties }}
     this.{{ .Name | escapeVar }} = {{ .Type | emptyValueForType }};
     {{- end }}
-
-    {{- range .Defaults }}
-    {{- range .Initializers }}
-    {{ . }}
-    {{- end }}
-    this.{{ .OptionName | lowerCamelCase | escapeVar }}({{ .Args|join ", " }});
-    {{- end }}
     }
     
     {{- range $opt := .Options }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -29,7 +29,11 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     }
     {{- end }}
     {{- else if .DefaultConstructorArgs }}
-    public {{ $.Name }}() {}
+    public {{ $.Name }}() {
+        {{- range .Defaults }}
+        this.{{ .Name | lowerCamelCase | escapeVar }} = {{ .Value }};
+        {{- end }}
+    }
     
     public {{ $.Name }}({{- template "args" dict "Arguments" .DefaultConstructorArgs "IsBuilder" false }}) {
         {{- range .DefaultConstructorArgs }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -123,6 +123,7 @@ type ClassTemplate struct {
 
 	Fields     []ast.StructField
 	Builders   []BuilderTemplate
+	Defaults   []Default
 	HasBuilder bool
 
 	Variant                 string
@@ -158,14 +159,12 @@ type BuilderTemplate struct {
 	Constructor          ast.Constructor
 	Properties           []ast.StructField
 	Options              []ast.Option
-	Defaults             []OptionCall
 	IsGenericPanel       bool
 }
 
-type OptionCall struct {
-	Initializers []string
-	OptionName   string
-	Args         []string
+type Default struct {
+	Name  string
+	Value string
 }
 
 type DataquerySchema struct {

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -66,7 +66,7 @@ func formatType(t ast.ScalarKind, val interface{}) string {
 	switch t {
 	case ast.KindInt64, ast.KindUint64:
 		return fmt.Sprintf("%dL", parseIntVal(val))
-	case ast.KindInt32, ast.KindUint32:
+	case ast.KindInt8, ast.KindUint8, ast.KindInt16, ast.KindUint16, ast.KindInt32, ast.KindUint32:
 		return fmt.Sprintf("%d", parseIntVal(val))
 	case ast.KindFloat32:
 		return fmt.Sprintf("%.1ff", parseFloatVal(val))

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilder/basic_struct_defaults/SomeStructBuilder.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilder/basic_struct_defaults/SomeStructBuilder.java
@@ -7,10 +7,6 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
     
     public SomeStructBuilder() {
         this.internal = new SomeStruct();
-    this.id(42L);
-    this.uid("default-uid");
-    this.tags(List.of("generated", "cog"));
-    this.liveNow(true);
     }
     public SomeStructBuilder id(Long id) {
     this.internal.id = id;

--- a/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
+++ b/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
@@ -6,7 +6,6 @@ public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Pane
     
     public PanelBuilder() {
         this.internal = new Panel();
-    this.onlyFromThisDashboard(false);
     }
     public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
     this.internal.onlyFromThisDashboard = onlyFromThisDashboard;

--- a/testdata/jennies/builders/panel_builders/JavaBuilder/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilder/panelbuilder/PanelBuilder.java
@@ -7,15 +7,6 @@ public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Opti
     
     public PanelBuilder() {
         this.internal = new Options();
-    this.onlyFromThisDashboard(false);
-    this.onlyInTimeRange(false);
-    this.limit(10);
-    this.showUser(true);
-    this.showTime(true);
-    this.showTags(true);
-    this.navigateToPanel(true);
-    this.navigateBefore("10m");
-    this.navigateAfter("10m");
     }
     public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
     this.internal.onlyFromThisDashboard = onlyFromThisDashboard;

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/StructBuilder.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/StructBuilder.java
@@ -1,21 +1,11 @@
 package struct_with_defaults;
 
-import struct_with_defaults.NestedStructBuilder;
 
 public class StructBuilder implements cog.Builder<Struct> {
     protected final Struct internal;
     
     public StructBuilder() {
         this.internal = new Struct();
-    NestedStructBuilder nestedStructResource = new NestedStructBuilder();
-    nestedStructResource.stringVal("hello");
-    nestedStructResource.intVal(3L);
-    this.allFields(nestedStructResource);
-    NestedStructBuilder nestedStructResource = new NestedStructBuilder();
-    nestedStructResource.intVal(4L);
-    this.partialFields(nestedStructResource);
-    this.complexField(new Object());
-    this.partialComplexField(new Object());
     }
     public StructBuilder allFields(cog.Builder<NestedStruct> allFields) {
     this.internal.allFields = allFields.build();

--- a/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
+++ b/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
@@ -3,7 +3,8 @@ package arrays;
 
 public class SomeStruct {
     public Object fieldAny;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
@@ -6,7 +6,8 @@ import java.util.List;
 public class RefStruct {
     public Map<String, String> labels;
     public List<String> tags;
-    public RefStruct() {}
+    public RefStruct() {
+    }
     
     public RefStruct(Map<String, String> labels,List<String> tags) {
         this.labels = labels;

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
@@ -6,7 +6,8 @@ public class SomeStruct {
     public Long maybeId;
     public String title;
     public refStruct refStruct;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(Long id,Long maybeId,String title,refStruct refStruct) {
         this.id = id;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
@@ -5,7 +5,8 @@ import java.util.List;
 public class Dashboard {
     public String title;
     public List<Panel> panels;
-    public Dashboard() {}
+    public Dashboard() {
+    }
     
     public Dashboard(String title,List<Panel> panels) {
         this.title = title;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/DataSourceRef.java
@@ -4,7 +4,8 @@ package dashboard;
 public class DataSourceRef {
     public String type;
     public String uid;
-    public DataSourceRef() {}
+    public DataSourceRef() {
+    }
     
     public DataSourceRef(String type,String uid) {
         this.type = type;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfig.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfig.java
@@ -4,7 +4,8 @@ package dashboard;
 public class FieldConfig {
     public String unit;
     public Object custom;
-    public FieldConfig() {}
+    public FieldConfig() {
+    }
     
     public FieldConfig(String unit,Object custom) {
         this.unit = unit;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfigSource.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/FieldConfigSource.java
@@ -3,7 +3,8 @@ package dashboard;
 
 public class FieldConfigSource {
     public FieldConfig defaults;
-    public FieldConfigSource() {}
+    public FieldConfigSource() {
+    }
     
     public FieldConfigSource(FieldConfig defaults) {
         this.defaults = defaults;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
@@ -10,7 +10,8 @@ public class Panel {
     public Object options;
     public List<Dataquery> targets;
     public FieldConfigSource fieldConfig;
-    public Panel() {}
+    public Panel() {
+    }
     
     public Panel(String title,String type,DataSourceRef datasource,Object options,List<Dataquery> targets,FieldConfigSource fieldConfig) {
         this.title = title;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
@@ -4,7 +4,8 @@ package disjunctions;
 public class BoolOrRef {
     public Boolean bool;
     public SomeStruct someStruct;
-    public BoolOrRef() {}
+    public BoolOrRef() {
+    }
     
     public BoolOrRef(Boolean bool,SomeStruct someStruct) {
         this.bool = bool;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
@@ -4,7 +4,8 @@ package disjunctions;
 public class SomeOtherStruct {
     public String type;
     public Byte foo;
-    public SomeOtherStruct() {}
+    public SomeOtherStruct() {
+    }
     
     public SomeOtherStruct(String type,Byte foo) {
         this.type = type;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
@@ -4,7 +4,8 @@ package disjunctions;
 public class SomeStruct {
     public String type;
     public Object fieldAny;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(String type,Object fieldAny) {
         this.type = type;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
@@ -4,7 +4,8 @@ package disjunctions;
 public class YetAnotherStruct {
     public String type;
     public Integer bar;
-    public YetAnotherStruct() {}
+    public YetAnotherStruct() {
+    }
     
     public YetAnotherStruct(String type,Integer bar) {
         this.type = type;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
@@ -6,7 +6,8 @@ public class DefaultsStructComplexField {
     public String uid;
     public DefaultsStructComplexFieldNested nested;
     public List<String> array;
-    public DefaultsStructComplexField() {}
+    public DefaultsStructComplexField() {
+    }
     
     public DefaultsStructComplexField(String uid,DefaultsStructComplexFieldNested nested,List<String> array) {
         this.uid = uid;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
@@ -3,7 +3,8 @@ package defaults;
 
 public class DefaultsStructComplexFieldNested {
     public String nestedVal;
-    public DefaultsStructComplexFieldNested() {}
+    public DefaultsStructComplexFieldNested() {
+    }
     
     public DefaultsStructComplexFieldNested(String nestedVal) {
         this.nestedVal = nestedVal;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
@@ -4,7 +4,8 @@ package defaults;
 public class DefaultsStructPartialComplexField {
     public String uid;
     public Long intVal;
-    public DefaultsStructPartialComplexField() {}
+    public DefaultsStructPartialComplexField() {
+    }
     
     public DefaultsStructPartialComplexField(String uid,Long intVal) {
         this.uid = uid;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
@@ -4,7 +4,8 @@ package defaults;
 public class NestedStruct {
     public String stringVal;
     public Long intVal;
-    public NestedStruct() {}
+    public NestedStruct() {
+    }
     
     public NestedStruct(String stringVal,Long intVal) {
         this.stringVal = stringVal;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
@@ -7,7 +7,12 @@ public class Struct {
     public NestedStruct emptyFields;
     public DefaultsStructComplexField complexField;
     public DefaultsStructPartialComplexField partialComplexField;
-    public Struct() {}
+    public Struct() {
+        this.allFields = new NestedStruct("hello", 3L);
+        this.partialFields = new NestedStruct("", 3L);
+        this.complexField = new DefaultsStructComplexField("myUID", new DefaultsStructComplexFieldNested("nested"), List.of("hello"));
+        this.partialComplexField = new DefaultsStructPartialComplexField("", 0L);
+    }
     
     public Struct(NestedStruct allFields,NestedStruct partialFields,NestedStruct emptyFields,DefaultsStructComplexField complexField,DefaultsStructPartialComplexField partialComplexField) {
         this.allFields = allFields;

--- a/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
+++ b/testdata/jennies/rawtypes/intersections/JavaRawTypes/intersections/SomeStruct.java
@@ -3,7 +3,9 @@ package intersections;
 
 public class SomeStruct {
     public Boolean fieldBool;
-    public SomeStruct() {}
+    public SomeStruct() {
+        this.fieldBool = true;
+    }
     
     public SomeStruct(Boolean fieldBool) {
         this.fieldBool = fieldBool;

--- a/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
+++ b/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
@@ -3,7 +3,8 @@ package maps;
 
 public class SomeStruct {
     public Object fieldAny;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
@@ -3,7 +3,8 @@ package withdashes;
 
 public class SomeStruct {
     public Object fieldAny;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
@@ -3,7 +3,8 @@ package refs;
 
 public class RefToSomeStruct {
     public Object fieldAny;
-    public RefToSomeStruct() {}
+    public RefToSomeStruct() {
+    }
     
     public RefToSomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
@@ -3,7 +3,8 @@ package struct_complex_fields;
 
 public class SomeOtherStruct {
     public Object fieldAny;
-    public SomeOtherStruct() {}
+    public SomeOtherStruct() {
+    }
     
     public SomeOtherStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -14,7 +14,8 @@ public class SomeStruct {
     public Map<String, String> fieldMapOfStringToString;
     public StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
     public String fieldRefToConstant;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(SomeOtherStruct fieldRef,StringOrBool fieldDisjunctionOfScalars,StringOrSomeOtherStruct fieldMixedDisjunction,String fieldDisjunctionWithNull,SomeStructOperator operator,List<String> fieldArrayOfStrings,Map<String, String> fieldMapOfStringToString,StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct,String fieldRefToConstant) {
         this.fieldRef = fieldRef;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
@@ -4,7 +4,8 @@ package struct_complex_fields;
 public class StringOrSomeOtherStruct {
     public String string;
     public SomeOtherStruct someOtherStruct;
-    public StringOrSomeOtherStruct() {}
+    public StringOrSomeOtherStruct() {
+    }
     
     public StringOrSomeOtherStruct(String string,SomeOtherStruct someOtherStruct) {
         this.string = string;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
@@ -3,7 +3,8 @@ package struct_complex_fields;
 
 public class StructComplexFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
-    public StructComplexFieldsSomeStructFieldAnonymousStruct() {}
+    public StructComplexFieldsSomeStructFieldAnonymousStruct() {
+    }
     
     public StructComplexFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
@@ -7,7 +7,12 @@ public class SomeStruct {
     public String fieldStringWithConstantValue;
     public Float fieldFloat32;
     public Integer fieldInt32;
-    public SomeStruct() {}
+    public SomeStruct() {
+        this.fieldBool = true;
+        this.fieldString = "foo";
+        this.fieldFloat32 = 42.4f;
+        this.fieldInt32 = 42;
+    }
     
     public SomeStruct(Boolean fieldBool,String fieldString,String fieldStringWithConstantValue,Float fieldFloat32,Integer fieldInt32) {
         this.fieldBool = fieldBool;

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
@@ -3,7 +3,8 @@ package struct_optional_fields;
 
 public class SomeOtherStruct {
     public Object fieldAny;
-    public SomeOtherStruct() {}
+    public SomeOtherStruct() {
+    }
     
     public SomeOtherStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeStruct.java
@@ -8,7 +8,8 @@ public class SomeStruct {
     public SomeStructOperator operator;
     public List<String> fieldArrayOfStrings;
     public StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(SomeOtherStruct fieldRef,String fieldString,SomeStructOperator operator,List<String> fieldArrayOfStrings,StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct) {
         this.fieldRef = fieldRef;

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
@@ -3,7 +3,8 @@ package struct_optional_fields;
 
 public class StructOptionalFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
-    public StructOptionalFieldsSomeStructFieldAnonymousStruct() {}
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct() {
+    }
     
     public StructOptionalFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
@@ -23,7 +23,8 @@ public class SomeStruct {
     public Short fieldInt16;
     public Integer fieldInt32;
     public Long fieldInt64;
-    public SomeStruct() {}
+    public SomeStruct() {
+    }
     
     public SomeStruct(Object fieldAny,Boolean fieldBool,Byte fieldBytes,String fieldString,String fieldStringWithConstantValue,Float fieldFloat32,Double fieldFloat64,Integer fieldUint8,Short fieldUint16,Integer fieldUint32,Long fieldUint64,Integer fieldInt8,Short fieldInt16,Integer fieldInt32,Long fieldInt64) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
+++ b/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
@@ -3,7 +3,8 @@ package time_hint;
 
 public class ObjWithTimeField {
     public String registeredAt;
-    public ObjWithTimeField() {}
+    public ObjWithTimeField() {
+    }
     
     public ObjWithTimeField(String registeredAt) {
         this.registeredAt = registeredAt;

--- a/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
+++ b/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
@@ -4,7 +4,8 @@ package variant_dataquery;
 public class Query implements cog.variants.Dataquery {
     public String expr;
     public Boolean instant;
-    public Query() {}
+    public Query() {
+    }
     
     public Query(String expr,Boolean instant) {
         this.expr = expr;

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
@@ -3,7 +3,8 @@ package variant_panelcfg_full;
 
 public class FieldConfig {
     public String timeseriesFieldConfigOption;
-    public FieldConfig() {}
+    public FieldConfig() {
+    }
     
     public FieldConfig(String timeseriesFieldConfigOption) {
         this.timeseriesFieldConfigOption = timeseriesFieldConfigOption;

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
@@ -3,7 +3,8 @@ package variant_panelcfg_full;
 
 public class Options {
     public String timeseriesOption;
-    public Options() {}
+    public Options() {
+    }
     
     public Options(String timeseriesOption) {
         this.timeseriesOption = timeseriesOption;

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
@@ -3,7 +3,8 @@ package variant_panelcfg_only_options;
 
 public class Options {
     public String content;
-    public Options() {}
+    public Options() {
+    }
     
     public Options(String content) {
         this.content = content;


### PR DESCRIPTION
Closes: https://github.com/grafana/cog/issues/660

The main motivation of this is to have the same structure than the other languages. The defaults defined in schemas should be inside the default constructor to ensure to set these values if someone decides not to use the builders.

I also deleted some unused code to clean it up a bit...