### PR TITLE
Add an option allowing to emit `any` types as `interface{}` in Go

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -167,6 +167,9 @@ func (pipeline *SchemaToTypesPipeline) SchemaTransformations(passes ...compiler.
 type GoConfig struct {
 	// GenerateEqual controls the generation of `Equal()` methods on types.
 	GenerateEqual bool
+
+	// AnyAsInterface instructs cog to emit `interface{}` instead of `any`.
+	AnyAsInterface bool
 }
 
 // Golang sets the output to Golang types.
@@ -175,7 +178,8 @@ func (pipeline *SchemaToTypesPipeline) Golang(config GoConfig) *SchemaToTypesPip
 		Go: &golang.Config{
 			SkipRuntime: true,
 
-			GenerateEqual: config.GenerateEqual,
+			GenerateEqual:  config.GenerateEqual,
+			AnyAsInterface: config.AnyAsInterface,
 		},
 	}
 	return pipeline

--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -27,7 +27,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(config)
 	jenny := Builder{
 		Config:          config,
-		Tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 
@@ -47,11 +47,12 @@ func TestBuilder_Generate(t *testing.T) {
 }
 
 func TestBuilder_emptyValueForGuard(t *testing.T) {
+	config := Config{
+		PackageRoot: "github.com/grafana/cog/generated",
+	}
 	jenny := Builder{
-		Config: Config{
-			PackageRoot: "github.com/grafana/cog/generated",
-		},
-		Tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		Config:          config,
+		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/golang/converter_test.go
+++ b/internal/jennies/golang/converter_test.go
@@ -27,7 +27,7 @@ func TestConverter_Generate(t *testing.T) {
 	jenny := Converter{
 		Config:          config,
 		NullableConfig:  language.NullableKinds(),
-		Tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -49,6 +49,9 @@ type Config struct {
 	// Root path for imports.
 	// Ex: github.com/grafana/cog/generated
 	PackageRoot string `yaml:"package_root"`
+
+	// AnyAsInterface instructs this jenny to emit `interface{}` instead of `any`.
+	AnyAsInterface bool `yaml:"any_as_interface"`
 }
 
 func (config *Config) InterpolateParameters(interpolator func(input string) string) {
@@ -90,7 +93,7 @@ func (language *Language) Name() string {
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
 
-	tmpl := initTemplates(language.apiRefCollector, language.config.OverridesTemplatesDirectories)
+	tmpl := initTemplates(config, language.apiRefCollector)
 
 	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef
@@ -122,7 +125,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 				"PackageRoot": config.PackageRoot,
 			},
 			ExtraData: config.ExtraFilesTemplatesData,
-			TmplFuncs: formattingTemplateFuncs(),
+			TmplFuncs: formattingTemplateFuncs(config),
 		},
 	)
 	jenny.AddPostprocessors(formatGoFiles, common.GeneratedCommentHeader(globalConfig))

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -27,7 +27,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 	jenny := RawTypes{
 		Config:          config,
-		Tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 	compilerPasses := New(config).CompilerPasses()

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
@@ -8,7 +8,7 @@ func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) erro
 	}
 
 	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
-	parsedAsMap := make(map[string]any)
+	parsedAsMap := make(map[string]{{ formatAny }})
 	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
 		return err
 	}

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.strict.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.strict.json_unmarshal.tmpl
@@ -9,7 +9,7 @@ func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSONStrict(raw []byte
 
 	{{- $hint := index .def.Type.Hints "disjunction_of_refs" }}
 	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
-	parsedAsMap := make(map[string]any)
+	parsedAsMap := make(map[string]{{ formatAny }})
 	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
 		return err
 	}

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -92,6 +92,9 @@ func (formatter *typeFormatter) formatEnumDef(def ast.Object) string {
 
 func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool) string {
 	actualFormatter := func() string {
+		if def.IsAny() && formatter.config.AnyAsInterface {
+			return "interface{}"
+		}
 		if def.IsAny() {
 			return "any"
 		}

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -341,6 +341,10 @@
         "package_root": {
           "type": "string",
           "description": "Root path for imports.\nEx: github.com/grafana/cog/generated"
+        },
+        "any_as_interface": {
+          "type": "boolean",
+          "description": "AnyAsInterface instructs this jenny to emit `interface{}` instead of `any`."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Will be useful in codebases that don't support `any` (or prefer `interface{}`).