### PR TITLE
Ensure a consistent pass trail for the HintObject pass

### DIFF
--- a/internal/ast/compiler/hint_object.go
+++ b/internal/ast/compiler/hint_object.go
@@ -2,6 +2,7 @@ package compiler
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
@@ -32,6 +33,9 @@ func (pass *HintObject) processObject(_ *Visitor, _ *ast.Schema, object ast.Obje
 		object.Type.Hints[hint] = val
 		hintsTrail = append(hintsTrail, fmt.Sprintf("%s=%v", hint, val))
 	}
+
+	// to ensure a consistent trail
+	sort.Strings(hintsTrail)
 
 	object.AddToPassesTrail(fmt.Sprintf("HintObject[%s]", strings.Join(hintsTrail, ", ")))
 


### PR DESCRIPTION
Should help getting rid of these annoyingly flaky diffs: https://github.com/grafana/cog/pull/725#issuecomment-2613554430