### PR TITLE
Turn the ComposeBuilders veneer into a noop if the source builder is …

### DIFF
--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -277,7 +277,7 @@ func ComposeBuilders(selector Selector, config CompositionConfig) RewriteRule {
 
 		sourceBuilder, found := builders.LocateByObject(sourceBuilderPkg, sourceBuilderNameWithoutPkg)
 		if !found {
-			return nil, fmt.Errorf("could not apply ComposeBuilders builder veneer: source builder '%s' not found", config.SourceBuilderName)
+			return builders, nil
 		}
 
 		// - add to newBuilders all the builders that are not composable (ie: don't comply to the selector)


### PR DESCRIPTION
…not found

It makes this veneer usable across a range of schema versions, not all of which having the object to compose.

See #722 