### PR TITLE
Better error reporting in veneer yaml loading

### DIFF
--- a/internal/yaml/veneers_test.go
+++ b/internal/yaml/veneers_test.go
@@ -60,7 +60,7 @@ options:
 		t.Run(tc.desc, func(t *testing.T) {
 			req := require.New(t)
 
-			rules, err := NewVeneersLoader().Load(strings.NewReader(tc.input))
+			rules, err := NewVeneersLoader().load(strings.NewReader(tc.input))
 			req.NoError(err)
 
 			tc.check(req, rules)
@@ -74,7 +74,7 @@ func TestLoader_Load_withNoPackage(t *testing.T) {
 builders: ~
 options: ~`
 
-	_, err := NewVeneersLoader().Load(strings.NewReader(input))
+	_, err := NewVeneersLoader().load(strings.NewReader(input))
 	req.Error(err)
 	req.ErrorContains(err, "missing 'package'")
 }


### PR DESCRIPTION
When veneers can't be loaded, the error message should contain the file that caused the error.