### PR TITLE
Final compiler passes should be applied after language-specific passes

### DIFF
--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -221,7 +221,7 @@ func (pipeline *Pipeline) LoadSchemas(ctx context.Context) (ast.Schemas, error) 
 		return nil, err
 	}
 
-	return commonPasses.Concat(pipeline.finalPasses()).Process(allSchemas)
+	return commonPasses.Process(allSchemas)
 }
 
 func (pipeline *Pipeline) OutputLanguages() (languages.Languages, error) {

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -72,7 +72,8 @@ func (pipeline *Pipeline) ContextForLanguage(language languages.Language, schema
 	}
 
 	// apply  language-specific compiler passes
-	jenniesInput.Schemas, err = language.CompilerPasses().Process(jenniesInput.Schemas)
+	compilerPasses := language.CompilerPasses().Concat(pipeline.finalPasses())
+	jenniesInput.Schemas, err = compilerPasses.Process(jenniesInput.Schemas)
 	if err != nil {
 		return languages.Context{}, err
 	}


### PR DESCRIPTION
Otherwise they're not really final, are they?