### PR TITLE
Compiler pass/constant to enum

### DIFF
--- a/docs/reference/schema_transformations.md
+++ b/docs/reference/schema_transformations.md
@@ -62,6 +62,20 @@ Will become:
 anonymous_structs_to_named: {}
 ```
 
+## `constant_to_enum`
+
+ConstantToEnum turns `string` constants into an enum definition with a
+single member.
+This is useful to "future-proof" a schema where a type can have a single
+value for now but is expected to allow more in the future.
+
+### Usage
+
+```yaml
+constant_to_enum:
+  objects: []string
+```
+
 ## `dataquery_identification`
 
 N/A

--- a/internal/ast/compiler/constant_to_enum.go
+++ b/internal/ast/compiler/constant_to_enum.go
@@ -6,6 +6,10 @@ import (
 
 var _ Pass = (*ConstantToEnum)(nil)
 
+// ConstantToEnum turns `string` constants into an enum definition with a
+// single member.
+// This is useful to "future-proof" a schema where a type can have a single
+// value for now but is expected to allow more in the future.
 type ConstantToEnum struct {
 	Objects ObjectReferences
 }

--- a/internal/ast/compiler/constant_to_enum.go
+++ b/internal/ast/compiler/constant_to_enum.go
@@ -1,0 +1,42 @@
+package compiler
+
+import (
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*ConstantToEnum)(nil)
+
+type ConstantToEnum struct {
+	Objects ObjectReferences
+}
+
+func (pass *ConstantToEnum) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	visitor := &Visitor{
+		OnObject: pass.processObject,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (pass *ConstantToEnum) processObject(_ *Visitor, _ *ast.Schema, object ast.Object) (ast.Object, error) {
+	if !pass.Objects.Matches(object) {
+		return object, nil
+	}
+
+	if !object.Type.IsConcreteScalar() || object.Type.Scalar.ScalarKind != ast.KindString {
+		return object, nil
+	}
+
+	trailMessage := "ConstantToEnum"
+
+	object.Type = ast.NewEnum([]ast.EnumValue{
+		{
+			Type:  object.Type,
+			Name:  object.Type.Scalar.Value.(string),
+			Value: object.Type.Scalar.Value.(string),
+		},
+	})
+	object.AddToPassesTrail(trailMessage)
+
+	return object, nil
+}

--- a/internal/ast/compiler/constant_to_enum.go
+++ b/internal/ast/compiler/constant_to_enum.go
@@ -27,16 +27,14 @@ func (pass *ConstantToEnum) processObject(_ *Visitor, _ *ast.Schema, object ast.
 		return object, nil
 	}
 
-	trailMessage := "ConstantToEnum"
-
 	object.Type = ast.NewEnum([]ast.EnumValue{
 		{
-			Type:  object.Type,
+			Type:  ast.String(),
 			Name:  object.Type.Scalar.Value.(string),
 			Value: object.Type.Scalar.Value.(string),
 		},
 	})
-	object.AddToPassesTrail(trailMessage)
+	object.AddToPassesTrail("ConstantToEnum")
 
 	return object, nil
 }

--- a/internal/ast/compiler/constant_to_enum_test.go
+++ b/internal/ast/compiler/constant_to_enum_test.go
@@ -1,0 +1,56 @@
+package compiler
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/testutils"
+)
+
+func TestConstantToEnum(t *testing.T) {
+	// Prepare test input
+	strAlias := ast.NewObject("sandbox", "String", ast.String())
+	strConstant := ast.NewObject("sandbox", "Mode", ast.String(ast.Value("auto")))
+	notTargetedStrConstant := ast.NewObject("sandbox", "Alignment", ast.String(ast.Value("center")))
+	intConstant := ast.NewObject("sandbox", "DefaultSize", ast.NewScalar(ast.KindInt32, ast.Value(42)))
+	obj := ast.NewObject("sandbox", "Obj", ast.NewStruct(ast.NewStructField("foo", ast.String())))
+	schema := &ast.Schema{
+		Package: "sandbox",
+		Objects: testutils.ObjectsMap(
+			strAlias,
+			strConstant,
+			notTargetedStrConstant,
+			intConstant,
+			obj,
+		),
+	}
+
+	newEnum := ast.NewObject("sandbox", "Mode", ast.NewEnum([]ast.EnumValue{
+		{
+			Type:  ast.String(),
+			Name:  "auto",
+			Value: "auto",
+		},
+	}))
+	newEnum.AddToPassesTrail("ConstantToEnum")
+	expected := &ast.Schema{
+		Package: "sandbox",
+		Objects: testutils.ObjectsMap(
+			strAlias,
+			newEnum,
+			notTargetedStrConstant,
+			intConstant,
+			obj,
+		),
+	}
+
+	// Run the compiler pass
+	runPassOnSchema(t, &ConstantToEnum{
+		Objects: []ObjectReference{
+			{Package: "sandbox", Object: "String"},
+			{Package: "sandbox", Object: "Mode"},
+			{Package: "sandbox", Object: "DefaultSize"},
+			{Package: "sandbox", Object: "Obj"},
+		},
+	}, schema, expected)
+}

--- a/internal/ast/compiler/types.go
+++ b/internal/ast/compiler/types.go
@@ -7,6 +7,18 @@ import (
 	"github.com/grafana/cog/internal/ast"
 )
 
+type ObjectReferences []ObjectReference
+
+func (refs ObjectReferences) Matches(object ast.Object) bool {
+	for _, ref := range refs {
+		if ref.Matches(object) {
+			return true
+		}
+	}
+
+	return false
+}
+
 type ObjectReference struct {
 	Package string
 	Object  string

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -338,6 +338,9 @@
         "trim_enum_values": {
           "$ref": "#/$defs/YamlTrimEnumValues"
         },
+        "constant_to_enum": {
+          "$ref": "#/$defs/YamlConstantToEnum"
+        },
         "anonymous_structs_to_named": {
           "$ref": "#/$defs/YamlAnonymousStructsToNamed"
         },
@@ -352,6 +355,19 @@
         },
         "disjunction_with_constant_to_default": {
           "$ref": "#/$defs/YamlDisjunctionWithConstantToDefault"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlConstantToEnum": {
+      "properties": {
+        "objects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Expected format: [package].[object]"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
The `ConstantToEnum` compiler pass turns `string` constants into an enum definition with a
single member.

This is useful to "future-proof" a schema where a type can have a single value for now but is expected to allow more in the future.

Example: https://github.com/grafana/grafana/blob/7564ce8ce1cd2ed0a0a8bdb72f6221767e1d5321/packages/grafana-schema/src/schema/dashboard/v2alpha0/dashboard.schema.cue#L469

(we can and will adjust the original schema, but this pass is still a useful one to have)