### PR TITLE
Add support for setting comments and arguments in AddOption builder veneer

### DIFF
--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -468,8 +468,8 @@ func AddOption(selector Selector, newOption veneers.Option) RewriteRule {
 				return nil, fmt.Errorf("could not apply AddOption builder veneer: %w", err)
 			}
 
+			newOpt.AddToVeneerTrail("AddOption")
 			builders[i].Options = append(builders[i].Options, newOpt)
-			builders[i].AddToVeneerTrail("AddOption")
 		}
 
 		return builders, nil

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -463,7 +463,7 @@ func AddOption(selector Selector, newOption veneers.Option) RewriteRule {
 				continue
 			}
 
-			newOpt, err := newOption.AsIR(builders, builder)
+			newOpt, err := newOption.AsIR(schemas, builders, builder)
 			if err != nil {
 				return nil, fmt.Errorf("could not apply AddOption builder veneer: %w", err)
 			}

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -657,8 +657,8 @@ func DuplicateAction(duplicateName string) RewriteAction {
 
 // AddAssignmentAction adds an assignment to an existing option.
 func AddAssignmentAction(assignment veneers.Assignment) RewriteAction {
-	return func(_ ast.Schemas, builder ast.Builder, option ast.Option) []ast.Option {
-		irAssignment, err := assignment.AsIR(ast.Builders{builder}, builder)
+	return func(schemas ast.Schemas, builder ast.Builder, option ast.Option) []ast.Option {
+		irAssignment, err := assignment.AsIR(schemas, ast.Builders{builder}, builder)
 		if err != nil {
 			// TODO: let veneers return errors
 			option.AddToVeneerTrail(fmt.Sprintf("AddAssignment[err=%s]", err.Error()))

--- a/internal/veneers/types.go
+++ b/internal/veneers/types.go
@@ -1,6 +1,8 @@
 package veneers
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -11,10 +13,10 @@ type Option struct {
 	Assignments []Assignment   `yaml:"assignments"`
 }
 
-func (opt Option) AsIR(builders ast.Builders, root ast.Builder) (ast.Option, error) {
+func (opt Option) AsIR(schemas ast.Schemas, builders ast.Builders, root ast.Builder) (ast.Option, error) {
 	assignments := make([]ast.Assignment, 0, len(opt.Assignments))
 	for _, assignment := range opt.Assignments {
-		irAssignment, err := assignment.AsIR(builders, root)
+		irAssignment, err := assignment.AsIR(schemas, builders, root)
 		if err != nil {
 			return ast.Option{}, err
 		}
@@ -33,19 +35,101 @@ func (opt Option) AsIR(builders ast.Builders, root ast.Builder) (ast.Option, err
 type Assignment struct {
 	Path   string               `yaml:"path"`
 	Method ast.AssignmentMethod `yaml:"method"`
-	Value  ast.AssignmentValue  `yaml:"value"`
+	Value  AssignmentValue      `yaml:"value"`
 }
 
-func (assignment Assignment) AsIR(builders ast.Builders, root ast.Builder) (ast.Assignment, error) {
-	// TODO
+func (assignment Assignment) AsIR(schemas ast.Schemas, builders ast.Builders, root ast.Builder) (ast.Assignment, error) {
 	path, err := root.MakePath(builders, assignment.Path)
+	if err != nil {
+		return ast.Assignment{}, err
+	}
+
+	value, err := assignment.Value.AsIR(schemas, path)
 	if err != nil {
 		return ast.Assignment{}, err
 	}
 
 	return ast.Assignment{
 		Path:   path,
-		Value:  assignment.Value,
+		Value:  value,
 		Method: assignment.Method,
+	}, nil
+}
+
+type AssignmentValue struct {
+	Argument *ast.Argument       `json:",omitempty"`
+	Constant any                 `json:",omitempty"`
+	Envelope *AssignmentEnvelope `json:",omitempty"`
+}
+
+func (value AssignmentValue) AsIR(schemas ast.Schemas, assignmentPath ast.Path) (ast.AssignmentValue, error) {
+	if value.Argument != nil {
+		return ast.AssignmentValue{Argument: value.Argument}, nil
+	}
+	if value.Constant != nil {
+		return ast.AssignmentValue{Constant: value.Constant}, nil
+	}
+	if value.Envelope != nil {
+		envelopeType := assignmentPath.Last().Type
+		if envelopeType.IsArray() {
+			envelopeType = envelopeType.Array.ValueType
+		}
+		if envelopeType.IsMap() {
+			envelopeType = envelopeType.Map.ValueType
+		}
+
+		envelope, err := value.Envelope.AsIR(schemas, envelopeType)
+		if err != nil {
+			return ast.AssignmentValue{}, err
+		}
+
+		return ast.AssignmentValue{Envelope: &envelope}, nil
+	}
+
+	return ast.AssignmentValue{}, fmt.Errorf("empty assignment value")
+}
+
+type AssignmentEnvelope struct {
+	Values []EnvelopeFieldValue
+}
+
+func (envelope AssignmentEnvelope) AsIR(schemas ast.Schemas, envelopeType ast.Type) (ast.AssignmentEnvelope, error) {
+	var err error
+	values := make([]ast.EnvelopeFieldValue, len(envelope.Values))
+	for i, val := range envelope.Values {
+		values[i], err = val.AsIR(schemas, envelopeType)
+		if err != nil {
+			return ast.AssignmentEnvelope{}, err
+		}
+	}
+
+	return ast.AssignmentEnvelope{
+		Type:   envelopeType,
+		Values: values,
+	}, nil
+}
+
+type EnvelopeFieldValue struct {
+	Field string          // where to assign within the struct/ref
+	Value AssignmentValue // what to assign
+}
+
+func (envelopeField EnvelopeFieldValue) AsIR(schemas ast.Schemas, envelopeType ast.Type) (ast.EnvelopeFieldValue, error) {
+	resolvedEnvelope := schemas.ResolveToType(envelopeType)
+	field, found := resolvedEnvelope.Struct.FieldByName(envelopeField.Field)
+	if !found {
+		return ast.EnvelopeFieldValue{}, fmt.Errorf("envelope field %s not found", envelopeField.Field)
+	}
+
+	path := ast.PathFromStructField(field)
+
+	value, err := envelopeField.Value.AsIR(schemas, path)
+	if err != nil {
+		return ast.EnvelopeFieldValue{}, err
+	}
+
+	return ast.EnvelopeFieldValue{
+		Path:  path,
+		Value: value,
 	}, nil
 }

--- a/internal/veneers/types.go
+++ b/internal/veneers/types.go
@@ -5,8 +5,10 @@ import (
 )
 
 type Option struct {
-	Name        string       `yaml:"name"`
-	Assignments []Assignment `yaml:"assignments"`
+	Name        string         `yaml:"name"`
+	Comments    []string       `yaml:"comments"`
+	Arguments   []ast.Argument `yaml:"arguments"`
+	Assignments []Assignment   `yaml:"assignments"`
 }
 
 func (opt Option) AsIR(builders ast.Builders, root ast.Builder) (ast.Option, error) {
@@ -22,6 +24,8 @@ func (opt Option) AsIR(builders ast.Builders, root ast.Builder) (ast.Option, err
 
 	return ast.Option{
 		Name:        opt.Name,
+		Comments:    opt.Comments,
+		Args:        opt.Arguments,
 		Assignments: assignments,
 	}, nil
 }

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -350,6 +350,18 @@
         "name": {
           "type": "string"
         },
+        "comments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "arguments": {
+          "items": {
+            "$ref": "#/$defs/AstArgument"
+          },
+          "type": "array"
+        },
         "assignments": {
           "items": {
             "$ref": "#/$defs/VeneersAssignment"


### PR DESCRIPTION
This PR tweaks the `AddOption` builder veneer to make it easier to use.

See https://github.com/grafana/grafana-foundation-sdk/pull/598 where I use this veneer to add a few convenience options to add overrides to panels.