### PR TITLE
Select builders to "merge into" by name instead of object

### DIFF
--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -140,6 +140,16 @@ func (builders Builders) LocateByObject(pkg string, name string) (Builder, bool)
 	return Builder{}, false
 }
 
+func (builders Builders) LocateByName(pkg string, name string) (Builder, bool) {
+	for _, builder := range builders {
+		if builder.For.SelfRef.ReferredPkg == pkg && builder.Name == name {
+			return builder, true
+		}
+	}
+
+	return Builder{}, false
+}
+
 func (builders Builders) ByPackage(pkg string) Builders {
 	return tools.Filter(builders, func(builder Builder) bool {
 		return builder.Package == pkg

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -91,7 +91,7 @@ func Omit(selector Selector) RewriteRule {
 
 func MergeInto(selector Selector, sourceBuilderName string, underPath string, excludeOptions []string, renameOptions map[string]string) RewriteRule {
 	return mapToSelected(selector, func(builders ast.Builders, destinationBuilder ast.Builder) (ast.Builder, error) {
-		sourceBuilder, found := builders.LocateByObject(destinationBuilder.For.SelfRef.ReferredPkg, sourceBuilderName)
+		sourceBuilder, found := builders.LocateByName(destinationBuilder.For.SelfRef.ReferredPkg, sourceBuilderName)
 		if !found {
 			// We couldn't find the source builder: let's return the selected builder untouched.
 			return destinationBuilder, nil

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -100,7 +100,7 @@ type MergeInto struct {
 
 func (rule MergeInto) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	return builder.MergeInto(
-		builder.ByObjectName(pkg, rule.Destination),
+		builder.ByName(pkg, rule.Destination),
 		rule.Source,
 		rule.UnderPath,
 		rule.ExcludeOptions,

--- a/internal/yaml/option.go
+++ b/internal/yaml/option.go
@@ -287,12 +287,17 @@ func (selector OptionSelector) AsSelector(pkg string) (option.Selector, error) {
 
 type ByNamesSelector struct {
 	Object  string   `yaml:"object"`
+	Builder string   `yaml:"builder"`
 	Options []string `yaml:"options"`
 }
 
 func (selector ByNamesSelector) AsSelector(pkg string) (option.Selector, error) {
-	if selector.Object == "" {
-		return nil, fmt.Errorf("`object` is required")
+	if selector.Object == "" && selector.Builder == "" {
+		return nil, fmt.Errorf("`object` or `builder` is required")
+	}
+
+	if selector.Builder != "" {
+		return option.ByBuilder(pkg, selector.Builder, selector.Options...), nil
 	}
 
 	return option.ByName(pkg, selector.Object, selector.Options...), nil


### PR DESCRIPTION
It is more intuitive to refer to builders by their name, instead of the name of the object they're building.

Moreover, this will allow us to use the "merge into" veneer on more builders