### PR TITLE
Cleanup override-related code in examples

### DIFF
--- a/examples/_go/disk.go
+++ b/examples/_go/disk.go
@@ -22,21 +22,9 @@ func diskIOTimeseries() *timeseries.PanelBuilder {
 			basicPrometheusQuery(`rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} IO time"),
 		).
 		// Overrides configuration
-		WithOverride(
-			// TODO: not very intuitive
-			// we could have "factory" functions:
-			// - dashboard.OverrideByName("Mounted on")
-			// - dashboard.OverrideByRegexp("/ regex /")
-			// - ...
-			// Also: knowing what to set in the Value field is far from obvious
-			dashboard.MatcherConfig{
-				Id:      "byRegexp", // TODO: we don't have constants for these?
-				Options: "/ io time/",
-			},
-			[]dashboard.DynamicConfigValue{
-				{Id: "unit", Value: "percentunit"},
-			},
-		)
+		OverrideByRegexp("/ io time/", []dashboard.DynamicConfigValue{
+			{Id: "unit", Value: "percentunit"},
+		})
 }
 
 func diskSpaceUsageTable() *table.PanelBuilder {
@@ -131,43 +119,28 @@ func diskSpaceUsageTable() *table.PanelBuilder {
 		}).
 
 		// Overrides configuration
-		WithOverride(
-			dashboard.MatcherConfig{Id: "byName", Options: "Mounted on"},
-			[]dashboard.DynamicConfigValue{
-				{Id: "custom.width", Value: 260},
-			},
-		).
-		WithOverride(
-			dashboard.MatcherConfig{Id: "byName", Options: "Size"},
-			[]dashboard.DynamicConfigValue{
-				{Id: "custom.width", Value: 93},
-			},
-		).
-		WithOverride(
-			dashboard.MatcherConfig{Id: "byName", Options: "Used"},
-			[]dashboard.DynamicConfigValue{
-				{Id: "custom.width", Value: 72},
-			},
-		).
-		WithOverride(
-			dashboard.MatcherConfig{Id: "byName", Options: "Available"},
-			[]dashboard.DynamicConfigValue{
-				{Id: "custom.width", Value: 88},
-			},
-		).
-		WithOverride(
-			dashboard.MatcherConfig{Id: "byName", Options: "Used, %"},
-			[]dashboard.DynamicConfigValue{
-				{Id: "unit", Value: "percentunit"},
-				{Id: "custom.cellOptions", Value: struct {
-					Mode string `json:"mode"`
-					Type string `json:"type"`
-				}{
-					Mode: "gradient",
-					Type: "gauge",
-				}},
-				{Id: "min", Value: 0},
-				{Id: "max", Value: 1},
-			},
-		)
+		OverrideByName("Mounted on", []dashboard.DynamicConfigValue{
+			{Id: "custom.width", Value: 260},
+		}).
+		OverrideByName("Size", []dashboard.DynamicConfigValue{
+			{Id: "custom.width", Value: 93},
+		}).
+		OverrideByName("Used", []dashboard.DynamicConfigValue{
+			{Id: "custom.width", Value: 72},
+		}).
+		OverrideByName("Available", []dashboard.DynamicConfigValue{
+			{Id: "custom.width", Value: 88},
+		}).
+		OverrideByName("Used, %", []dashboard.DynamicConfigValue{
+			{Id: "unit", Value: "percentunit"},
+			{Id: "custom.cellOptions", Value: struct {
+				Mode string `json:"mode"`
+				Type string `json:"type"`
+			}{
+				Mode: "gradient",
+				Type: "gauge",
+			}},
+			{Id: "min", Value: 0},
+			{Id: "max", Value: 1},
+		})
 }

--- a/examples/java/src/main/java/test/Disk.java
+++ b/examples/java/src/main/java/test/Disk.java
@@ -26,9 +26,9 @@ public class Disk {
                                 .withTarget(Common.basicPrometheusQuery(
                                                 "rate(node_disk_io_time_seconds_total{job=\"integrations/raspberrypi-node\", instance=\"$instance\", device!=\"\"}[$__rate_interval])",
                                                 "{{device}} IO time"))
-                                .withOverride(new DashboardFieldConfigSourceOverridesBuilder()
-                                                .matcher(new MatcherConfig("byRegexp", "/ io time/"))
-                                                .properties(List.of(new DynamicConfigValue("unit", "percentunit"))));
+                                .overrideByRegexp("/ io time/", List.of(
+                                    new DynamicConfigValue("unit", "percentunit")
+                                ));
         }
 
         public static com.grafana.foundation.table.PanelBuilder diskSpaceUsageTable() {
@@ -47,17 +47,16 @@ public class Disk {
                                 .withTransformation(transformation("calculateField", transformer4Options()))
                                 .withTransformation(transformation("organize", transformer5Options()))
                                 .withTransformation(transformation("sortBy", transformer6Options()))
-                                .withOverride(defaultOverrides("Mounted on", 260))
-                                .withOverride(defaultOverrides("Size", 93)).withOverride(defaultOverrides("Used", 72))
-                                .withOverride(defaultOverrides("Available", 88))
-                                .withOverride(new DashboardFieldConfigSourceOverridesBuilder()
-                                                .matcher(new MatcherConfig("byName", "Used, %")).properties(List.of(
-                                                                new DynamicConfigValue("unit", "percentunit"),
-                                                                new DynamicConfigValue("custom.cellOptions",
-                                                                                Map.of("mode", "gradient", "type",
-                                                                                                "gauge")),
-                                                                new DynamicConfigValue("min", 0),
-                                                                new DynamicConfigValue("max", 1))));
+                                .overrideByName("Mounted on", List.of(new DynamicConfigValue("custom.width", 260)))
+                                .overrideByName("Size", List.of(new DynamicConfigValue("custom.width", 93)))
+                                .overrideByName("Used", List.of(new DynamicConfigValue("custom.width", 72)))
+                                .overrideByName("Available", List.of(new DynamicConfigValue("custom.width", 88)))
+                                .overrideByName("Used, %", List.of(
+                                    new DynamicConfigValue("unit", "percentunit"),
+                                    new DynamicConfigValue("custom.cellOptions", Map.of("mode", "gradient", "type", "gauge")),
+                                    new DynamicConfigValue("min", 0),
+                                    new DynamicConfigValue("max", 1)
+                                ));
         }
 
         private static DataTransformerConfig transformation(String id, Object options) {
@@ -116,10 +115,5 @@ public class Disk {
                 return Map.of(
                                 "fields", List.of(),
                                 "sort", Map.of("field", "Mounted on"));
-        }
-
-        private static Builder<DashboardFieldConfigSourceOverrides> defaultOverrides(String options, Integer value) {
-                return new DashboardFieldConfigSourceOverridesBuilder().matcher(new MatcherConfig("byName", options))
-                                .properties(List.of(new DynamicConfigValue("custom.width", value)));
         }
 }

--- a/examples/php/src/Monitoring/Disk.php
+++ b/examples/php/src/Monitoring/Disk.php
@@ -23,12 +23,9 @@ class Disk
                 Common::basicPrometheusQuery('rate(node_disk_written_bytes_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])', '{{ device }} written'),
                 Common::basicPrometheusQuery('rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])', '{{ device }} IO time'),
             ])
-            ->withOverride(
-                new MatcherConfig(id: 'byRegexp', options: '/ io time/'),
-                [
-                    new DynamicConfigValue(id: 'unit', value: 'percentunit'),
-                ],
-            );
+            ->overrideByRegexp('/ io time/', [
+                new DynamicConfigValue(id: 'unit', value: 'percentunit'),
+            ]);
     }
 
     public static function spaceUsageTable(): Table\PanelBuilder
@@ -116,33 +113,26 @@ class Disk
                 ],
             ))
             // Overrides
-            ->withOverride(
-                new MatcherConfig(id: 'byName', options: 'Mounted on'),
-                [new DynamicConfigValue(id: 'custom.width', value: 260)],
-            )
-            ->withOverride(
-                new MatcherConfig(id: 'byName', options: 'Size'),
-                [new DynamicConfigValue(id: 'custom.width', value: 93)],
-            )
-            ->withOverride(
-                new MatcherConfig(id: 'byName', options: 'Used'),
-                [new DynamicConfigValue(id: 'custom.width', value: 72)],
-            )
-            ->withOverride(
-                new MatcherConfig(id: 'byName', options: 'Available'),
-                [new DynamicConfigValue(id: 'custom.width', value: 88)],
-            )
-            ->withOverride(
-                new MatcherConfig(id: 'byName', options: 'Used, %'),
-                [
-                    new DynamicConfigValue(id: 'unit', value: 'percentunit'),
-                    new DynamicConfigValue(id: 'custom.cellOptions', value: [
-                        'mode' => 'gradient',
-                        'type' => 'gauge',
-                    ]),
-                    new DynamicConfigValue(id: 'min', value: 0),
-                    new DynamicConfigValue(id: 'max', value: 1),
-                ],
-            );
+            ->overrideByName('Mounted on', [
+                new DynamicConfigValue(id: 'custom.width', value: 260),
+            ])
+            ->overrideByName('Size', [
+                new DynamicConfigValue(id: 'custom.width', value: 93),
+            ])
+            ->overrideByName('Used', [
+                new DynamicConfigValue(id: 'custom.width', value: 72),
+            ])
+            ->overrideByName('Available', [
+                new DynamicConfigValue(id: 'custom.width', value: 88),
+            ])
+            ->overrideByName('Used, %', [
+                new DynamicConfigValue(id: 'unit', value: 'percentunit'),
+                new DynamicConfigValue(id: 'custom.cellOptions', value: [
+                    'mode' => 'gradient',
+                    'type' => 'gauge',
+                ]),
+                new DynamicConfigValue(id: 'min', value: 0),
+                new DynamicConfigValue(id: 'max', value: 1),
+            ]);
     }
 }

--- a/examples/python/raspberry/disk.py
+++ b/examples/python/raspberry/disk.py
@@ -21,12 +21,9 @@ def disk_io_timeseries() -> cogbuilder.Builder[dashboard.Panel]:
         .with_target(
             basic_prometheus_query('rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])', "{{device}} IO time")
         )
-        .with_override(
-            dashboard.MatcherConfig(id_val="byRegexp", options="/ io time/"),
-            [
-                dashboard.DynamicConfigValue(id_val="unit", value="percentunit"),
-            ],
-        )
+        .override_by_regexp("/ io time/", [
+            dashboard.DynamicConfigValue(id_val="unit", value="percentunit"),
+        ])
     )
 
 
@@ -130,33 +127,26 @@ def disk_space_usage_table() -> cogbuilder.Builder[dashboard.Panel]:
             )
         )
         # Overrides configuration
-        .with_override(
-            dashboard.MatcherConfig(id_val="byName", options="Mounted on"),
-            [dashboard.DynamicConfigValue(id_val="custom.width", value=260)]
-        )
-        .with_override(
-            dashboard.MatcherConfig(id_val="byName", options="Size"),
-            [dashboard.DynamicConfigValue(id_val="custom.width", value=93)]
-        )
-        .with_override(
-            dashboard.MatcherConfig(id_val="byName", options="Used"),
-            [dashboard.DynamicConfigValue(id_val="custom.width", value=72)]
-        )
-        .with_override(
-            dashboard.MatcherConfig(id_val="byName", options="Available"),
-            [dashboard.DynamicConfigValue(id_val="custom.width", value=88)]
-        )
-        .with_override(
-            dashboard.MatcherConfig(id_val="byName", options="Used, %"),
-            [
-                dashboard.DynamicConfigValue(id_val="unit", value="percentunit"),
-                dashboard.DynamicConfigValue(
-                    id_val="custom.cellOptions",
-                    value={"mode": "gradient", "type": "gauge"},
-                ),
-                dashboard.DynamicConfigValue(id_val="max", value="1"),
-                dashboard.DynamicConfigValue(id_val="min", value="0"),
-            ]
-        )
+        .override_by_name("Mounted on", [
+            dashboard.DynamicConfigValue(id_val="custom.width", value=260),
+        ])
+        .override_by_name("Size", [
+            dashboard.DynamicConfigValue(id_val="custom.width", value=93),
+        ])
+        .override_by_name("Used", [
+            dashboard.DynamicConfigValue(id_val="custom.width", value=72),
+        ])
+        .override_by_name("Available", [
+            dashboard.DynamicConfigValue(id_val="custom.width", value=88),
+        ])
+        .override_by_name("Used, %", [
+            dashboard.DynamicConfigValue(id_val="unit", value="percentunit"),
+            dashboard.DynamicConfigValue(
+                id_val="custom.cellOptions",
+                value={"mode": "gradient", "type": "gauge"},
+            ),
+            dashboard.DynamicConfigValue(id_val="max", value="1"),
+            dashboard.DynamicConfigValue(id_val="min", value="0"),
+        ])
     )
 

--- a/examples/typescript/disk.ts
+++ b/examples/typescript/disk.ts
@@ -17,12 +17,9 @@ export const diskIOTimeseries = (): TimeseriesPanelBuilder => {
         .withTarget(
             basicPrometheusQuery(`rate(node_disk_io_time_seconds_total{job="integrations/raspberrypi-node", instance="$instance", device!=""}[$__rate_interval])`, "{{device}} IO time"),
         )
-        .withOverride({
-            matcher: {id: "byRegexp", options: "/ io time/"},
-            properties: [
-                {id: "unit", value: "percentunit"},
-            ]
-        });
+        .overrideByRegexp("/ io time/", [
+            {id: "unit", value: "percentunit"},
+        ]);
 };
 
 export const diskSpaceUsageTable = (): TablePanelBuilder => {
@@ -115,33 +112,18 @@ export const diskSpaceUsageTable = (): TablePanelBuilder => {
         })
 
         // Overrides configuration
-        .withOverride({
-            matcher: {id: "byName", options: "Mounted on"},
-            properties: [{id: "custom.width", value: 260}]
-        })
-        .withOverride({
-            matcher: {id: "byName", options: "Size"},
-            properties: [{id: "custom.width", value: 93}]
-        })
-        .withOverride({
-            matcher: {id: "byName", options: "Used"},
-            properties: [{id: "custom.width", value: 72}]
-        })
-        .withOverride({
-            matcher: {id: "byName", options: "Available"},
-            properties: [{id: "custom.width", value: 88}]
-        })
-        .withOverride({
-            matcher: {id: "byName", options: "Used, %"},
-            properties: [
-                {id: "unit", value: "percentunit"},
-                {
-                    id: "custom.cellOptions",
-                    value: {mode: "gradient", type: "gauge"}
-                },
-                {id: "max", value: 1},
-                {id: "min", value: 0}
-            ]
-        })
+        .overrideByName("Mounted on", [{id: "custom.width", value: 260}])
+        .overrideByName("Size", [{id: "custom.width", value: 93}])
+        .overrideByName("Used", [{id: "custom.width", value: 72}])
+        .overrideByName("Available", [{id: "custom.width", value: 88}])
+        .overrideByName("Used, %", [
+            {id: "unit", value: "percentunit"},
+            {
+                id: "custom.cellOptions",
+                value: {mode: "gradient", type: "gauge"}
+            },
+            {id: "max", value: 1},
+            {id: "min", value: 0}
+        ])
     ;
 };


### PR DESCRIPTION
Now that we have <sub>slightly</sub> cleaner ways of defining overrides, let's reflect that in the examples!