### PR TITLE
Java bug fixes

### DIFF
--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -310,6 +310,10 @@ func (path Path) Last() PathItem {
 	return path[len(path)-1]
 }
 
+func (path Path) RemoveLast() Path {
+	return path[:len(path)-1]
+}
+
 func (path Path) String() string {
 	return strings.Join(tools.Map(path, func(t PathItem) string {
 		return t.Identifier

--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -75,6 +75,7 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 		"formatPath":               jenny.typeFormatter.formatFieldPath,
 		"formatRefType":            jenny.typeFormatter.formatRefType,
 		"formatType":               jenny.typeFormatter.formatFieldType,
+		"formatPathIndex":          jenny.typeFormatter.formatPathIndex,
 	}).RenderAsBytes("builders/builder.tmpl", tmpl)
 }
 

--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -69,8 +69,6 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 	return jenny.tmpl.Funcs(map[string]any{
 		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
 		"emptyValueForType":        jenny.typeFormatter.emptyValueForType,
-		"shouldCastNilCheck":       jenny.typeFormatter.shouldCastNilCheck,
-		"formatCastValue":          jenny.typeFormatter.formatCastValue,
 		"typeHasBuilder":           jenny.typeFormatter.typeHasBuilder,
 		"resolvesToComposableSlot": jenny.typeFormatter.resolvesToComposableSlot,
 		"formatAssignmentPath":     jenny.typeFormatter.formatAssignmentPath,

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -216,12 +216,13 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 }
 
 func (jenny RawTypes) formatReference(pkg string, identifier string, object ast.Object) ([]byte, error) {
-	reference := jenny.typeFormatter.formatReference(object.Type.AsRef())
+	ref := object.Type.AsRef()
+	reference := fmt.Sprintf("%s.%s", jenny.config.formatPackage(formatPackageName(ref.ReferredPkg)), formatObjectName(ref.ReferredType))
 
 	return jenny.getTemplate().RenderAsBytes("types/class.tmpl", ClassTemplate{
 		Package:    jenny.config.formatPackage(pkg),
 		Imports:    jenny.imports,
-		Name:       tools.UpperCamelCase(object.Name),
+		Name:       formatObjectName(object.Name),
 		Extends:    []string{reference},
 		Comments:   object.Comments,
 		Variant:    jenny.getVariant(object.Type),

--- a/internal/jennies/java/templates/builders/assigments.tmpl
+++ b/internal/jennies/java/templates/builders/assigments.tmpl
@@ -67,6 +67,11 @@
 {{- define "assignment_method" }}
     {{ $path := formatAssignmentPath "this.internal" .Path }}
         {{- if eq .Method "direct" }}{{ $path }} = {{ .Value }};{{ end }}
-        {{- if eq .Method "index" }}{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "index" }}
+            {{ $index := .Path.Last.Index }}
+            {{ $path = formatAssignmentPath "this.internal" .Path.RemoveLast }}
+            {{ $path }}.put({{ $index|formatPathIndex }}, {{ .Value }});
+        {{ end }}
+        {{- if and (eq .Method "index") (.Path.Last.Type.IsArray) }}{{ $path }} = {{ .Value }};{{ end }}
         {{- if eq .Method "append" }}{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/builders/assigments.tmpl
+++ b/internal/jennies/java/templates/builders/assigments.tmpl
@@ -19,22 +19,12 @@
 {{- end }}
 
 {{- define "assignment_setup" }}
-    {{- $castPath := formatCastValue $.Assignment.Path }}
-    {{- with .Value.Argument }}
-        {{- if not (eq $castPath.Value "") }}
-        {{ if not $castPath.IsNilChecked }}{{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{- $castPath.Class }}) this.internal.{{ $castPath.Path }};{{ end }}
-        {{ $castPath.Value | lowerCamelCase }}Resource.{{ lastPathIdentifier $.Assignment.Path }} = {{ .Name | lowerCamelCase }}{{ if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}.build(){{ end }};
-        {{- end }}
-    {{- end }}
     {{- with .Value.Envelope }}
         {{- range .Values }}
         {{- template "assignment_setup" (dict "Assignment" $.Assignment "Value" .Value) }}
         {{- end }}
 
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
-    {{- end }}
-    {{- if and (not (eq .Value.Constant nil)) (not (eq $castPath.Value "")) }}
-        {{ $castPath.Value | lowerCamelCase }}Resource.{{ lastPathIdentifier $.Assignment.Path }} = {{ .Value.Constant }};
     {{- end }}
     {{- $type := $.Assignment.Path.Last.Type }}
     {{- if and $type.IsMap (typeHasBuilder $type) }}
@@ -46,18 +36,11 @@
 {{- end }}
 
 {{- define "assignment_value" }}
-    {{- $castPath := formatCastValue $.Assignment.Path }}
     {{- if not (eq .Value.Constant nil) }}
-        {{- if not (eq $castPath.Value "") }}
-        {{- $castPath.Value | lowerCamelCase }}Resource
-        {{- else }}
         {{- formatRefType .Assignment.Path.Last.Type .Value.Constant }}
-        {{- end }}
     {{- end }}
     {{- with .Value.Argument }}
-        {{- if not (eq $castPath.Value "") }}
-            {{- $castPath.Value | lowerCamelCase }}Resource
-        {{- else if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
+        {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
             {{- if .Type.IsMap }}
             {{- .Name | escapeVar | lowerCamelCase }}Resource
             {{- else }}
@@ -82,8 +65,8 @@
 {{- end }}
 
 {{- define "assignment_method" }}
-    {{ $path := formatAssignmentPath .Path }}
-        {{- if eq .Method "direct" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
-        {{- if eq .Method "index" }}this.internal.{{ $path }} = {{ .Value }};{{ end }}
-        {{- if eq .Method "append" }}this.internal.{{ $path }}.add({{ .Value }});{{ end -}}
+    {{ $path := formatAssignmentPath "this.internal" .Path }}
+        {{- if eq .Method "direct" }}{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "index" }}{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "append" }}{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/builders/assigments.tmpl
+++ b/internal/jennies/java/templates/builders/assigments.tmpl
@@ -65,13 +65,13 @@
 {{- end }}
 
 {{- define "assignment_method" }}
-    {{ $path := formatAssignmentPath "this.internal" .Path }}
+        {{ $path := formatAssignmentPath "this.internal" .Path }}
         {{- if eq .Method "direct" }}{{ $path }} = {{ .Value }};{{ end }}
         {{- if eq .Method "index" }}
-            {{ $index := .Path.Last.Index }}
-            {{ $path = formatAssignmentPath "this.internal" .Path.RemoveLast }}
-            {{ $path }}.put({{ $index|formatPathIndex }}, {{ .Value }});
-        {{ end }}
+            {{- $index := .Path.Last.Index }}
+            {{- $path = formatAssignmentPath "this.internal" .Path.RemoveLast }}
+            {{- $path }}.put({{ $index|formatPathIndex }}, {{ .Value }});
+        {{- end }}
         {{- if and (eq .Method "index") (.Path.Last.Type.IsArray) }}{{ $path }} = {{ .Value }};{{ end }}
         {{- if eq .Method "append" }}{{ $path }}.add({{ .Value }});{{ end -}}
 {{- end }}

--- a/internal/jennies/java/templates/builders/nilcheck.tmpl
+++ b/internal/jennies/java/templates/builders/nilcheck.tmpl
@@ -1,13 +1,6 @@
 {{- define "nil_check" }}
-        {{- $castPath := shouldCastNilCheck .Path }}
-        {{- if $castPath.IsNilChecked }}
-        {{ $castPath.Class }} {{ $castPath.Value | lowerCamelCase }}Resource = ({{ $castPath.Class }}) this.internal.{{ $castPath.Path }};
-        if ({{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} == null) {
-            {{ $castPath.Value | lowerCamelCase }}Resource.{{ .Path|formatPath }} = {{ .EmptyValueType|emptyValueForType }};
-        }
-        {{- else }}
-		if (this.internal.{{ .Path|formatPath }} == null) {
-			this.internal.{{ .Path|formatPath }} = {{ .EmptyValueType|emptyValueForType }};
+        {{- $path := formatAssignmentPath "this.internal" .Path }}
+		if ({{ $path }} == null) {
+			{{ $path }} = {{ .EmptyValueType|emptyValueForType }};
 		}
-		{{- end }}
 {{- end }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -73,11 +73,8 @@ func functions() template.FuncMap {
 		"formatValue": func(_ ast.Type) string {
 			panic("formatValue() needs to be overridden by a jenny")
 		},
-		"formatCastValue": func(_ ast.Type) string {
-			panic("formatCastValue() needs to be overridden by a jenny")
-		},
-		"shouldCastNilCheck": func(_ ast.Type) string {
-			panic("shouldCastNilCheck() needs to be overridden by a jenny")
+		"formatPathIndex": func(_ *ast.PathIndex) string {
+			panic("formatPathIndex() needs to be overridden by a jenny")
 		},
 		"formatPath": func(_ ast.Type) string {
 			panic("formatPath() needs to be overridden by a jenny")

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -14,6 +14,14 @@ func formatObjectName(name string) string {
 	return tools.UpperCamelCase(name)
 }
 
+func formatArgName(name string) string {
+	return escapeVarName(tools.LowerCamelCase(name))
+}
+
+func formatFieldName(name string) string {
+	return escapeVarName(tools.LowerCamelCase(name))
+}
+
 func formatPackageName(pkg string) string {
 	rgx := regexp.MustCompile("[^a-zA-Z0-9_]+")
 

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -71,7 +71,7 @@ func (tf *typeFormatter) formatBuilderFieldType(def ast.Type) string {
 }
 
 func (tf *typeFormatter) formatReference(def ast.RefType) string {
-	object, _ := tf.context.LocateObject(def.ReferredPkg, def.ReferredType)
+	object, _ := tf.context.LocateObjectByRef(def)
 	switch object.Type.Kind {
 	case ast.KindScalar:
 		return formatScalarType(object.Type.AsScalar())
@@ -81,7 +81,7 @@ func (tf *typeFormatter) formatReference(def ast.RefType) string {
 		return tf.formatArray(object.Type.AsArray())
 	default:
 		tf.packageMapper(def.ReferredPkg, def.ReferredType)
-		return def.ReferredType
+		return formatObjectName(def.ReferredType)
 	}
 }
 
@@ -192,94 +192,6 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 	}
 }
 
-type CastPath struct {
-	Class        string
-	Value        string
-	Path         string
-	IsNilChecked bool
-}
-
-// formatCastValue identifies if the object to set is a generic one, so it needs
-// to do a cast to the desired object to be able to set their values.
-func (tf *typeFormatter) formatCastValue(fieldPath ast.Path) CastPath {
-	refPkg := ""
-	refType := ""
-	for _, path := range fieldPath {
-		if path.TypeHint != nil && path.TypeHint.Kind == ast.KindRef {
-			refPkg = path.TypeHint.AsRef().ReferredPkg
-			refType = path.TypeHint.AsRef().ReferredType
-		}
-	}
-
-	if refType == "" {
-		return CastPath{}
-	}
-
-	castedPath := fieldPath[0].Identifier
-	isNilChecked := false
-	genericFound := false
-
-	for i, p := range fieldPath {
-		if i > 0 && fieldPath[i-1].Type.IsAny() && i != len(fieldPath)-1 {
-			isNilChecked = true
-		}
-
-		if !genericFound {
-			if i > 0 {
-				castedPath = fmt.Sprintf("%s.%s", castedPath, tools.LowerCamelCase(p.Identifier))
-			}
-			genericFound = p.Type.IsAny()
-		}
-	}
-
-	return CastPath{
-		Class:        fmt.Sprintf("%s.%s", tf.config.formatPackage(refPkg), refType),
-		Value:        refType,
-		Path:         castedPath,
-		IsNilChecked: isNilChecked,
-	}
-}
-
-func (tf *typeFormatter) shouldCastNilCheck(fieldPath ast.Path) CastPath {
-	refPkg := ""
-	refType := ""
-	for _, path := range fieldPath {
-		if path.TypeHint == nil && path.Type.Kind == ast.KindRef {
-			refPkg = path.Type.AsRef().ReferredPkg
-			refType = path.Type.AsRef().ReferredType
-		}
-	}
-
-	if refType == "" {
-		return CastPath{}
-	}
-
-	castedPath := fieldPath[0].Identifier
-	isNilChecked := false
-	genericFound := false
-
-	for i, p := range fieldPath {
-		if i > 0 && p.Type.IsRef() && !fieldPath[i-1].Type.IsRef() {
-			refType = fieldPath[i-1].Identifier
-			isNilChecked = true
-		}
-
-		if !genericFound {
-			if i > 0 {
-				castedPath = fmt.Sprintf("%s.%s", castedPath, tools.LowerCamelCase(p.Identifier))
-			}
-			genericFound = p.Type.IsAny()
-		}
-	}
-
-	return CastPath{
-		Class:        fmt.Sprintf("%s.%s", tf.config.formatPackage(refPkg), tools.UpperCamelCase(refType)),
-		Value:        refType,
-		Path:         castedPath,
-		IsNilChecked: isNilChecked,
-	}
-}
-
 func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
 	parts := make([]string, 0)
 	for i, part := range fieldPath {
@@ -297,33 +209,38 @@ func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
 
 // formatAssignmentPath generates the pad to assign the value. When the value is a generic one (Object) like Custom or FieldConfig
 // we should return until this pad to set the object to it.
-func (tf *typeFormatter) formatAssignmentPath(fieldPath ast.Path) string {
-	path := escapeVarName(tools.LowerCamelCase(fieldPath[0].Identifier))
+func (tf *typeFormatter) formatAssignmentPath(resourceRoot string, fieldPath ast.Path) string {
+	path := resourceRoot
 
-	if len(fieldPath[1:]) == 1 && fieldPath[0].TypeHint != nil && fieldPath[0].TypeHint.Kind == ast.KindRef {
-		return path
-	}
+	for i := range fieldPath {
+		output := fieldPath[i].Identifier
+		if !fieldPath[i].Root {
+			output = escapeVarName(tools.LowerCamelCase(output))
+		}
 
-	for i, p := range fieldPath[1:] {
-		if p.Index != nil {
-			path += "["
-			if p.Index.Constant != nil {
-				path += fmt.Sprintf("%#v", p.Index.Constant)
+		if fieldPath[i].Index != nil {
+			output += "["
+			if fieldPath[i].Index.Constant != nil {
+				output += fmt.Sprintf("%#v", fieldPath[i].Index.Constant)
 			} else {
-				path += tools.LowerCamelCase(p.Index.Argument.Name)
+				output += escapeVarName(tools.LowerCamelCase(fieldPath[i].Index.Argument.Name))
 			}
-			path += "]"
+			output += "]"
+
+			path += output
 			continue
 		}
 
-		if fieldPath[i].Type.IsAny() && i != len(fieldPath)-1 {
-			return path
+		// don't generate type hints if:
+		// * there isn't one defined
+		// * the type isn't "any"
+		// * as a trailing element in the path
+		if !fieldPath[i].Type.IsAny() || fieldPath[i].TypeHint == nil || i == len(fieldPath)-1 {
+			path += "." + output
+			continue
 		}
 
-		path = fmt.Sprintf("%s.%s", path, tools.LowerCamelCase(p.Identifier))
-		if p.TypeHint != nil {
-			return path
-		}
+		path = fmt.Sprintf("((%s) %s.%s)", tf.formatReference(fieldPath[i].TypeHint.AsRef()), path, output)
 	}
 
 	return path
@@ -331,7 +248,7 @@ func (tf *typeFormatter) formatAssignmentPath(fieldPath ast.Path) string {
 
 func (tf *typeFormatter) formatRefType(destinationType ast.Type, value any) string {
 	if destinationType.IsRef() {
-		referredObj, found := tf.context.LocateObject(destinationType.AsRef().ReferredPkg, destinationType.AsRef().ReferredType)
+		referredObj, found := tf.context.LocateObjectByRef(destinationType.AsRef())
 		if found && referredObj.Type.IsEnum() {
 			return tf.formatEnumValue(referredObj, value)
 		}

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -207,6 +207,14 @@ func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
 	return strings.Join(parts, ".")
 }
 
+func (tf *typeFormatter) formatPathIndex(pathIndex *ast.PathIndex) string {
+	if pathIndex.Constant != nil {
+		return fmt.Sprintf("%#v", pathIndex.Constant)
+	}
+
+	return formatArgName(pathIndex.Argument.Name)
+}
+
 // formatAssignmentPath generates the pad to assign the value. When the value is a generic one (Object) like Custom or FieldConfig
 // we should return until this pad to set the object to it.
 func (tf *typeFormatter) formatAssignmentPath(resourceRoot string, fieldPath ast.Path) string {
@@ -215,19 +223,11 @@ func (tf *typeFormatter) formatAssignmentPath(resourceRoot string, fieldPath ast
 	for i := range fieldPath {
 		output := fieldPath[i].Identifier
 		if !fieldPath[i].Root {
-			output = escapeVarName(tools.LowerCamelCase(output))
+			output = formatFieldName(output)
 		}
 
 		if fieldPath[i].Index != nil {
-			output += "["
-			if fieldPath[i].Index.Constant != nil {
-				output += fmt.Sprintf("%#v", fieldPath[i].Index.Constant)
-			} else {
-				output += escapeVarName(tools.LowerCamelCase(fieldPath[i].Index.Argument.Name))
-			}
-			output += "]"
-
-			path += output
+			path += output + "[" + tf.formatPathIndex(fieldPath[i].Index) + "]"
 			continue
 		}
 

--- a/testdata/jennies/builders/anonymous_struct/JavaBuilder/anonymous_struct/SomeStructBuilder.java
+++ b/testdata/jennies/builders/anonymous_struct/JavaBuilder/anonymous_struct/SomeStructBuilder.java
@@ -8,7 +8,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeStructBuilder time(Object time) {
-    this.internal.time = time;
+        this.internal.time = time;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/array_append/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/array_append/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -12,7 +12,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.tags == null) {
 			this.internal.tags = new LinkedList<>();
 		}
-    this.internal.tags.add(tags);
+        this.internal.tags.add(tags);
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/basic_struct/JavaBuilder/basic_struct/SomeStructBuilder.java
+++ b/testdata/jennies/builders/basic_struct/JavaBuilder/basic_struct/SomeStructBuilder.java
@@ -9,22 +9,22 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeStructBuilder id(Long id) {
-    this.internal.id = id;
+        this.internal.id = id;
         return this;
     }
     
     public SomeStructBuilder uid(String uid) {
-    this.internal.uid = uid;
+        this.internal.uid = uid;
         return this;
     }
     
     public SomeStructBuilder tags(List<String> tags) {
-    this.internal.tags = tags;
+        this.internal.tags = tags;
         return this;
     }
     
     public SomeStructBuilder liveNow(Boolean liveNow) {
-    this.internal.liveNow = liveNow;
+        this.internal.liveNow = liveNow;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/basic_struct_defaults/JavaBuilder/basic_struct_defaults/SomeStructBuilder.java
+++ b/testdata/jennies/builders/basic_struct_defaults/JavaBuilder/basic_struct_defaults/SomeStructBuilder.java
@@ -9,22 +9,22 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeStructBuilder id(Long id) {
-    this.internal.id = id;
+        this.internal.id = id;
         return this;
     }
     
     public SomeStructBuilder uid(String uid) {
-    this.internal.uid = uid;
+        this.internal.uid = uid;
         return this;
     }
     
     public SomeStructBuilder tags(List<String> tags) {
-    this.internal.tags = tags;
+        this.internal.tags = tags;
         return this;
     }
     
     public SomeStructBuilder liveNow(Boolean liveNow) {
-    this.internal.liveNow = liveNow;
+        this.internal.liveNow = liveNow;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/builder_delegation/JavaBuilder/builder_delegation/DashboardBuilder.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilder/builder_delegation/DashboardBuilder.java
@@ -9,27 +9,27 @@ public class DashboardBuilder implements cog.Builder<Dashboard> {
         this.internal = new Dashboard();
     }
     public DashboardBuilder id(Long id) {
-    this.internal.id = id;
+        this.internal.id = id;
         return this;
     }
     
     public DashboardBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     
     public DashboardBuilder links(cog.Builder<List<DashboardLink>> links) {
-    this.internal.links = links.build();
+        this.internal.links = links.build();
         return this;
     }
     
     public DashboardBuilder linksOfLinks(cog.Builder<List<List<DashboardLink>>> linksOfLinks) {
-    this.internal.linksOfLinks = linksOfLinks.build();
+        this.internal.linksOfLinks = linksOfLinks.build();
         return this;
     }
     
     public DashboardBuilder singleLink(cog.Builder<DashboardLink> singleLink) {
-    this.internal.singleLink = singleLink.build();
+        this.internal.singleLink = singleLink.build();
         return this;
     }
     public Dashboard build() {

--- a/testdata/jennies/builders/builder_delegation/JavaBuilder/builder_delegation/DashboardLinkBuilder.java
+++ b/testdata/jennies/builders/builder_delegation/JavaBuilder/builder_delegation/DashboardLinkBuilder.java
@@ -8,12 +8,12 @@ public class DashboardLinkBuilder implements cog.Builder<DashboardLink> {
         this.internal = new DashboardLink();
     }
     public DashboardLinkBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     
     public DashboardLinkBuilder url(String url) {
-    this.internal.url = url;
+        this.internal.url = url;
         return this;
     }
     public DashboardLink build() {

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/DashboardBuilder.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/DashboardBuilder.java
@@ -9,17 +9,17 @@ public class DashboardBuilder implements cog.Builder<Dashboard> {
         this.internal = new Dashboard();
     }
     public DashboardBuilder singleLinkOrString(cog.Builder<unknown> singleLinkOrString) {
-    this.internal.singleLinkOrString = singleLinkOrString.build();
+        this.internal.singleLinkOrString = singleLinkOrString.build();
         return this;
     }
     
     public DashboardBuilder linksOrStrings(cog.Builder<List<unknown>> linksOrStrings) {
-    this.internal.linksOrStrings = linksOrStrings.build();
+        this.internal.linksOrStrings = linksOrStrings.build();
         return this;
     }
     
     public DashboardBuilder disjunctionOfBuilders(cog.Builder<unknown> disjunctionOfBuilders) {
-    this.internal.disjunctionOfBuilders = disjunctionOfBuilders.build();
+        this.internal.disjunctionOfBuilders = disjunctionOfBuilders.build();
         return this;
     }
     public Dashboard build() {

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/DashboardLinkBuilder.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/DashboardLinkBuilder.java
@@ -8,12 +8,12 @@ public class DashboardLinkBuilder implements cog.Builder<DashboardLink> {
         this.internal = new DashboardLink();
     }
     public DashboardLinkBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     
     public DashboardLinkBuilder url(String url) {
-    this.internal.url = url;
+        this.internal.url = url;
         return this;
     }
     public DashboardLink build() {

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/ExternalLinkBuilder.java
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/JavaBuilder/builder_delegation_in_disjunction/ExternalLinkBuilder.java
@@ -8,7 +8,7 @@ public class ExternalLinkBuilder implements cog.Builder<ExternalLink> {
         this.internal = new ExternalLink();
     }
     public ExternalLinkBuilder url(String url) {
-    this.internal.url = url;
+        this.internal.url = url;
         return this;
     }
     public ExternalLink build() {

--- a/testdata/jennies/builders/composable_slot/JavaBuilder/composable_slot/LokiBuilderBuilder.java
+++ b/testdata/jennies/builders/composable_slot/JavaBuilder/composable_slot/LokiBuilderBuilder.java
@@ -10,12 +10,12 @@ public class LokiBuilderBuilder implements cog.Builder<Dashboard> {
         this.internal = new Dashboard();
     }
     public LokiBuilderBuilder target(cog.Builder<Dataquery> target) {
-    this.internal.target = target.build();
+        this.internal.target = target.build();
         return this;
     }
     
     public LokiBuilderBuilder targets(cog.Builder<List<Dataquery>> targets) {
-    this.internal.targets = targets.build();
+        this.internal.targets = targets.build();
         return this;
     }
     public Dashboard build() {

--- a/testdata/jennies/builders/constant_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/constant_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -8,22 +8,22 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeStructBuilder editable() {
-    this.internal.editable = true;
+        this.internal.editable = true;
         return this;
     }
     
     public SomeStructBuilder readonly() {
-    this.internal.editable = false;
+        this.internal.editable = false;
         return this;
     }
     
     public SomeStructBuilder autoRefresh() {
-    this.internal.autoRefresh = true;
+        this.internal.autoRefresh = true;
         return this;
     }
     
     public SomeStructBuilder noAutoRefresh() {
-    this.internal.autoRefresh = false;
+        this.internal.autoRefresh = false;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/constraints/JavaBuilder/constraints/SomeStructBuilder.java
+++ b/testdata/jennies/builders/constraints/JavaBuilder/constraints/SomeStructBuilder.java
@@ -14,7 +14,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         if (!(id < 10)) {
             throw new IllegalArgumentException("id must be < 10");
         }
-    this.internal.id = id;
+        this.internal.id = id;
         return this;
     }
     
@@ -22,7 +22,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         if (!(title.length() >= 1)) {
             throw new IllegalArgumentException("title.length() must be >= 1");
         }
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/constructor_argument/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/constructor_argument/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -6,10 +6,10 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
     
     public SomeStructBuilder(String title) {
         this.internal = new SomeStruct();
-    this.internal.title = title;
+        this.internal.title = title;
     }
     public SomeStructBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/constructor_initializations/JavaBuilder/constructor_initializations/SomePanelBuilder.java
+++ b/testdata/jennies/builders/constructor_initializations/JavaBuilder/constructor_initializations/SomePanelBuilder.java
@@ -6,11 +6,11 @@ public class SomePanelBuilder implements cog.Builder<SomePanel> {
     
     public SomePanelBuilder() {
         this.internal = new SomePanel();
-    this.internal.type = "panel_type";
-    this.internal.cursor = CursorMode.TOOLTIP;
+        this.internal.type = "panel_type";
+        this.internal.cursor = CursorMode.TOOLTIP;
     }
     public SomePanelBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     public SomePanel build() {

--- a/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
+++ b/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
@@ -8,7 +8,7 @@ public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Pane
         this.internal = new Panel();
     }
     public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
-    this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
+        this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
         return (T) this;
     }
     public Panel build() {

--- a/testdata/jennies/builders/dataquery_variant_builder/JavaBuilder/dataquery_variant_builder/LokiBuilderBuilder.java
+++ b/testdata/jennies/builders/dataquery_variant_builder/JavaBuilder/dataquery_variant_builder/LokiBuilderBuilder.java
@@ -8,7 +8,7 @@ public class LokiBuilderBuilder implements cog.Builder<cog.variants.Dataquery> {
         this.internal = new Loki();
     }
     public LokiBuilderBuilder expr(String expr) {
-    this.internal.expr = expr;
+        this.internal.expr = expr;
         return this;
     }
     public Loki build() {

--- a/testdata/jennies/builders/envelope_assignment/JavaBuilder/sandbox/DashboardBuilder.java
+++ b/testdata/jennies/builders/envelope_assignment/JavaBuilder/sandbox/DashboardBuilder.java
@@ -15,7 +15,7 @@ public class DashboardBuilder implements cog.Builder<Dashboard> {
     Variable variable = new Variable();
         variable.name = name;
         variable.value = value;
-    this.internal.variables.add(variable);
+        this.internal.variables.add(variable);
         return this;
     }
     public Dashboard build() {

--- a/testdata/jennies/builders/foreign_builder/JavaBuilder/builder_pkg/SomeNiceBuilderBuilder.java
+++ b/testdata/jennies/builders/foreign_builder/JavaBuilder/builder_pkg/SomeNiceBuilderBuilder.java
@@ -9,7 +9,7 @@ public class SomeNiceBuilderBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeNiceBuilderBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/initialization_safeguards/JavaBuilder/initialization_safeguards/SomePanelBuilder.java
+++ b/testdata/jennies/builders/initialization_safeguards/JavaBuilder/initialization_safeguards/SomePanelBuilder.java
@@ -8,7 +8,7 @@ public class SomePanelBuilder implements cog.Builder<SomePanel> {
         this.internal = new SomePanel();
     }
     public SomePanelBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     
@@ -19,7 +19,7 @@ public class SomePanelBuilder implements cog.Builder<SomePanel> {
 		if (this.internal.options.legend == null) {
 			this.internal.options.legend = new initialization_safeguards.LegendOptions();
 		}
-    this.internal.options.legend.show = show;
+        this.internal.options.legend.show = show;
         return this;
     }
     public SomePanel build() {

--- a/testdata/jennies/builders/known_any/JavaBuilder/known_any/SomeStructBuilder.java
+++ b/testdata/jennies/builders/known_any/JavaBuilder/known_any/SomeStructBuilder.java
@@ -11,9 +11,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.config == null) {
 			this.internal.config = new known_any.Config();
 		}
-        known_any.Config configResource = (known_any.Config) this.internal.config;
-        configResource.title = title;
-    this.internal.config = configResource;
+    ((Config) this.internal.config).title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/known_any/JavaBuilder/known_any/SomeStructBuilder.java
+++ b/testdata/jennies/builders/known_any/JavaBuilder/known_any/SomeStructBuilder.java
@@ -11,7 +11,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.config == null) {
 			this.internal.config = new known_any.Config();
 		}
-    ((Config) this.internal.config).title = title;
+        ((Config) this.internal.config).title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/map_index_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/map_index_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -12,11 +12,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.annotations == null) {
 			this.internal.annotations = new HashMap<>();
 		}
-    
-            
-            
-            this.internal.annotations.put(key, value);
-        
+        this.internal.annotations.put(key, value);
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/map_index_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/map_index_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -12,7 +12,11 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.annotations == null) {
 			this.internal.annotations = new HashMap<>();
 		}
-    this.internal.annotations[key] = value;
+    
+            
+            
+            this.internal.annotations.put(key, value);
+        
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/map_of_builders/JavaBuilder/map_of_builders/DashboardBuilder.java
+++ b/testdata/jennies/builders/map_of_builders/JavaBuilder/map_of_builders/DashboardBuilder.java
@@ -14,7 +14,7 @@ public class DashboardBuilder implements cog.Builder<Dashboard> {
         for (var entry : panels.entrySet()) {
            panelsResource.put(entry.getKey(), entry.getValue().build());
         }
-    this.internal.panels = panelsResource;
+        this.internal.panels = panelsResource;
         return this;
     }
     public Dashboard build() {

--- a/testdata/jennies/builders/map_of_builders/JavaBuilder/map_of_builders/PanelBuilder.java
+++ b/testdata/jennies/builders/map_of_builders/JavaBuilder/map_of_builders/PanelBuilder.java
@@ -8,7 +8,7 @@ public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Pane
         this.internal = new Panel();
     }
     public T title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return (T) this;
     }
     public Panel build() {

--- a/testdata/jennies/builders/nullable_map_assignment/JavaBuilder/nullable_map_assignment/SomeStructBuilder.java
+++ b/testdata/jennies/builders/nullable_map_assignment/JavaBuilder/nullable_map_assignment/SomeStructBuilder.java
@@ -9,7 +9,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeStructBuilder config(Map<String, String> config) {
-    this.internal.config = config;
+        this.internal.config = config;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/package-with-dashes/JavaBuilder/builderpkg/SomeNiceBuilderBuilder.java
+++ b/testdata/jennies/builders/package-with-dashes/JavaBuilder/builderpkg/SomeNiceBuilderBuilder.java
@@ -9,7 +9,7 @@ public class SomeNiceBuilderBuilder implements cog.Builder<SomeStruct> {
         this.internal = new SomeStruct();
     }
     public SomeNiceBuilderBuilder title(String title) {
-    this.internal.title = title;
+        this.internal.title = title;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/panel_builders/JavaBuilder/panelbuilder/PanelBuilder.java
+++ b/testdata/jennies/builders/panel_builders/JavaBuilder/panelbuilder/PanelBuilder.java
@@ -9,52 +9,52 @@ public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Opti
         this.internal = new Options();
     }
     public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
-    this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
+        this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
         return (T) this;
     }
     
     public T onlyInTimeRange(Boolean onlyInTimeRange) {
-    this.internal.onlyInTimeRange = onlyInTimeRange;
+        this.internal.onlyInTimeRange = onlyInTimeRange;
         return (T) this;
     }
     
     public T tags(List<String> tags) {
-    this.internal.tags = tags;
+        this.internal.tags = tags;
         return (T) this;
     }
     
     public T limit(Integer limit) {
-    this.internal.limit = limit;
+        this.internal.limit = limit;
         return (T) this;
     }
     
     public T showUser(Boolean showUser) {
-    this.internal.showUser = showUser;
+        this.internal.showUser = showUser;
         return (T) this;
     }
     
     public T showTime(Boolean showTime) {
-    this.internal.showTime = showTime;
+        this.internal.showTime = showTime;
         return (T) this;
     }
     
     public T showTags(Boolean showTags) {
-    this.internal.showTags = showTags;
+        this.internal.showTags = showTags;
         return (T) this;
     }
     
     public T navigateToPanel(Boolean navigateToPanel) {
-    this.internal.navigateToPanel = navigateToPanel;
+        this.internal.navigateToPanel = navigateToPanel;
         return (T) this;
     }
     
     public T navigateBefore(String navigateBefore) {
-    this.internal.navigateBefore = navigateBefore;
+        this.internal.navigateBefore = navigateBefore;
         return (T) this;
     }
     
     public T navigateAfter(String navigateAfter) {
-    this.internal.navigateAfter = navigateAfter;
+        this.internal.navigateAfter = navigateAfter;
         return (T) this;
     }
     public Options build() {

--- a/testdata/jennies/builders/properties/JavaBuilder/properties/SomeStructBuilder.java
+++ b/testdata/jennies/builders/properties/JavaBuilder/properties/SomeStructBuilder.java
@@ -10,7 +10,7 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
     this.someBuilderProperty = "";
     }
     public SomeStructBuilder id(Long id) {
-    this.internal.id = id;
+        this.internal.id = id;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/references/JavaBuilder/some_pkg/PersonBuilder.java
+++ b/testdata/jennies/builders/references/JavaBuilder/some_pkg/PersonBuilder.java
@@ -9,7 +9,7 @@ public class PersonBuilder implements cog.Builder<Person> {
         this.internal = new Person();
     }
     public PersonBuilder name(Name name) {
-    this.internal.name = name;
+        this.internal.name = name;
         return this;
     }
     public Person build() {

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -11,8 +11,8 @@ public class SomeStructBuilder implements cog.Builder<SomeStruct> {
 		if (this.internal.time == null) {
 			this.internal.time = new Object();
 		}
-    this.internal.time.from = from;
-    this.internal.time.to = to;
+        this.internal.time.from = from;
+        this.internal.time.to = to;
         return this;
     }
     public SomeStruct build() {

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/NestedStructBuilder.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/NestedStructBuilder.java
@@ -8,12 +8,12 @@ public class NestedStructBuilder implements cog.Builder<NestedStruct> {
         this.internal = new NestedStruct();
     }
     public NestedStructBuilder stringVal(String stringVal) {
-    this.internal.stringVal = stringVal;
+        this.internal.stringVal = stringVal;
         return this;
     }
     
     public NestedStructBuilder intVal(Long intVal) {
-    this.internal.intVal = intVal;
+        this.internal.intVal = intVal;
         return this;
     }
     public NestedStruct build() {

--- a/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/StructBuilder.java
+++ b/testdata/jennies/builders/struct_with_defaults/JavaBuilder/struct_with_defaults/StructBuilder.java
@@ -8,27 +8,27 @@ public class StructBuilder implements cog.Builder<Struct> {
         this.internal = new Struct();
     }
     public StructBuilder allFields(cog.Builder<NestedStruct> allFields) {
-    this.internal.allFields = allFields.build();
+        this.internal.allFields = allFields.build();
         return this;
     }
     
     public StructBuilder partialFields(cog.Builder<NestedStruct> partialFields) {
-    this.internal.partialFields = partialFields.build();
+        this.internal.partialFields = partialFields.build();
         return this;
     }
     
     public StructBuilder emptyFields(cog.Builder<NestedStruct> emptyFields) {
-    this.internal.emptyFields = emptyFields.build();
+        this.internal.emptyFields = emptyFields.build();
         return this;
     }
     
     public StructBuilder complexField(Object complexField) {
-    this.internal.complexField = complexField;
+        this.internal.complexField = complexField;
         return this;
     }
     
     public StructBuilder partialComplexField(Object partialComplexField) {
-    this.internal.partialComplexField = partialComplexField;
+        this.internal.partialComplexField = partialComplexField;
         return this;
     }
     public Struct build() {

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
@@ -5,11 +5,11 @@ public class SomeStruct {
     public Long id;
     public Long maybeId;
     public String title;
-    public refStruct refStruct;
+    public RefStruct refStruct;
     public SomeStruct() {
     }
     
-    public SomeStruct(Long id,Long maybeId,String title,refStruct refStruct) {
+    public SomeStruct(Long id,Long maybeId,String title,RefStruct refStruct) {
         this.id = id;
         this.maybeId = maybeId;
         this.title = title;

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStructFromOtherPackage.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStructFromOtherPackage.java
@@ -1,6 +1,5 @@
 package refs;
 
-import otherpkg.SomeDistantStruct;
 
-public class RefToSomeStructFromOtherPackage extends SomeDistantStruct {
+public class RefToSomeStructFromOtherPackage extends otherpkg.SomeDistantStruct {
 }


### PR DESCRIPTION
This PR addresses a few bugs in the Java jenny, found while [playing with the dashboard v2 schema](https://github.com/grafana/cog/pull/722).

Specifically:

* the way paths with casts were handled could result in conflicting variables being generated
* assignments to a specific key of a map was borked
* default values for structs generated from disjunctions generated incorrect code

The fixes here are most definitely not perfect: a deeper look and more systematic check of the java jenny is definitely needed.
But at least, this jenny can now deal with the current foundation SDK while also being able to generate valid code for the dashboard v2 schema. I call this good enough for now :sweat_smile: 