### PR TITLE
Improve `cog inspect`

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/codegen"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/tools"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +17,24 @@ type options struct {
 	BuilderIR       bool
 	ConfigPath      string
 	ExtraParameters map[string]string
+	Selector        string
 }
 
 func Command() *cobra.Command {
 	opts := options{}
 
 	// TODO:
-	//  - support inspecting "transformed" IRs: common & language-specific compiler passes, veneers, ...
+	//  - better support for inspecting "transformed" IRs: language-specific compiler passes, veneers, ...
 	cmd := &cobra.Command{
 		Use:   "inspect",
-		Short: "Inspects the intermediate representation.", // TODO: better descriptions
-		Long:  `Inspects the intermediate representation.`,
+		Short: "Inspects the intermediate representation.",
+		Long: `Inspects the intermediate representation of types and builders.
+
+Common and schema-specific transformations are applied.
+Language-specific transformations are NOT applied.
+
+Builder transformations are currently NOT applied.
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doInspect(opts)
 		},
@@ -33,6 +42,7 @@ func Command() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.BuilderIR, "builder-ir", false, "Inspect the \"builder IR\" instead of the \"types\" one.") // TODO: better usage text
 	cmd.Flags().StringToStringVar(&opts.ExtraParameters, "parameters", nil, "Sets or overrides parameters used in the config file.")
+	cmd.Flags().StringVar(&opts.Selector, "selector", "", "Selector allowing to narrow down the result of the inspection to selected objects. Format: package.[object] for types, package.[builder].[option] for builders.")
 
 	cmd.Flags().StringVar(&opts.ConfigPath, "config", "", "Codegen pipeline configuration file.")
 	_ = cmd.MarkFlagFilename("config")
@@ -42,32 +52,36 @@ func Command() *cobra.Command {
 }
 
 func doInspect(opts options) error {
-	ctx := context.Background()
-
 	pipeline, err := codegen.PipelineFromFile(opts.ConfigPath, codegen.Parameters(opts.ExtraParameters))
 	if err != nil {
 		return err
 	}
 
-	schemas, err := pipeline.LoadSchemas(ctx)
+	// Load schemas
+	schemas, err := pipeline.LoadSchemas(context.Background())
 	if err != nil {
 		return err
 	}
 
+	// apply compiler passes
+
 	if opts.BuilderIR {
-		return inspectBuilderIR(schemas)
+		return inspectBuilderIR(opts, schemas)
 	}
 
-	return prettyPrintJSON(schemas)
+	selectedResult, err := applyTypesIRSelector(schemas, opts.Selector)
+	if err != nil {
+		return err
+	}
+
+	return prettyPrintJSON(selectedResult)
 }
 
-func inspectBuilderIR(schemas []*ast.Schema) error {
+func inspectBuilderIR(opts options, schemas []*ast.Schema) error {
 	var err error
-	generator := &ast.BuilderGenerator{}
-
 	codegenCtx := languages.Context{
 		Schemas:  schemas,
-		Builders: generator.FromAST(schemas),
+		Builders: (&ast.BuilderGenerator{}).FromAST(schemas),
 	}
 
 	codegenCtx, err = languages.GenerateBuilderNilChecks(nil, codegenCtx)
@@ -75,7 +89,12 @@ func inspectBuilderIR(schemas []*ast.Schema) error {
 		return err
 	}
 
-	return prettyPrintJSON(codegenCtx)
+	selectedResult, err := applyBuilderIRSelector(codegenCtx, opts.Selector)
+	if err != nil {
+		return err
+	}
+
+	return prettyPrintJSON(selectedResult)
 }
 
 func prettyPrintJSON(input any) error {
@@ -87,4 +106,77 @@ func prettyPrintJSON(input any) error {
 	fmt.Println(string(marshaled))
 
 	return nil
+}
+
+func applyTypesIRSelector(schemas ast.Schemas, selector string) (any, error) {
+	if selector == "" {
+		return schemas, nil
+	}
+
+	selectorParts := strings.Split(selector, ".")
+	if len(selectorParts) > 2 {
+		return nil, fmt.Errorf("invalid selector '%s'", selector)
+	}
+
+	// select a package
+	schema, found := schemas.Locate(selectorParts[0])
+	if !found {
+		return nil, fmt.Errorf("package '%s' not found", selectorParts[0])
+	}
+	if len(selectorParts) == 1 {
+		return schema, nil
+	}
+
+	// select a specific object
+	objects := schema.Objects.Filter(func(_ string, object ast.Object) bool {
+		return strings.EqualFold(object.Name, selectorParts[1])
+	})
+	if objects.Len() == 0 {
+		return nil, fmt.Errorf("object '%s.%s' not found", selectorParts[0], selectorParts[1])
+	}
+
+	return objects.At(0), nil
+}
+
+func applyBuilderIRSelector(context languages.Context, selector string) (any, error) {
+	if selector == "" {
+		return context, nil
+	}
+
+	selectorParts := strings.Split(selector, ".")
+	if len(selectorParts) > 3 {
+		return nil, fmt.Errorf("invalid selector '%s'", selector)
+	}
+
+	// select builders within a package
+	builders := tools.Filter(context.Builders, func(b ast.Builder) bool {
+		return strings.EqualFold(b.Package, selectorParts[0])
+	})
+	if len(builders) == 0 {
+		return nil, fmt.Errorf("package '%s' not found", selectorParts[0])
+	}
+	if len(selectorParts) == 1 {
+		return builders, nil
+	}
+
+	// target a specific builder
+	builders = tools.Filter(builders, func(builder ast.Builder) bool {
+		return strings.EqualFold(builder.Name, selectorParts[1])
+	})
+	if len(builders) == 0 {
+		return nil, fmt.Errorf("builder '%s.%s' not found", selectorParts[0], selectorParts[1])
+	}
+	if len(selectorParts) == 2 {
+		return builders[0], nil
+	}
+
+	// select a specific option within a builder
+	opts := tools.Filter(builders[0].Options, func(opt ast.Option) bool {
+		return strings.EqualFold(opt.Name, selectorParts[2])
+	})
+	if len(opts) == 0 {
+		return nil, fmt.Errorf("option '%s' not found", selector)
+	}
+
+	return opts[0], nil
 }

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
-	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/veneers/rewrite"
@@ -17,13 +16,6 @@ func (pipeline *Pipeline) Run(ctx context.Context) (*codejen.FS, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	commonPasses, err := pipeline.commonPasses()
-	if err != nil {
-		return nil, err
-	}
-
-	finalPasses := pipeline.finalPasses()
 
 	// Here begins the code generation setup
 	targetsByLanguage, err := pipeline.outputLanguages()
@@ -46,7 +38,7 @@ func (pipeline *Pipeline) Run(ctx context.Context) (*codejen.FS, error) {
 			return nil, err
 		}
 
-		jenniesInput, err := pipeline.jenniesInputForLanguage(target, schemas, commonPasses, finalPasses, veneers)
+		jenniesInput, err := pipeline.jenniesInputForLanguage(target, schemas, veneers)
 		if err != nil {
 			return nil, err
 		}
@@ -78,15 +70,14 @@ func (pipeline *Pipeline) Run(ctx context.Context) (*codejen.FS, error) {
 	return generatedFS, nil
 }
 
-func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, schemas ast.Schemas, commonPasses compiler.Passes, finalPasses compiler.Passes, veneers *rewrite.Rewriter) (languages.Context, error) {
+func (pipeline *Pipeline) jenniesInputForLanguage(language languages.Language, schemas ast.Schemas, veneers *rewrite.Rewriter) (languages.Context, error) {
 	var err error
 	jenniesInput := languages.Context{
 		Schemas: schemas,
 	}
 
-	// apply common and language-specific compiler passes
-	compilerPasses := commonPasses.Concat(language.CompilerPasses()).Concat(finalPasses)
-	jenniesInput.Schemas, err = compilerPasses.Process(jenniesInput.Schemas)
+	// apply  language-specific compiler passes
+	jenniesInput.Schemas, err = language.CompilerPasses().Process(jenniesInput.Schemas)
 	if err != nil {
 		return languages.Context{}, err
 	}


### PR DESCRIPTION
Adds support for filtering inspection results with "selectors". For types: `package.[object]`
For builders: `package.[builder].[option]`

Ensure that transformations that aren't language-specific are applied.

These two improvements help with making that command useful when inspecting a large amount of data (think Foundation SDK and all the schemas, types, builders that we generate for it)