### PR TITLE
Fix package override via configuration in cue

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -75,7 +75,8 @@ func GenerateAST(val cue.Value, c Config) (*ast.Schema, error) {
 	g := &generator{
 		schema: ast.NewSchema(c.Package, c.SchemaMetadata),
 		refResolver: newReferenceResolver(val, referenceResolverConfig{
-			Libraries: c.Libraries,
+			Libraries:     c.Libraries,
+			SchemaPackage: c.Package,
 		}),
 		rootVal:    val,
 		rootPath:   val.Path(),

--- a/internal/simplecue/referenceresolver.go
+++ b/internal/simplecue/referenceresolver.go
@@ -9,7 +9,8 @@ import (
 )
 
 type referenceResolverConfig struct {
-	Libraries []LibraryInclude
+	SchemaPackage string
+	Libraries     []LibraryInclude
 }
 
 type referenceResolver struct {
@@ -26,6 +27,15 @@ func newReferenceResolver(root cue.Value, config referenceResolverConfig) *refer
 
 	resolver.importsAliasMap = resolver.buildImportsAliasMap(root)
 	resolver.librariesMap = resolver.buildLibrariesMap(config.Libraries)
+
+	// map the package originally declared in the CUE file to the one configured by the user
+	if fileAst, ok := root.Source().(*cueast.File); ok {
+		for _, decl := range fileAst.Decls {
+			if pkgDecl, ok := decl.(*cueast.Package); ok {
+				resolver.importsAliasMap[pkgDecl.Name.String()] = config.SchemaPackage
+			}
+		}
+	}
 
 	return resolver
 }

--- a/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
+++ b/testdata/simplecue/nested_disjunctions/GenerateAST/ir.json
@@ -169,7 +169,7 @@
               "Kind": "ref",
               "Nullable": false,
               "Ref": {
-                "ReferredPkg": "test",
+                "ReferredPkg": "grafanatest",
                 "ReferredType": "HelloMsg"
               }
             },
@@ -177,7 +177,7 @@
               "Kind": "ref",
               "Nullable": false,
               "Ref": {
-                "ReferredPkg": "test",
+                "ReferredPkg": "grafanatest",
                 "ReferredType": "ByeMsg"
               }
             }
@@ -200,7 +200,7 @@
               "Kind": "ref",
               "Nullable": false,
               "Ref": {
-                "ReferredPkg": "test",
+                "ReferredPkg": "grafanatest",
                 "ReferredType": "ChitChat"
               }
             },
@@ -208,7 +208,7 @@
               "Kind": "ref",
               "Nullable": false,
               "Ref": {
-                "ReferredPkg": "test",
+                "ReferredPkg": "grafanatest",
                 "ReferredType": "QuestionMsg"
               }
             },
@@ -216,7 +216,7 @@
               "Kind": "ref",
               "Nullable": false,
               "Ref": {
-                "ReferredPkg": "test",
+                "ReferredPkg": "grafanatest",
                 "ReferredType": "AnswerMsg"
               }
             }

--- a/testdata/simplecue/nested_disjunctions/schema.cue
+++ b/testdata/simplecue/nested_disjunctions/schema.cue
@@ -1,5 +1,3 @@
-package test
-
 HelloMsg: {
     type: "hello"
     salutation: string


### PR DESCRIPTION
Overriding the package name via the codegen pipeline doesn't work for cue schemas.

This PR addresses that.