### PR TITLE
Better detection of "out-of-root" types in CUE

### DIFF
--- a/testdata/simplecue/refs/GenerateAST/ir.json
+++ b/testdata/simplecue/refs/GenerateAST/ir.json
@@ -59,32 +59,6 @@
         "ReferredType": "IntEnum"
       }
     },
-    "SomeInlineDefinition": {
-      "Name": "SomeInlineDefinition",
-      "Type": {
-        "Kind": "struct",
-        "Nullable": false,
-        "Struct": {
-          "Fields": [
-            {
-              "Name": "field",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": true
-            }
-          ]
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "grafanatest",
-        "ReferredType": "SomeInlineDefinition"
-      }
-    },
     "container": {
       "Name": "container",
       "Type": {
@@ -168,6 +142,32 @@
       "SelfRef": {
         "ReferredPkg": "grafanatest",
         "ReferredType": "container"
+      }
+    },
+    "SomeInlineDefinition": {
+      "Name": "SomeInlineDefinition",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "field",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "SomeInlineDefinition"
       }
     }
   }


### PR DESCRIPTION
Relates to grafana/grafana#99966

One issue highlighted by the PR above comes from cog not being always able to discover objects within a schema (especially objects defined outside of the cue value given as input to cog).

To fix that, the CUE parser now follows references and parses the objects they point to.