### PR TITLE
Support inspecting the "converters" IR

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -16,7 +16,7 @@ import (
 )
 
 type options struct {
-	BuilderIR       bool
+	IRType          string
 	ConfigPath      string
 	ExtraParameters map[string]string
 	Selector        string
@@ -37,12 +37,18 @@ Language-specific transformations are NOT applied until a language is specified 
 Common builder transformations are applied.
 Language-specific builder transformations are NOT applied until a language is specified with the --language flag.
 `,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if opts.IRType != "types" && opts.IRType != "builders" && opts.IRType != "converters" {
+				return fmt.Errorf("invalid IR type '%s'. Valid values: types, builders, converters", opts.IRType)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return doInspect(opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.BuilderIR, "builders", false, "Inspect the intermediate representation of builders instead of schemas.")
+	cmd.Flags().StringVar(&opts.IRType, "ir", "types", "Type of intermediate representation to Inspect. Valid values: types, builders, converters.")
 	cmd.Flags().StringToStringVar(&opts.ExtraParameters, "parameters", nil, "Sets or overrides parameters used in the config file.")
 	cmd.Flags().StringVar(&opts.Selector, "selector", "", "Selector allowing to narrow down the result of the inspection to selected objects. Format: package.[object] for types, package.[builder].[option] for builders.")
 	cmd.Flags().StringVar(&opts.Language, "language", "", "Language to use when applying language-specific schema and builder transformations. If left empty, only common transformations are applied.")
@@ -60,7 +66,7 @@ func doInspect(opts options) error {
 		return err
 	}
 
-	// Load schemas
+	// Create a codegen context
 	schemas, err := pipeline.LoadSchemas(context.Background())
 	if err != nil {
 		return err
@@ -75,16 +81,17 @@ func doInspect(opts options) error {
 	if err != nil {
 		return err
 	}
-	if opts.BuilderIR {
-		return inspectBuilderIR(codegenCtx, opts.Selector)
+
+	// Inspect the desired IR
+	if opts.IRType == "types" {
+		return inspectTypesIR(codegenCtx, opts.Selector)
 	}
 
-	selectedResult, err := applyTypesIRSelector(codegenCtx, opts.Selector)
-	if err != nil {
-		return err
+	if opts.IRType == "builders" {
+		return inspectBuildersIR(codegenCtx, opts.Selector)
 	}
 
-	return prettyPrintJSON(selectedResult)
+	return inspectConvertersIR(codegenCtx, language, opts.Selector)
 }
 
 func inspectedLanguage(pipeline *codegen.Pipeline, opts options) (languages.Language, error) {
@@ -99,13 +106,22 @@ func inspectedLanguage(pipeline *codegen.Pipeline, opts options) (languages.Lang
 
 	language := languagesMap[opts.Language]
 	if language == nil {
-		return nil, fmt.Errorf("language \"%s\" is not supported", opts.Language)
+		return nil, fmt.Errorf("language \"%s\" is not supported. Valid languages are: %s", opts.Language, strings.Join(tools.Keys(languagesMap), ", "))
 	}
 
 	return language, nil
 }
 
-func inspectBuilderIR(codegenCtx languages.Context, selector string) error {
+func inspectTypesIR(codegenCtx languages.Context, selector string) error {
+	selectedResult, err := applyTypesIRSelector(codegenCtx, selector)
+	if err != nil {
+		return err
+	}
+
+	return prettyPrintJSON(selectedResult)
+}
+
+func inspectBuildersIR(codegenCtx languages.Context, selector string) error {
 	selectedResult, err := applyBuilderIRSelector(codegenCtx, selector)
 	if err != nil {
 		return err
@@ -114,15 +130,28 @@ func inspectBuilderIR(codegenCtx languages.Context, selector string) error {
 	return prettyPrintJSON(selectedResult)
 }
 
-func prettyPrintJSON(input any) error {
-	marshaled, err := json.MarshalIndent(input, "", "  ")
-	if err != nil {
-		return err
+func inspectConvertersIR(codegenCtx languages.Context, language languages.Language, selector string) error {
+	selectorParts := strings.Split(selector, ".")
+	if len(selectorParts) != 2 {
+		return fmt.Errorf("inspecting the converters IR requires a builder selector: [package].[builder]")
 	}
 
-	fmt.Println(string(marshaled))
+	// select builders within a package
+	builders := tools.Filter(codegenCtx.Builders, func(b ast.Builder) bool {
+		return strings.EqualFold(b.Package, selectorParts[0]) && strings.EqualFold(b.Name, selectorParts[1])
+	})
+	if len(builders) == 0 {
+		return fmt.Errorf("builder '%s' not found", selector)
+	}
 
-	return nil
+	nullableConfig, ok := language.(languages.NullableKindsProvider)
+	if !ok {
+		return fmt.Errorf("language '%s' does not appear to support converters", language.Name())
+	}
+
+	converter := languages.NewConverterGenerator(nullableConfig.NullableKinds()).FromBuilder(codegenCtx, builders[0])
+
+	return prettyPrintJSON(converter)
 }
 
 func applyTypesIRSelector(codegenCtx languages.Context, selector string) (any, error) {
@@ -198,6 +227,17 @@ func applyBuilderIRSelector(context languages.Context, selector string) (any, er
 	}
 
 	return opts[0], nil
+}
+
+func prettyPrintJSON(input any) error {
+	marshaled, err := json.MarshalIndent(input, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(marshaled))
+
+	return nil
 }
 
 type dummyLanguage struct {


### PR DESCRIPTION
This PR extends the `cog inspect` command to support inspecting "converters" intermediate representations.