### PR TITLE
Fix array parsing for jsonschema draft 2020

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -388,17 +388,21 @@ func (g *generator) walkList(schema *schemaparser.Schema) (ast.Type, error) {
 	var itemsDef ast.Type
 	var err error
 
-	if schema.Items == nil {
+	switch {
+	case schema.Items == nil && schema.Items2020 == nil:
 		itemsDef = ast.Any()
-	} else {
+	case schema.Items2020 != nil:
+		itemsDef, err = g.walkDefinition(schema.Items2020)
+	default:
 		// TODO: schema.Items might not be a schema?
 		itemsDef, err = g.walkDefinition(schema.Items.(*schemaparser.Schema))
-		// items contains an empty schema: `{}`
-		if errors.Is(err, errUndescriptiveSchema) {
-			itemsDef = ast.Any()
-		} else if err != nil {
-			return ast.Type{}, err
-		}
+	}
+
+	// items contains an empty schema: `{}`
+	if errors.Is(err, errUndescriptiveSchema) {
+		itemsDef = ast.Any()
+	} else if err != nil {
+		return ast.Type{}, err
 	}
 
 	return ast.NewArray(itemsDef, ast.Default(schema.Default)), nil


### PR DESCRIPTION
Without this fix, cog can't properly parse its own [codegen pipeline schema](https://github.com/grafana/cog/blob/main/schemas/pipeline.json) :scream: 

(not that we need to parse it, but still)