### PR TITLE
Support preserving the original builders in ComposeBuilders veneer

### DIFF
--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -116,6 +116,7 @@ type ComposeBuilders struct {
 	ExcludeOptions           []string          `yaml:"exclude_options"`
 	CompositionMap           map[string]string `yaml:"composition_map"`
 	ComposedBuilderName      string            `yaml:"composed_builder_name"`
+	PreserveOriginalBuilders bool              `yaml:"preserve_original_builders"`
 }
 
 func (rule ComposeBuilders) AsRewriteRule(pkg string) (builder.RewriteRule, error) {

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -547,6 +547,9 @@
         },
         "composed_builder_name": {
           "type": "string"
+        },
+        "preserve_original_builders": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This is needed to support both dashboard & dashboardv2, since both of these packages need to perform similar composition transformations for panels.