### PR TITLE
Add `datasource` schema

### DIFF
--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -108,6 +108,16 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for "datasource" queries
+  - cue:
+      entrypoint: '%__config_dir%/foundation-sdk/.cog/schemas/composable/datasource'
+      metadata:
+        kind: composable
+        variant: dataquery
+        identifier: datasource
+      cue_imports:
+        - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
+
 transformations:
   schemas:
     - '%__config_dir%/foundation-sdk/.cog/compiler/common_passes.yaml'


### PR DESCRIPTION
Was added in the Foundation SDK via https://github.com/grafana/grafana-foundation-sdk/pull/575, this PR is just to have the dev codegen pipeline used by cog align with the one in the Foundation SDK