### PR TITLE
Sort constants in java to ensure a deterministic output

### DIFF
--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -3,6 +3,7 @@ package java
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/grafana/codejen"
@@ -201,6 +202,11 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 			Value: scalar.Value,
 		})
 	}
+
+	// To ensure deterministic output
+	sort.SliceStable(constants, func(i, j int) bool {
+		return constants[i].Name < constants[j].Name
+	})
 
 	return jenny.getTemplate().RenderAsBytes("types/constants.tmpl", ConstantTemplate{
 		Package:   jenny.config.formatPackage(pkg),


### PR DESCRIPTION
This has been itching me for a while :sweat_smile: 

In PRs, we often get a preview diff with Java constant definitions flapping around:

```patch
diff --new-file --unidirectional-new-file '--color=never' --unified --recursive '--exclude=.git' '--exclude=gradle.properties' '--exclude=pyproject.toml' '--exclude=package.json' '--exclude=*.md' /tmp/foundation-workspace-main/foundation-sdk/java/src/main/java/com/grafana/foundation/common/Constants.java /tmp/foundation-workspace-current/foundation-sdk/java/src/main/java/com/grafana/foundation/common/Constants.java
--- /tmp/foundation-workspace-main/foundation-sdk/java/src/main/java/com/grafana/foundation/common/Constants.java	2025-01-09 11:56:53.298994454 +0000
+++ /tmp/foundation-workspace-current/foundation-sdk/java/src/main/java/com/grafana/foundation/common/Constants.java	2025-01-09 11:56:36.712904983 +0000
@@ -3,6 +3,6 @@
 package com.grafana.foundation.common;
 
 public class Constants {
-    public static final String TimeZoneUtc = "utc";
     public static final String TimeZoneBrowser = "browser";
+    public static final String TimeZoneUtc = "utc";
 }
```

To avoid this, we now sort constants before generating them.