### PR TITLE
Fix some disjunctions bugs in Python

### DIFF
--- a/internal/ast/compiler/flatten_disjunctions.go
+++ b/internal/ast/compiler/flatten_disjunctions.go
@@ -79,6 +79,10 @@ func (pass *FlattenDisjunctions) flattenDisjunction(schema *ast.Schema, disjunct
 			typeName = fmt.Sprintf("branch_%d", i)
 		}
 
+		if branch.IsConcreteScalar() {
+			typeName = fmt.Sprintf("concrete_%s_%v", typeName, branch.Scalar.Value)
+		}
+
 		if !branch.IsRef() {
 			addBranch(typeName, branch)
 			continue

--- a/internal/ast/compiler/flatten_disjunctions_test.go
+++ b/internal/ast/compiler/flatten_disjunctions_test.go
@@ -51,6 +51,20 @@ func TestFlattenDisjunctions_WithNestedDisjunctionOfRefs_AsAnObject(t *testing.T
 	runPassOnObjects(t, &FlattenDisjunctions{}, objects, expectedObjects)
 }
 
+func TestFlattenDisjunctions_WithDisjunctionOfStringAndConstants(t *testing.T) {
+	// Prepare test input
+	objects := []ast.Object{
+		ast.NewObject("test", "ADisjunction", ast.NewDisjunction([]ast.Type{
+			ast.String(),
+			ast.String(ast.Value("*")),
+			ast.String(ast.Value("none")),
+		})),
+	}
+
+	// Call the compiler pass
+	runPassOnObjects(t, &FlattenDisjunctions{}, objects, objects)
+}
+
 func TestFlattenDisjunctions_WithDisjunctionsOfAnonymousStructs(t *testing.T) {
 	// Prepare test input
 	objects := []ast.Object{

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -171,7 +171,7 @@ func (jenny RawTypes) generateInitMethod(schemas ast.Schemas, object ast.Object)
 		if field.Type.IsConcreteScalar() {
 			assignments = append(assignments, fmt.Sprintf("        self.%s = %s", fieldName, formatValue(field.Type.AsScalar().Value)))
 			continue
-		} else if field.Type.IsAnyOf(ast.KindStruct, ast.KindRef, ast.KindEnum, ast.KindMap, ast.KindArray) {
+		} else if field.Type.IsAnyOf(ast.KindStruct, ast.KindRef, ast.KindEnum, ast.KindMap, ast.KindArray, ast.KindDisjunction) {
 			if !field.Type.Nullable {
 				typingPkg := jenny.importPkg("typing", "typing")
 				fieldType = fmt.Sprintf("%s.Optional[%s]", typingPkg, fieldType)

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PythonRawTypes/models/struct_complex_fields.py
@@ -16,10 +16,10 @@ class SomeStruct:
     field_anonymous_struct: 'StructComplexFieldsSomeStructFieldAnonymousStruct'
     field_ref_to_constant: typing.Literal["straight"]
 
-    def __init__(self, field_ref: typing.Optional['SomeOtherStruct'] = None, field_disjunction_of_scalars: typing.Union[str, bool] = "", field_mixed_disjunction: typing.Union[str, 'SomeOtherStruct'] = "", field_disjunction_with_null: typing.Optional[str] = None, operator: typing.Optional[typing.Literal[">", "<"]] = None, field_array_of_strings: typing.Optional[list[str]] = None, field_map_of_string_to_string: typing.Optional[dict[str, str]] = None, field_anonymous_struct: typing.Optional['StructComplexFieldsSomeStructFieldAnonymousStruct'] = None, field_ref_to_constant: typing.Optional[typing.Literal["straight"]] = None):
+    def __init__(self, field_ref: typing.Optional['SomeOtherStruct'] = None, field_disjunction_of_scalars: typing.Optional[typing.Union[str, bool]] = None, field_mixed_disjunction: typing.Optional[typing.Union[str, 'SomeOtherStruct']] = None, field_disjunction_with_null: typing.Optional[str] = None, operator: typing.Optional[typing.Literal[">", "<"]] = None, field_array_of_strings: typing.Optional[list[str]] = None, field_map_of_string_to_string: typing.Optional[dict[str, str]] = None, field_anonymous_struct: typing.Optional['StructComplexFieldsSomeStructFieldAnonymousStruct'] = None, field_ref_to_constant: typing.Optional[typing.Literal["straight"]] = None):
         self.field_ref = field_ref if field_ref is not None else SomeOtherStruct()
-        self.field_disjunction_of_scalars = field_disjunction_of_scalars
-        self.field_mixed_disjunction = field_mixed_disjunction
+        self.field_disjunction_of_scalars = field_disjunction_of_scalars if field_disjunction_of_scalars is not None else ""
+        self.field_mixed_disjunction = field_mixed_disjunction if field_mixed_disjunction is not None else ""
         self.field_disjunction_with_null = field_disjunction_with_null
         self.operator = operator if operator is not None else ">"
         self.field_array_of_strings = field_array_of_strings if field_array_of_strings is not None else []


### PR DESCRIPTION
This PR addresses two issues related to disjunctions in Python:
* the code generated for disjunction parameters in constructors was incorrect
* the "flatten disjunctions" compiler pass incorrectly flattened disjunction of strings + constants