### PR TITLE
Configurable filepath prefix in typescript

### DIFF
--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
@@ -39,8 +38,7 @@ func (jenny *Builder) Generate(context languages.Context) (codejen.Files, error)
 			return nil, err
 		}
 
-		filename := filepath.Join(
-			"src",
+		filename := jenny.config.pathWithPrefix(
 			formatPackageName(builder.Package),
 			fmt.Sprintf("%sBuilder.gen.ts", tools.LowerCamelCase(builder.Name)),
 		)

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -19,6 +19,7 @@ func TestBuilder_Generate(t *testing.T) {
 	}
 
 	config := Config{}
+	config.applyDefaults()
 	language := New(config)
 	jenny := Builder{
 		config:          config,

--- a/internal/jennies/typescript/index.go
+++ b/internal/jennies/typescript/index.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/grafana/codejen"
@@ -11,6 +10,7 @@ import (
 )
 
 type Index struct {
+	config  Config
 	Targets languages.Config
 }
 
@@ -35,7 +35,8 @@ func (jenny Index) Generate(context languages.Context) (codejen.Files, error) {
 	}
 
 	for pkg, refs := range packages {
-		files = append(files, *codejen.NewFile(filepath.Join("src", formatPackageName(pkg), "index.ts"), jenny.generateIndex(refs), jenny))
+		filename := jenny.config.pathWithPrefix(formatPackageName(pkg), "index.ts")
+		files = append(files, *codejen.NewFile(filename, jenny.generateIndex(refs), jenny))
 	}
 
 	return files, nil

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -2,7 +2,6 @@ package typescript
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/grafana/codejen"
@@ -34,8 +33,7 @@ func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error)
 			return nil, err
 		}
 
-		filename := filepath.Join(
-			"src",
+		filename := jenny.config.pathWithPrefix(
 			formatPackageName(schema.Package),
 			"types.gen.ts",
 		)

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -16,6 +16,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	config := Config{}
+	config.applyDefaults()
 	jenny := RawTypes{config: config}
 	compilerPasses := New(config).CompilerPasses()
 

--- a/internal/jennies/typescript/runtime.go
+++ b/internal/jennies/typescript/runtime.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Runtime struct {
+	config Config
 }
 
 func (jenny Runtime) JennyName() string {
@@ -14,9 +15,9 @@ func (jenny Runtime) JennyName() string {
 
 func (jenny Runtime) Generate(_ languages.Context) (codejen.Files, error) {
 	return codejen.Files{
-		*codejen.NewFile("src/cog/variants_gen.ts", []byte(jenny.generateVariantsFile()), jenny),
-		*codejen.NewFile("src/cog/builder_gen.ts", []byte(jenny.generateOptionsBuilderFile()), jenny),
-		*codejen.NewFile("src/cog/index.ts", []byte(jenny.generateIndexFile()), jenny),
+		*codejen.NewFile(jenny.config.pathWithPrefix("cog/variants_gen.ts"), []byte(jenny.generateVariantsFile()), jenny),
+		*codejen.NewFile(jenny.config.pathWithPrefix("cog/builder_gen.ts"), []byte(jenny.generateOptionsBuilderFile()), jenny),
+		*codejen.NewFile(jenny.config.pathWithPrefix("cog/index.ts"), []byte(jenny.generateIndexFile()), jenny),
 	}, nil
 }
 

--- a/internal/jennies/typescript/runtime_test.go
+++ b/internal/jennies/typescript/runtime_test.go
@@ -9,7 +9,10 @@ import (
 
 func TestRuntime(t *testing.T) {
 	req := require.New(t)
-	jenny := Runtime{}
+
+	config := Config{}
+	config.applyDefaults()
+	jenny := Runtime{config: config}
 
 	files, err := jenny.Generate(languages.Context{})
 	req.NoError(err)

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -21,3 +21,7 @@ func AnyToInt64(value any) int64 {
 
 	return value.(int64)
 }
+
+func ToPtr[T any](v T) *T {
+	return &v
+}

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -444,7 +444,8 @@
     "TypescriptConfig": {
       "properties": {
         "path_prefix": {
-          "type": "string"
+          "type": "string",
+          "description": "PathPrefix holds an optional prefix for all Typescript file paths generated.\nIf left undefined, `src` is used as a default prefix."
         },
         "skip_runtime": {
           "type": "boolean",


### PR DESCRIPTION
Because there is no reason to force the generated TS code to live under a `src` directory.