### PR TITLE
Move the definition of concrete value at type-level instead of on scalars only

### DIFF
--- a/internal/ast/compiler/constant_to_enum.go
+++ b/internal/ast/compiler/constant_to_enum.go
@@ -34,8 +34,8 @@ func (pass *ConstantToEnum) processObject(_ *Visitor, _ *ast.Schema, object ast.
 	object.Type = ast.NewEnum([]ast.EnumValue{
 		{
 			Type:  ast.String(),
-			Name:  object.Type.Scalar.Value.(string),
-			Value: object.Type.Scalar.Value.(string),
+			Name:  object.Type.Value.(string),
+			Value: object.Type.Value.(string),
 		},
 	})
 	object.AddToPassesTrail("ConstantToEnum")

--- a/internal/ast/compiler/disjunction_with_constant_to_default.go
+++ b/internal/ast/compiler/disjunction_with_constant_to_default.go
@@ -36,16 +36,16 @@ func (pass *DisjunctionWithConstantToDefault) processDisjunction(_ *Visitor, _ *
 		return def, nil
 	}
 
-	if branches[0].Scalar.IsConcrete() == branches[1].Scalar.IsConcrete() {
+	if branches[0].IsConcrete() == branches[1].IsConcrete() {
 		return def, nil
 	}
 
-	if branches[0].Scalar.IsConcrete() {
+	if branches[0].IsConcrete() {
 		def = branches[1]
-		def.Default = branches[0].Scalar.Value
+		def.Default = branches[0].Value
 	} else {
 		def = branches[0]
-		def.Default = branches[1].Scalar.Value
+		def.Default = branches[1].Value
 	}
 
 	def.AddToPassesTrail("DisjunctionWithConstantToDefault")

--- a/internal/ast/compiler/disjunctions_infer_mapping.go
+++ b/internal/ast/compiler/disjunctions_infer_mapping.go
@@ -104,7 +104,7 @@ func (pass *DisjunctionInferMapping) inferDiscriminatorField(schema *ast.Schema,
 				continue
 			}
 
-			candidates[typeName][field.Name] = scalarField.Value
+			candidates[typeName][field.Name] = field.Type.Value
 		}
 	}
 
@@ -163,8 +163,8 @@ func (pass *DisjunctionInferMapping) buildDiscriminatorMapping(schema *ast.Schem
 		typeName := branch.AsRef().ReferredType
 
 		switch {
-		case field.Type.AsScalar().IsConcrete():
-			mapping[field.Type.AsScalar().Value.(string)] = typeName
+		case field.Type.IsConcrete():
+			mapping[field.Type.Value.(string)] = typeName
 		case field.Type.Default != nil:
 			mapping[field.Type.Default.(string)] = typeName
 		default:

--- a/internal/ast/compiler/disjunctions_of_anonymous_to_explicit.go
+++ b/internal/ast/compiler/disjunctions_of_anonymous_to_explicit.go
@@ -61,7 +61,7 @@ func (pass *DisjunctionOfAnonymousStructsToExplicit) processDisjunction(visitor 
 func (pass *DisjunctionOfAnonymousStructsToExplicit) generateBranchName(branch ast.Type, index int) string {
 	for _, field := range branch.Struct.Fields {
 		if field.Type.IsConcreteScalar() {
-			val := fmt.Sprintf("%v", field.Type.Scalar.Value)
+			val := fmt.Sprintf("%v", field.Type.Value)
 			return fmt.Sprintf("%s%s", tools.UpperCamelCase(field.Name), tools.UpperCamelCase(val))
 		}
 	}

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -271,7 +271,7 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 				defaultValue = jenny.maybeValueAsPointer(defaultValue, field.Type.Nullable, resolvedFieldType)
 			}
 		} else if field.Type.IsConcreteScalar() {
-			defaultValue = formatScalar(field.Type.Scalar.Value)
+			defaultValue = formatScalar(field.Type.Value)
 
 			defaultValue = jenny.maybeValueAsPointer(defaultValue, field.Type.Nullable, resolvedFieldType)
 		} else if resolvedFieldType.IsAnyOf(ast.KindScalar, ast.KindMap, ast.KindArray) && field.Type.Default != nil {

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -51,12 +51,10 @@ func (formatter *typeFormatter) formatTypeDeclaration(def ast.Object) string {
 	case ast.KindEnum:
 		buffer.WriteString(formatter.formatEnumDef(def))
 	case ast.KindScalar:
-		scalarType := def.Type.AsScalar()
-
 		//nolint: gocritic
-		if scalarType.Value != nil {
-			buffer.WriteString(fmt.Sprintf("const %s = %s", defName, formatScalar(scalarType.Value)))
-		} else if scalarType.ScalarKind == ast.KindBytes {
+		if def.Type.Value != nil {
+			buffer.WriteString(fmt.Sprintf("const %s = %s", defName, formatScalar(def.Type.Value)))
+		} else if def.Type.Scalar.ScalarKind == ast.KindBytes {
 			buffer.WriteString(fmt.Sprintf("type %s %s", defName, "[]byte"))
 		} else {
 			buffer.WriteString(fmt.Sprintf("type %s %s", defName, formatter.formatType(def.Type)))

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -61,7 +61,7 @@ func (jenny RawTypes) getTemplate() *template.Template {
 func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, error) {
 	var err error
 	files := make(codejen.Files, 0)
-	scalars := make(map[string]ast.ScalarType)
+	scalars := make(map[string]ast.Type)
 
 	packageMapper := func(pkg string, class string) string {
 		if jenny.imports.IsIdentical(pkg, schema.Package) {
@@ -78,10 +78,8 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 		if object.Type.IsMap() || object.Type.IsArray() {
 			return
 		}
-		if object.Type.IsScalar() {
-			if object.Type.AsScalar().IsConcrete() {
-				scalars[object.Name] = object.Type.AsScalar()
-			}
+		if object.Type.IsConcreteScalar() {
+			scalars[object.Name] = object.Type
 			return
 		}
 
@@ -193,12 +191,12 @@ func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Obj
 	})
 }
 
-func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarType) ([]byte, error) {
+func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.Type) ([]byte, error) {
 	constants := make([]Constant, 0)
 	for name, scalar := range scalars {
 		constants = append(constants, Constant{
 			Name:  name,
-			Type:  formatScalarType(scalar),
+			Type:  formatScalarType(scalar.AsScalar()),
 			Value: scalar.Value,
 		})
 	}

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -160,8 +160,8 @@ func (jenny Schema) formatScalar(typeDef ast.Type) Definition {
 	}
 
 	// constant value?
-	if typeDef.AsScalar().IsConcrete() {
-		definition.Set("const", typeDef.AsScalar().Value)
+	if typeDef.IsConcrete() {
+		definition.Set("const", typeDef.Value)
 	}
 
 	return definition

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -93,7 +93,7 @@ func (jenny RawTypes) generateConstants(schema *ast.Schema, objects *orderedmap.
 
 	objects.Iterate(func(_ string, object ast.Object) {
 		name := formatConstantName(object.Name)
-		value := formatValue(object.Type.Scalar.Value)
+		value := formatValue(object.Type.Value)
 
 		constant := fmt.Sprintf("const %s = %s;", name, value)
 		if len(object.Comments) != 0 {
@@ -280,7 +280,7 @@ func (jenny RawTypes) generateConstructor(context languages.Context, def ast.Obj
 
 		// initialize constant fields
 		if field.Type.IsConcreteScalar() {
-			assignments = append(assignments, fmt.Sprintf("    $this->%s = %s;\n", fieldName, formatValue(field.Type.AsScalar().Value)))
+			assignments = append(assignments, fmt.Sprintf("    $this->%s = %s;\n", fieldName, formatValue(field.Type.Value)))
 			continue
 		}
 

--- a/internal/jennies/php/tools.go
+++ b/internal/jennies/php/tools.go
@@ -232,19 +232,19 @@ func defaultValueForType(config Config, schemas ast.Schemas, typeDef ast.Type, d
 	case ast.KindMap, ast.KindArray:
 		return raw("[]")
 	case ast.KindScalar:
-		return defaultValueForScalar(typeDef.AsScalar())
+		return defaultValueForScalar(typeDef)
 	default:
 		return "unknown"
 	}
 }
 
-func defaultValueForScalar(scalar ast.ScalarType) any {
+func defaultValueForScalar(scalar ast.Type) any {
 	// The scalar represents a constant
 	if scalar.Value != nil {
 		return scalar.Value
 	}
 
-	switch scalar.ScalarKind {
+	switch scalar.Scalar.ScalarKind {
 	case ast.KindNull, ast.KindAny:
 		return nil
 

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -166,7 +166,7 @@ func (jenny RawTypes) generateInitMethod(schemas ast.Schemas, object ast.Object)
 		}
 
 		if field.Type.IsConcreteScalar() {
-			assignments = append(assignments, fmt.Sprintf("        self.%s = %s", fieldName, formatValue(field.Type.AsScalar().Value)))
+			assignments = append(assignments, fmt.Sprintf("        self.%s = %s", fieldName, formatValue(field.Type.Value)))
 			continue
 		} else if field.Type.IsAnyOf(ast.KindStruct, ast.KindRef, ast.KindEnum, ast.KindMap, ast.KindArray) {
 			if !field.Type.Nullable {

--- a/internal/jennies/python/tools.go
+++ b/internal/jennies/python/tools.go
@@ -201,19 +201,19 @@ func defaultValueForType(schemas ast.Schemas, typeDef ast.Type, importModule mod
 	case ast.KindArray:
 		return raw("[]")
 	case ast.KindScalar:
-		return defaultValueForScalar(typeDef.AsScalar())
+		return defaultValueForScalar(typeDef)
 	default:
 		return "unknown"
 	}
 }
 
-func defaultValueForScalar(scalar ast.ScalarType) any {
+func defaultValueForScalar(scalarDef ast.Type) any {
 	// The scalar represents a constant
-	if scalar.Value != nil {
-		return scalar.Value
+	if scalarDef.Value != nil {
+		return scalarDef.Value
 	}
 
-	switch scalar.ScalarKind {
+	switch scalarDef.Scalar.ScalarKind {
 	case ast.KindNull, ast.KindAny:
 		return nil
 

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -47,7 +47,7 @@ func (formatter *typeFormatter) formatObject(object ast.Object) (string, error) 
 	}
 
 	if object.Type.IsConcreteScalar() {
-		buffer.WriteString(fmt.Sprintf("%s: %s = %s", defName, formatter.formatType(object.Type), formatValue(object.Type.AsScalar().Value)))
+		buffer.WriteString(fmt.Sprintf("%s: %s = %s", defName, formatter.formatType(object.Type), formatValue(object.Type.Value)))
 
 		return buffer.String(), nil
 	}
@@ -85,9 +85,9 @@ func (formatter *typeFormatter) formatType(def ast.Type) string {
 
 	if def.IsScalar() {
 		// This scalar actually refers to a constant
-		if def.AsScalar().IsConcrete() {
+		if def.IsConcrete() {
 			typingPkg := formatter.importPkg("typing", "typing")
-			result = fmt.Sprintf("%s.Literal[%s]", typingPkg, formatValue(def.AsScalar().Value))
+			result = fmt.Sprintf("%s.Literal[%s]", typingPkg, formatValue(def.Value))
 		} else {
 			result = formatter.formatScalarKind(def.AsScalar().ScalarKind)
 		}

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -93,7 +93,7 @@ func (jenny RawTypes) formatObject(def ast.Object, packageMapper packageMapper) 
 	objectName := tools.CleanupNames(def.Name)
 
 	// generate a "default value factory" for every object, except for constants or composability slots
-	if (!def.Type.IsScalar() && !def.Type.IsComposableSlot()) || (def.Type.IsScalar() && !def.Type.AsScalar().IsConcrete()) {
+	if (!def.Type.IsScalar() && !def.Type.IsComposableSlot()) || (def.Type.IsScalar() && !def.Type.IsConcrete()) {
 		buffer.WriteString("\n")
 
 		buffer.WriteString(fmt.Sprintf("export const default%[1]s = (): %[2]s => (", tools.UpperCamelCase(objectName), objectName))
@@ -161,7 +161,7 @@ func (jenny RawTypes) defaultValueForType(typeDef ast.Type, packageMapper packag
 	case ast.KindArray:
 		return raw("[]")
 	case ast.KindScalar:
-		return defaultValueForScalar(typeDef.AsScalar())
+		return defaultValueForScalar(typeDef)
 	case ast.KindIntersection:
 		return jenny.defaultValuesForIntersection(typeDef.AsIntersection(), packageMapper)
 	default:
@@ -203,13 +203,13 @@ func (jenny RawTypes) defaultValuesForStructType(structType ast.Type, packageMap
 	return defaults
 }
 
-func defaultValueForScalar(scalar ast.ScalarType) any {
+func defaultValueForScalar(scalar ast.Type) any {
 	// The scalar represents a constant
 	if scalar.Value != nil {
 		return scalar.Value
 	}
 
-	switch scalar.ScalarKind {
+	switch scalar.Scalar.ScalarKind {
 	case ast.KindNull:
 		return raw("null")
 	case ast.KindAny:
@@ -318,7 +318,7 @@ func (jenny RawTypes) defaultValueForStructs(def ast.StructType, m *orderedmap.M
 			case ast.KindArray:
 				buffer.WriteString(fmt.Sprintf("%s: []", f.Name))
 			case ast.KindScalar:
-				buffer.WriteString(fmt.Sprintf("%s: %v, ", f.Name, defaultValueForScalar(f.Type.AsScalar())))
+				buffer.WriteString(fmt.Sprintf("%s: %v, ", f.Name, defaultValueForScalar(f.Type)))
 			}
 		}
 	}
@@ -336,7 +336,7 @@ func defaultEmptyValuesForStructs(def ast.StructType) string {
 		case ast.KindArray:
 			buffer.WriteString(fmt.Sprintf("%s: []", f.Name))
 		case ast.KindScalar:
-			buffer.WriteString(fmt.Sprintf("%s: %v, ", f.Name, defaultValueForScalar(f.Type.AsScalar())))
+			buffer.WriteString(fmt.Sprintf("%s: %v, ", f.Name, defaultValueForScalar(f.Type)))
 		default:
 		}
 	}

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -65,10 +65,10 @@ func (formatter *typeFormatter) formatTypeDeclaration(def ast.Object) string {
 		buffer.WriteString(fmt.Sprintf("type %s = %s;\n", objectName, formatter.formatType(def.Type)))
 	case ast.KindScalar:
 		scalarType := def.Type.AsScalar()
-		typeValue := formatValue(scalarType.Value)
+		typeValue := formatValue(def.Type.Value)
 
-		if !scalarType.IsConcrete() || def.Type.Hints["kind"] == "type" {
-			if !scalarType.IsConcrete() {
+		if !def.Type.IsConcrete() || def.Type.Hints["kind"] == "type" {
+			if !def.Type.IsConcrete() {
 				typeValue = formatter.formatScalarKind(scalarType.ScalarKind)
 			}
 
@@ -132,8 +132,8 @@ func (formatter *typeFormatter) doFormatType(def ast.Type, resolveBuilders bool)
 		return formatter.formatAnonymousEnum(def.AsEnum())
 	case ast.KindScalar:
 		// This scalar actually refers to a constant
-		if def.AsScalar().Value != nil {
-			return formatValue(def.AsScalar().Value)
+		if def.Value != nil {
+			return formatValue(def.Value)
 		}
 
 		return formatter.formatScalarKind(def.AsScalar().ScalarKind)

--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -296,7 +296,7 @@ func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 	def := ast.String(ast.Default(schema.Default))
 
 	if schema.Constant != nil {
-		def.Scalar.Value = schema.Constant[0]
+		def.Value = schema.Constant[0]
 	}
 
 	// to handle constant values defined as a string with a "static" regex:
@@ -307,7 +307,7 @@ func (g *generator) walkString(schema *schemaparser.Schema) (ast.Type, error) {
 	// }
 	// ```
 	if schema.Pattern != nil && tools.RegexMatchesConstantString(schema.Pattern.String()) {
-		def.Scalar.Value = tools.ConstantStringFromRegex(schema.Pattern.String())
+		def.Value = tools.ConstantStringFromRegex(schema.Pattern.String())
 	}
 
 	if schema.Format == formatDateTime {
@@ -334,7 +334,7 @@ func (g *generator) walkBool(schema *schemaparser.Schema) (ast.Type, error) {
 	def := ast.Bool(ast.Default(schema.Default))
 
 	if schema.Constant != nil {
-		def.Scalar.Value = schema.Constant[0]
+		def.Value = schema.Constant[0]
 	}
 
 	return def, nil
@@ -349,7 +349,7 @@ func (g *generator) walkNumber(schema *schemaparser.Schema) (ast.Type, error) {
 	def := ast.NewScalar(scalarKind, ast.Default(schema.Default))
 
 	if schema.Constant != nil {
-		def.Scalar.Value = unwrapJSONNumber(schema.Constant[0])
+		def.Value = unwrapJSONNumber(schema.Constant[0])
 	}
 
 	if schema.Minimum != nil {

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -184,7 +184,7 @@ func (g *generator) walkString(schema *openapi3.Schema) (ast.Type, error) {
 	}
 
 	if schema.Pattern != "" && tools.RegexMatchesConstantString(schema.Pattern) {
-		t.Scalar.Value = tools.ConstantStringFromRegex(schema.Pattern)
+		t.Value = tools.ConstantStringFromRegex(schema.Pattern)
 	}
 
 	t.Scalar.Constraints = getConstraints(schema)

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -742,7 +742,7 @@ func (g *generator) declareNumber(v cue.Value, defVal any, hints ast.JenniesHint
 			return typeDef, err
 		}
 
-		typeDef.Scalar.Value = val
+		typeDef.Value = val
 	}
 
 	// If the default (all lists have a default, usually self, ugh) differs from the

--- a/internal/veneers/option/actions.go
+++ b/internal/veneers/option/actions.go
@@ -284,7 +284,7 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 			}
 
 			// if the field has a value, it's a constant and we don't need to add it as an argument
-			isConstant := field.Type.IsConcreteScalar()
+			isConstant := field.Type.IsConcrete()
 			if !isConstant {
 				newOpt.Args = append(newOpt.Args, newArg)
 			}
@@ -294,7 +294,7 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 				if isConstant {
 					newAssignment = ast.ConstantAssignment(
 						assignmentPathPrefix.Append(ast.PathFromStructField(field)),
-						field.Type.AsScalar().Value,
+						field.Type.Value,
 					)
 				} else {
 					newAssignment = ast.ArgumentAssignment(
@@ -309,7 +309,7 @@ func StructFieldsAsArgumentsAction(explicitFields ...string) RewriteAction {
 			} else {
 				var assignmentValue ast.AssignmentValue
 				if isConstant {
-					assignmentValue = ast.AssignmentValue{Constant: field.Type.AsScalar().Value}
+					assignmentValue = ast.AssignmentValue{Constant: field.Type.Value}
 				} else {
 					assignmentValue = ast.AssignmentValue{Argument: &newArg}
 				}

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -112,9 +112,6 @@
           "type": "string",
           "description": "bool, bytes, string, int, float, ..."
         },
-        "value": {
-          "description": "if value isn't nil, we're representing a constant scalar"
-        },
         "constraints": {
           "items": {
             "$ref": "#/$defs/AstTypeConstraint"
@@ -171,6 +168,9 @@
         },
         "nullable": {
           "type": "boolean"
+        },
+        "value": {
+          "description": "meaning: concrete value"
         },
         "default": true,
         "disjunction": {

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -124,9 +124,6 @@
           "type": "string",
           "description": "bool, bytes, string, int, float, ..."
         },
-        "value": {
-          "description": "if value isn't nil, we're representing a constant scalar"
-        },
         "constraints": {
           "items": {
             "$ref": "#/$defs/AstTypeConstraint"
@@ -183,6 +180,9 @@
         },
         "nullable": {
           "type": "boolean"
+        },
+        "value": {
+          "description": "meaning: concrete value"
         },
         "default": true,
         "disjunction": {


### PR DESCRIPTION
This is the first step towards a better representation of "concrete" (ie: constant) values.

Jennies need to be adjusted to properly handle these values that can now be defined for any type, not just scalars anymore → will be done in subsequent PRs.