### PR TITLE
Support defining custom methods on objects and builders

### DIFF
--- a/docs/reference/template_blocks.md
+++ b/docs/reference/template_blocks.md
@@ -15,6 +15,7 @@ For types, the following blocks are supported:
 
 * `object_{{ Package }}_{{ ObjectName }}_custom_unmarshal`: allows the definition of a custom unmarshal function for the object.
 * `object_{{ Package }}_{{ ObjectName }}_field_{{ FieldName}}_custom_strict_unmarshal`: allows the definition of a custom — strict — unmarshal logic for a field.
+* `object_{{ Package }}_{{ ObjectName }}_custom_methods`: allows the definition of custom methods on objects.
 * `variant_{{ VariantName }}_field_unmarshal`: defines how to unmarshal fields of the given variant.
 * `object_variant_{{ VariantName }}`: allows the definition of custom methods for all objects implementing the variant `{{ VariantName }}`.
 * `schema_variant_{{ VariantName }}`: allows the definition of custom code for all schemas implementing the variant `{{ VariantName }}`.
@@ -23,6 +24,7 @@ For builders, the following blocks are supported:
 
 * `pre_assignment_{{ BuilderName }}_{{ OptionName }}`: will be rendered within an option, before the assignment.
 * `post_assignment_{{ BuilderName }}_{{ OptionName }}`: will be rendered within an option, after the assignment.
+* `builder_{{ Package }}_{{ BuilderName }}_custom_methods`: allows the definition of custom methods on builders.
 
 For API reference documentation, the following blocks are supported:
 

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -29,6 +29,8 @@ func (jenny RawTypes) JennyName() string {
 func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
+	jenny.Tmpl = jenny.Tmpl.Funcs(common.TypeResolvingTemplateHelpers(context))
+
 	for _, schema := range context.Schemas {
 		output, err := jenny.generateSchema(context, schema)
 		if err != nil {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -104,6 +104,18 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 				return
 			}
 		}
+
+		customMethodsBlock := template.CustomObjectMethodsBlock(object)
+		if jenny.Tmpl.Exists(customMethodsBlock) {
+			innerErr = jenny.Tmpl.RenderInBuffer(&buffer, customMethodsBlock, map[string]any{
+				"Object": object,
+			})
+			if innerErr != nil {
+				err = innerErr
+				return
+			}
+			buffer.WriteString("\n")
+		}
 	})
 	if err != nil {
 		return nil, err

--- a/internal/jennies/golang/templates/builders/builder.tmpl
+++ b/internal/jennies/golang/templates/builders/builder.tmpl
@@ -36,4 +36,8 @@ func (builder *{{ .BuilderName }}Builder) Build() ({{ .BuilderSignatureType }}, 
 
 	return *builder.internal, nil
 }
+
+{{- $customMethodsTmpl := print "builder_" .Package "_" .BuilderName "_custom_methods" }}
+{{- includeIfExists $customMethodsTmpl (dict) -}}
+
 {{- $options }}

--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -55,6 +55,7 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 	object, _ := context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
 	tmpl := BuilderTemplate{
 		Package:              jenny.config.formatPackage(builder.Package),
+		RawPackage:           builder.Package,
 		Imports:              jenny.imports,
 		ObjectName:           tools.UpperCamelCase(object.Name),
 		BuilderName:          tools.UpperCamelCase(builder.Name),

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -177,6 +177,7 @@ func (jenny RawTypes) formatEnum(pkg string, object ast.Object) ([]byte, error) 
 func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Object) ([]byte, error) {
 	return jenny.getTemplate().RenderAsBytes("types/class.tmpl", ClassTemplate{
 		Package:                 jenny.config.formatPackage(pkg),
+		RawPackage:              pkg,
 		Imports:                 jenny.imports,
 		Name:                    tools.UpperCamelCase(object.Name),
 		Fields:                  object.Type.AsStruct().Fields,

--- a/internal/jennies/java/templates/builders/builder.tmpl
+++ b/internal/jennies/java/templates/builders/builder.tmpl
@@ -37,5 +37,7 @@ public class {{ .BuilderName }}Builder{{ if .IsGenericPanel }}<T extends {{ .Bui
     public {{ .ObjectName }} build() {
         return this.internal;
     }
+{{- $customMethodsTmpl := print "builder_" .RawPackage "_" .BuilderName "_custom_methods" }}
+{{- includeIfExists $customMethodsTmpl (dict)|indent 4 }}
 }
 {{- end }}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -51,6 +51,9 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- if and (ne .ToJSONFunction "") (not .Extends) }}
     {{ .ToJSONFunction }}
     {{- end }}
+
+{{- $customMethodsTmpl := print "object_" .RawPackage "_" .Name "_custom_methods" }}
+{{- includeIfExists $customMethodsTmpl (dict)|indent 4 }}
 }
 {{- end }}
 

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -156,6 +156,7 @@ type Constant struct {
 
 type BuilderTemplate struct {
 	Package              string
+	RawPackage           string
 	BuilderSignatureType string
 	BuilderName          string
 	ObjectName           string

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -120,11 +120,12 @@ type EnumValue struct {
 }
 
 type ClassTemplate struct {
-	Package  string
-	Imports  fmt.Stringer
-	Name     string
-	Extends  []string
-	Comments []string
+	Package    string
+	RawPackage string
+	Imports    fmt.Stringer
+	Name       string
+	Extends    []string
+	Comments   []string
 
 	Fields     []ast.StructField
 	Builders   []BuilderTemplate

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -215,6 +215,19 @@ func (jenny RawTypes) formatStructDef(context languages.Context, schema *ast.Sch
 		}
 	}
 
+	customMethodsBlock := template.CustomObjectMethodsBlock(object)
+	if jenny.tmpl.Exists(customMethodsBlock) {
+		rendered, err := jenny.tmpl.Render(customMethodsBlock, map[string]any{
+			"Object": object,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		buffer.WriteString("\n\n")
+		buffer.WriteString(tools.Indent(rendered, 4))
+	}
+
 	buffer.WriteString("\n}")
 
 	return buffer.String(), nil

--- a/internal/jennies/php/templates/builders/builder.tmpl
+++ b/internal/jennies/php/templates/builders/builder.tmpl
@@ -29,8 +29,9 @@ class {{ .Builder.Name|formatObjectName }}Builder implements \{{ .NamespaceRoot 
     {
         return $this->internal;
     }
-
-{{ range .Builder.Options }}
-    {{- include "option" (dict "Builder" $.Builder "Option" .) | indent 4}}
+{{- $customMethodsTmpl := print "builder_" .Builder.Package "_" .Builder.Name "_custom_methods" }}
+{{ includeIfExists $customMethodsTmpl (dict) | indent 4 }}
+{{- range .Builder.Options }}
+{{ include "option" (dict "Builder" $.Builder "Option" .) | indent 4}}
 {{ end }}
 }

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -106,6 +106,20 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 			buffer.WriteString(fromJSON)
 		}
 
+		customMethodsBlock := template.CustomObjectMethodsBlock(object)
+		if jenny.tmpl.Exists(customMethodsBlock) {
+			buffer.WriteString("\n\n")
+			rendered, innerErr := jenny.tmpl.Render(customMethodsBlock, map[string]any{
+				"Object": object,
+			})
+			if innerErr != nil {
+				err = innerErr
+				return
+			}
+
+			buffer.WriteString(tools.Indent(rendered, 4))
+		}
+
 		customVariantTmpl := template.CustomObjectVariantBlock(object)
 		if object.Type.ImplementsVariant() && jenny.tmpl.Exists(customVariantTmpl) {
 			buffer.WriteString("\n\n\n")

--- a/internal/jennies/python/templates/builders/builder.tmpl
+++ b/internal/jennies/python/templates/builders/builder.tmpl
@@ -17,4 +17,7 @@ class {{ .BuilderName }}(cogbuilder.Builder[{{ .BuilderSignatureType }}]):
         """
         return self._internal
 
+{{- $customMethodsTmpl := print "builder_" .Package "_" .BuilderName "_custom_methods" }}
+{{- includeIfExists $customMethodsTmpl (dict)|indent 4 -}}
+
 {{- include "options" . | indent 4 -}}

--- a/internal/jennies/template/blocks.go
+++ b/internal/jennies/template/blocks.go
@@ -30,6 +30,10 @@ func CustomObjectVariantBlock(object ast.Object) string {
 	return fmt.Sprintf("object_variant_%s", object.Type.ImplementedVariant())
 }
 
+func CustomObjectMethodsBlock(obj ast.Object) string {
+	return fmt.Sprintf("object_%s_%s_custom_methods", obj.SelfRef.ReferredPkg, obj.SelfRef.ReferredType)
+}
+
 func CustomSchemaVariantBlock(schema *ast.Schema) string {
 	return fmt.Sprintf("schema_variant_%s", schema.Metadata.Variant)
 }

--- a/internal/jennies/typescript/builder.go
+++ b/internal/jennies/typescript/builder.go
@@ -98,6 +98,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 			},
 		}).
 		RenderAsBytes("builder.tmpl", map[string]any{
+			"BuilderPackage":       builder.Package,
 			"BuilderName":          builder.Name,
 			"ObjectName":           tools.CleanupNames(builder.For.Name),
 			"BuilderSignatureType": buildObjectSignature,

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -115,7 +115,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	jenny.AppendOneToMany(
 		common.If[languages.Context](!language.config.SkipRuntime, Runtime{config: language.config}),
 
-		common.If[languages.Context](globalConfig.Types, RawTypes{config: language.config}),
+		common.If[languages.Context](globalConfig.Types, RawTypes{config: language.config, tmpl: tmpl}),
 		common.If[languages.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{
 			config:          language.config,
 			tmpl:            tmpl,

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/tools"
@@ -15,6 +16,7 @@ type raw string
 
 type RawTypes struct {
 	config        Config
+	tmpl          *template.Template
 	typeFormatter *typeFormatter
 	schemas       ast.Schemas
 }
@@ -102,6 +104,17 @@ func (jenny RawTypes) formatObject(def ast.Object, packageMapper packageMapper) 
 		buffer.WriteString(formattedDefaults)
 
 		buffer.WriteString(");\n")
+	}
+
+	customMethodsBlock := template.CustomObjectMethodsBlock(def)
+	if jenny.tmpl.Exists(customMethodsBlock) {
+		err := jenny.tmpl.RenderInBuffer(&buffer, customMethodsBlock, map[string]any{
+			"Object": def,
+		})
+		if err != nil {
+			return nil, err
+		}
+		buffer.WriteString("\n")
 	}
 
 	return []byte(buffer.String()), nil

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -17,7 +17,10 @@ func TestRawTypes_Generate(t *testing.T) {
 
 	config := Config{}
 	config.applyDefaults()
-	jenny := RawTypes{config: config}
+	jenny := RawTypes{
+		tmpl:   initTemplates([]string{}),
+		config: config,
+	}
 	compilerPasses := New(config).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test[ast.Schema]) {

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -24,6 +24,10 @@ export class {{ .BuilderName|upperCamelCase }}Builder implements cog.Builder<{{ 
     build(): {{ .ImportAlias }}.{{ .ObjectName }} {
         return this.internal;
     }
+
+{{- $customMethodsTmpl := print "builder_" .BuilderPackage "_" .BuilderName "_custom_methods" }}
+{{- includeIfExists $customMethodsTmpl (dict) -}}
+
 {{- $options -}}
 }
 

--- a/internal/tools/strings.go
+++ b/internal/tools/strings.go
@@ -54,6 +54,10 @@ func CleanupNames(s string) string {
 }
 
 func Indent(input string, spaces int) string {
+	if input == "" {
+		return ""
+	}
+
 	pad := strings.Repeat(" ", spaces)
 	return pad + strings.ReplaceAll(input, "\n", "\n"+pad)
 }

--- a/testdata/jennies/builders/array_append/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/array_append/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     _internal: sandbox.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
         """
         return self._internal    
     
-    def tags(self, tags: str) -> typing.Self:        
+    def tags(self, tags: str) -> typing.Self:    
         if self._internal.tags is None:
             self._internal.tags = []
         

--- a/testdata/jennies/builders/basic_struct/PHPBuilder/src/BasicStruct/SomeStructBuilder.php
+++ b/testdata/jennies/builders/basic_struct/PHPBuilder/src/BasicStruct/SomeStructBuilder.php
@@ -33,12 +33,14 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function uid(string $uid): static
     {
         $this->internal->uid = $uid;
     
         return $this;
     }
+
     /**
      * @param array<string> $tags
      */
@@ -48,6 +50,7 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * This thing could be live.
      * Or maybe not.

--- a/testdata/jennies/builders/basic_struct/PythonBuilder/builders/basic_struct.py
+++ b/testdata/jennies/builders/basic_struct/PythonBuilder/builders/basic_struct.py
@@ -28,12 +28,12 @@ class SomeStruct(cogbuilder.Builder[basic_struct.SomeStruct]):
     
         return self
     
-    def uid(self, uid: str) -> typing.Self:        
+    def uid(self, uid: str) -> typing.Self:    
         self._internal.uid = uid
     
         return self
     
-    def tags(self, tags: list[str]) -> typing.Self:        
+    def tags(self, tags: list[str]) -> typing.Self:    
         self._internal.tags = tags
     
         return self

--- a/testdata/jennies/builders/basic_struct_defaults/PHPBuilder/src/BasicStructDefaults/SomeStructBuilder.php
+++ b/testdata/jennies/builders/basic_struct_defaults/PHPBuilder/src/BasicStructDefaults/SomeStructBuilder.php
@@ -29,12 +29,14 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function uid(string $uid): static
     {
         $this->internal->uid = $uid;
     
         return $this;
     }
+
     /**
      * @param array<string> $tags
      */
@@ -44,6 +46,7 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function liveNow(bool $liveNow): static
     {
         $this->internal->liveNow = $liveNow;

--- a/testdata/jennies/builders/basic_struct_defaults/PythonBuilder/builders/basic_struct_defaults.py
+++ b/testdata/jennies/builders/basic_struct_defaults/PythonBuilder/builders/basic_struct_defaults.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import basic_struct_defaults
 
 
-class SomeStruct(cogbuilder.Builder[basic_struct_defaults.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[basic_struct_defaults.SomeStruct]):
     _internal: basic_struct_defaults.SomeStruct
 
     def __init__(self):
@@ -15,22 +15,22 @@ class SomeStruct(cogbuilder.Builder[basic_struct_defaults.SomeStruct]):
         """
         return self._internal    
     
-    def id_val(self, id_val: int) -> typing.Self:        
+    def id_val(self, id_val: int) -> typing.Self:    
         self._internal.id_val = id_val
     
         return self
     
-    def uid(self, uid: str) -> typing.Self:        
+    def uid(self, uid: str) -> typing.Self:    
         self._internal.uid = uid
     
         return self
     
-    def tags(self, tags: list[str]) -> typing.Self:        
+    def tags(self, tags: list[str]) -> typing.Self:    
         self._internal.tags = tags
     
         return self
     
-    def live_now(self, live_now: bool) -> typing.Self:        
+    def live_now(self, live_now: bool) -> typing.Self:    
         self._internal.live_now = live_now
     
         return self

--- a/testdata/jennies/builders/builder_delegation/PHPBuilder/src/BuilderDelegation/DashboardBuilder.php
+++ b/testdata/jennies/builders/builder_delegation/PHPBuilder/src/BuilderDelegation/DashboardBuilder.php
@@ -29,12 +29,14 @@ class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function title(string $title): static
     {
         $this->internal->title = $title;
     
         return $this;
     }
+
     /**
      * will be expanded to []cog.Builder<DashboardLink>
      * @param array<\Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegation\DashboardLink>> $links
@@ -49,6 +51,7 @@ class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * will be expanded to [][]cog.Builder<DashboardLink>
      * @param array<array<\Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegation\DashboardLink>>> $linksOfLinks
@@ -68,6 +71,7 @@ class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * will be expanded to cog.Builder<DashboardLink>
      * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegation\DashboardLink> $singleLink

--- a/testdata/jennies/builders/builder_delegation/PHPBuilder/src/BuilderDelegation/DashboardLinkBuilder.php
+++ b/testdata/jennies/builders/builder_delegation/PHPBuilder/src/BuilderDelegation/DashboardLinkBuilder.php
@@ -29,6 +29,7 @@ class DashboardLinkBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function url(string $url): static
     {
         $this->internal->url = $url;

--- a/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
+++ b/testdata/jennies/builders/builder_delegation/PythonBuilder/builders/builder_delegation.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import builder_delegation
 
 
-class DashboardLink(cogbuilder.Builder[builder_delegation.DashboardLink]):    
+class DashboardLink(cogbuilder.Builder[builder_delegation.DashboardLink]):
     _internal: builder_delegation.DashboardLink
 
     def __init__(self):
@@ -15,18 +15,18 @@ class DashboardLink(cogbuilder.Builder[builder_delegation.DashboardLink]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self
     
-    def url(self, url: str) -> typing.Self:        
+    def url(self, url: str) -> typing.Self:    
         self._internal.url = url
     
         return self
     
 
-class Dashboard(cogbuilder.Builder[builder_delegation.Dashboard]):    
+class Dashboard(cogbuilder.Builder[builder_delegation.Dashboard]):
     _internal: builder_delegation.Dashboard
 
     def __init__(self):
@@ -38,12 +38,12 @@ class Dashboard(cogbuilder.Builder[builder_delegation.Dashboard]):
         """
         return self._internal    
     
-    def id_val(self, id_val: int) -> typing.Self:        
+    def id_val(self, id_val: int) -> typing.Self:    
         self._internal.id_val = id_val
     
         return self
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/PHPBuilder/src/BuilderDelegationInDisjunction/DashboardBuilder.php
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/PHPBuilder/src/BuilderDelegationInDisjunction/DashboardBuilder.php
@@ -35,6 +35,7 @@ class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * will be expanded to [](cog.Builder<DashboardLink> | string)
      * @param array<\Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegationInDisjunction\DashboardLink>|string> $linksOrStrings
@@ -49,6 +50,7 @@ class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegationInDisjunction\DashboardLink>|\Grafana\Foundation\Cog\Builder<\Grafana\Foundation\BuilderDelegationInDisjunction\ExternalLink> $disjunctionOfBuilders
      */

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/PHPBuilder/src/BuilderDelegationInDisjunction/DashboardLinkBuilder.php
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/PHPBuilder/src/BuilderDelegationInDisjunction/DashboardLinkBuilder.php
@@ -29,6 +29,7 @@ class DashboardLinkBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function url(string $url): static
     {
         $this->internal->url = $url;

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/PythonBuilder/builders/builder_delegation_in_disjunction.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import builder_delegation_in_disjunction
 
 
-class DashboardLink(cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink]):    
+class DashboardLink(cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink]):
     _internal: builder_delegation_in_disjunction.DashboardLink
 
     def __init__(self):
@@ -15,18 +15,18 @@ class DashboardLink(cogbuilder.Builder[builder_delegation_in_disjunction.Dashboa
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self
     
-    def url(self, url: str) -> typing.Self:        
+    def url(self, url: str) -> typing.Self:    
         self._internal.url = url
     
         return self
     
 
-class ExternalLink(cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]):    
+class ExternalLink(cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]):
     _internal: builder_delegation_in_disjunction.ExternalLink
 
     def __init__(self):
@@ -38,13 +38,13 @@ class ExternalLink(cogbuilder.Builder[builder_delegation_in_disjunction.External
         """
         return self._internal    
     
-    def url(self, url: str) -> typing.Self:        
+    def url(self, url: str) -> typing.Self:    
         self._internal.url = url
     
         return self
     
 
-class Dashboard(cogbuilder.Builder[builder_delegation_in_disjunction.Dashboard]):    
+class Dashboard(cogbuilder.Builder[builder_delegation_in_disjunction.Dashboard]):
     _internal: builder_delegation_in_disjunction.Dashboard
 
     def __init__(self):
@@ -77,7 +77,7 @@ class Dashboard(cogbuilder.Builder[builder_delegation_in_disjunction.Dashboard])
     
         return self
     
-    def disjunction_of_builders(self, disjunction_of_builders: typing.Union[cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink], cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]]) -> typing.Self:        
+    def disjunction_of_builders(self, disjunction_of_builders: typing.Union[cogbuilder.Builder[builder_delegation_in_disjunction.DashboardLink], cogbuilder.Builder[builder_delegation_in_disjunction.ExternalLink]]) -> typing.Self:    
         disjunction_of_builders_resource = disjunction_of_builders.build()
         self._internal.disjunction_of_builders = disjunction_of_builders_resource
     

--- a/testdata/jennies/builders/composable_slot/PHPBuilder/src/ComposableSlot/LokiBuilderBuilder.php
+++ b/testdata/jennies/builders/composable_slot/PHPBuilder/src/ComposableSlot/LokiBuilderBuilder.php
@@ -33,6 +33,7 @@ class LokiBuilderBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * @param array<\Grafana\Foundation\Cog\Builder<\Grafana\Foundation\Cog\Dataquery>> $targets
      */

--- a/testdata/jennies/builders/composable_slot/PythonBuilder/builders/composable_slot.py
+++ b/testdata/jennies/builders/composable_slot/PythonBuilder/builders/composable_slot.py
@@ -4,7 +4,7 @@ from ..models import composable_slot
 from ..cog import variants as cogvariants
 
 
-class LokiBuilder(cogbuilder.Builder[composable_slot.Dashboard]):    
+class LokiBuilder(cogbuilder.Builder[composable_slot.Dashboard]):
     _internal: composable_slot.Dashboard
 
     def __init__(self):
@@ -16,13 +16,13 @@ class LokiBuilder(cogbuilder.Builder[composable_slot.Dashboard]):
         """
         return self._internal    
     
-    def target(self, target: cogbuilder.Builder[cogvariants.Dataquery]) -> typing.Self:        
+    def target(self, target: cogbuilder.Builder[cogvariants.Dataquery]) -> typing.Self:    
         target_resource = target.build()
         self._internal.target = target_resource
     
         return self
     
-    def targets(self, targets: list[cogbuilder.Builder[cogvariants.Dataquery]]) -> typing.Self:        
+    def targets(self, targets: list[cogbuilder.Builder[cogvariants.Dataquery]]) -> typing.Self:    
         targets_resources = [r1.build() for r1 in targets]
         self._internal.targets = targets_resources
     

--- a/testdata/jennies/builders/constant_assignment/PHPBuilder/src/Sandbox/SomeStructBuilder.php
+++ b/testdata/jennies/builders/constant_assignment/PHPBuilder/src/Sandbox/SomeStructBuilder.php
@@ -29,18 +29,21 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function readonly(): static
     {
         $this->internal->editable = false;
     
         return $this;
     }
+
     public function autoRefresh(): static
     {
         $this->internal->autoRefresh = true;
     
         return $this;
     }
+
     public function noAutoRefresh(): static
     {
         $this->internal->autoRefresh = false;

--- a/testdata/jennies/builders/constant_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/constant_assignment/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     _internal: sandbox.SomeStruct
 
     def __init__(self):
@@ -15,22 +15,22 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
         """
         return self._internal    
     
-    def editable(self) -> typing.Self:        
+    def editable(self) -> typing.Self:    
         self._internal.editable = True
     
         return self
     
-    def readonly(self) -> typing.Self:        
+    def readonly(self) -> typing.Self:    
         self._internal.editable = False
     
         return self
     
-    def auto_refresh(self) -> typing.Self:        
+    def auto_refresh(self) -> typing.Self:    
         self._internal.auto_refresh = True
     
         return self
     
-    def no_auto_refresh(self) -> typing.Self:        
+    def no_auto_refresh(self) -> typing.Self:    
         self._internal.auto_refresh = False
     
         return self

--- a/testdata/jennies/builders/constraints/PHPBuilder/src/Constraints/SomeStructBuilder.php
+++ b/testdata/jennies/builders/constraints/PHPBuilder/src/Constraints/SomeStructBuilder.php
@@ -35,6 +35,7 @@ class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function title(string $title): static
     {
         if (!(strlen($title) >= 1)) {

--- a/testdata/jennies/builders/constraints/PythonBuilder/builders/constraints.py
+++ b/testdata/jennies/builders/constraints/PythonBuilder/builders/constraints.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import constraints
 
 
-class SomeStruct(cogbuilder.Builder[constraints.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[constraints.SomeStruct]):
     _internal: constraints.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[constraints.SomeStruct]):
         """
         return self._internal    
     
-    def id_val(self, id_val: int) -> typing.Self:        
+    def id_val(self, id_val: int) -> typing.Self:    
         if not id_val >= 5:
             raise ValueError("id_val must be >= 5")
         if not id_val < 10:
@@ -24,7 +24,7 @@ class SomeStruct(cogbuilder.Builder[constraints.SomeStruct]):
     
         return self
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         if not len(title) >= 1:
             raise ValueError("len(title) must be >= 1")
         self._internal.title = title

--- a/testdata/jennies/builders/constructor_argument/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/constructor_argument/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     _internal: sandbox.SomeStruct
 
     def __init__(self, title: str):
@@ -16,7 +16,7 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self

--- a/testdata/jennies/builders/constructor_initializations/PythonBuilder/builders/constructor_initializations.py
+++ b/testdata/jennies/builders/constructor_initializations/PythonBuilder/builders/constructor_initializations.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import constructor_initializations
 
 
-class SomePanel(cogbuilder.Builder[constructor_initializations.SomePanel]):    
+class SomePanel(cogbuilder.Builder[constructor_initializations.SomePanel]):
     _internal: constructor_initializations.SomePanel
 
     def __init__(self):
@@ -17,7 +17,7 @@ class SomePanel(cogbuilder.Builder[constructor_initializations.SomePanel]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self

--- a/testdata/jennies/builders/dataquery_variant_builder/PythonBuilder/builders/dataquery_variant_builder.py
+++ b/testdata/jennies/builders/dataquery_variant_builder/PythonBuilder/builders/dataquery_variant_builder.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import dataquery_variant_builder
 
 
-class LokiBuilder(cogbuilder.Builder[dataquery_variant_builder.Loki]):    
+class LokiBuilder(cogbuilder.Builder[dataquery_variant_builder.Loki]):
     _internal: dataquery_variant_builder.Loki
 
     def __init__(self):
@@ -15,7 +15,7 @@ class LokiBuilder(cogbuilder.Builder[dataquery_variant_builder.Loki]):
         """
         return self._internal    
     
-    def expr(self, expr: str) -> typing.Self:        
+    def expr(self, expr: str) -> typing.Self:    
         self._internal.expr = expr
     
         return self

--- a/testdata/jennies/builders/envelope_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/envelope_assignment/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class Dashboard(cogbuilder.Builder[sandbox.Dashboard]):    
+class Dashboard(cogbuilder.Builder[sandbox.Dashboard]):
     _internal: sandbox.Dashboard
 
     def __init__(self):
@@ -15,7 +15,7 @@ class Dashboard(cogbuilder.Builder[sandbox.Dashboard]):
         """
         return self._internal    
     
-    def with_variable(self, name: str, value: str) -> typing.Self:        
+    def with_variable(self, name: str, value: str) -> typing.Self:    
         if self._internal.variables is None:
             self._internal.variables = []
         

--- a/testdata/jennies/builders/foreign_builder/PythonBuilder/builders/builder_pkg.py
+++ b/testdata/jennies/builders/foreign_builder/PythonBuilder/builders/builder_pkg.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import some_pkg
 
 
-class SomeNiceBuilder(cogbuilder.Builder[some_pkg.SomeStruct]):    
+class SomeNiceBuilder(cogbuilder.Builder[some_pkg.SomeStruct]):
     _internal: some_pkg.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeNiceBuilder(cogbuilder.Builder[some_pkg.SomeStruct]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self

--- a/testdata/jennies/builders/initialization_safeguards/PHPBuilder/src/InitializationSafeguards/SomePanelBuilder.php
+++ b/testdata/jennies/builders/initialization_safeguards/PHPBuilder/src/InitializationSafeguards/SomePanelBuilder.php
@@ -29,6 +29,7 @@ class SomePanelBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function showLegend(bool $show): static
     {    
         if ($this->internal->options === null) {

--- a/testdata/jennies/builders/initialization_safeguards/PythonBuilder/builders/initialization_safeguards.py
+++ b/testdata/jennies/builders/initialization_safeguards/PythonBuilder/builders/initialization_safeguards.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import initialization_safeguards
 
 
-class SomePanel(cogbuilder.Builder[initialization_safeguards.SomePanel]):    
+class SomePanel(cogbuilder.Builder[initialization_safeguards.SomePanel]):
     _internal: initialization_safeguards.SomePanel
 
     def __init__(self):
@@ -15,12 +15,12 @@ class SomePanel(cogbuilder.Builder[initialization_safeguards.SomePanel]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self
     
-    def show_legend(self, show: bool) -> typing.Self:        
+    def show_legend(self, show: bool) -> typing.Self:    
         if self._internal.options is None:
             self._internal.options = initialization_safeguards.Options()
         assert isinstance(self._internal.options, initialization_safeguards.Options)

--- a/testdata/jennies/builders/known_any/PythonBuilder/builders/known_any.py
+++ b/testdata/jennies/builders/known_any/PythonBuilder/builders/known_any.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import known_any
 
 
-class SomeStruct(cogbuilder.Builder[known_any.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[known_any.SomeStruct]):
     _internal: known_any.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[known_any.SomeStruct]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         if self._internal.config is None:
             self._internal.config = known_any.Config()
         assert isinstance(self._internal.config, known_any.Config)

--- a/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/map_index_assignment/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     _internal: sandbox.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
         """
         return self._internal    
     
-    def annotations(self, key: str, value: str) -> typing.Self:        
+    def annotations(self, key: str, value: str) -> typing.Self:    
         if self._internal.annotations is None:
             self._internal.annotations = {}
         

--- a/testdata/jennies/builders/map_of_builders/PythonBuilder/builders/map_of_builders.py
+++ b/testdata/jennies/builders/map_of_builders/PythonBuilder/builders/map_of_builders.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import map_of_builders
 
 
-class Panel(cogbuilder.Builder[map_of_builders.Panel]):    
+class Panel(cogbuilder.Builder[map_of_builders.Panel]):
     _internal: map_of_builders.Panel
 
     def __init__(self):
@@ -15,13 +15,13 @@ class Panel(cogbuilder.Builder[map_of_builders.Panel]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self
     
 
-class Dashboard(cogbuilder.Builder[map_of_builders.Dashboard]):    
+class Dashboard(cogbuilder.Builder[map_of_builders.Dashboard]):
     _internal: map_of_builders.Dashboard
 
     def __init__(self):
@@ -33,7 +33,7 @@ class Dashboard(cogbuilder.Builder[map_of_builders.Dashboard]):
         """
         return self._internal    
     
-    def panels(self, panels: dict[str, cogbuilder.Builder[map_of_builders.Panel]]) -> typing.Self:        
+    def panels(self, panels: dict[str, cogbuilder.Builder[map_of_builders.Panel]]) -> typing.Self:    
         panels_resources = { key1: val1.build() for (key1, val1) in panels.items() }
         self._internal.panels = panels_resources
     

--- a/testdata/jennies/builders/nullable_map_assignment/PythonBuilder/builders/nullable_map_assignment.py
+++ b/testdata/jennies/builders/nullable_map_assignment/PythonBuilder/builders/nullable_map_assignment.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import nullable_map_assignment
 
 
-class SomeStruct(cogbuilder.Builder[nullable_map_assignment.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[nullable_map_assignment.SomeStruct]):
     _internal: nullable_map_assignment.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[nullable_map_assignment.SomeStruct]):
         """
         return self._internal    
     
-    def config(self, config: dict[str, str]) -> typing.Self:        
+    def config(self, config: dict[str, str]) -> typing.Self:    
         self._internal.config = config
     
         return self

--- a/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
+++ b/testdata/jennies/builders/package-with-dashes/PythonBuilder/builders/builder-pkg.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import with-dashes
 
 
-class SomeNiceBuilder(cogbuilder.Builder[with-dashes.SomeStruct]):    
+class SomeNiceBuilder(cogbuilder.Builder[with-dashes.SomeStruct]):
     _internal: with-dashes.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeNiceBuilder(cogbuilder.Builder[with-dashes.SomeStruct]):
         """
         return self._internal    
     
-    def title(self, title: str) -> typing.Self:        
+    def title(self, title: str) -> typing.Self:    
         self._internal.title = title
     
         return self

--- a/testdata/jennies/builders/panel_builders/PHPBuilder/src/Panelbuilder/PanelBuilder.php
+++ b/testdata/jennies/builders/panel_builders/PHPBuilder/src/Panelbuilder/PanelBuilder.php
@@ -29,12 +29,14 @@ class PanelBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function onlyInTimeRange(bool $onlyInTimeRange): static
     {
         $this->internal->onlyInTimeRange = $onlyInTimeRange;
     
         return $this;
     }
+
     /**
      * @param array<string> $tags
      */
@@ -44,42 +46,49 @@ class PanelBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function limit(int $limit): static
     {
         $this->internal->limit = $limit;
     
         return $this;
     }
+
     public function showUser(bool $showUser): static
     {
         $this->internal->showUser = $showUser;
     
         return $this;
     }
+
     public function showTime(bool $showTime): static
     {
         $this->internal->showTime = $showTime;
     
         return $this;
     }
+
     public function showTags(bool $showTags): static
     {
         $this->internal->showTags = $showTags;
     
         return $this;
     }
+
     public function navigateToPanel(bool $navigateToPanel): static
     {
         $this->internal->navigateToPanel = $navigateToPanel;
     
         return $this;
     }
+
     public function navigateBefore(string $navigateBefore): static
     {
         $this->internal->navigateBefore = $navigateBefore;
     
         return $this;
     }
+
     public function navigateAfter(string $navigateAfter): static
     {
         $this->internal->navigateAfter = $navigateAfter;

--- a/testdata/jennies/builders/panel_builders/PythonBuilder/builders/panelbuilder.py
+++ b/testdata/jennies/builders/panel_builders/PythonBuilder/builders/panelbuilder.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import panelbuilder
 
 
-class Panel(cogbuilder.Builder[panelbuilder.Panel]):    
+class Panel(cogbuilder.Builder[panelbuilder.Panel]):
     _internal: panelbuilder.Panel
 
     def __init__(self):
@@ -15,52 +15,52 @@ class Panel(cogbuilder.Builder[panelbuilder.Panel]):
         """
         return self._internal    
     
-    def only_from_this_dashboard(self, only_from_this_dashboard: bool) -> typing.Self:        
+    def only_from_this_dashboard(self, only_from_this_dashboard: bool) -> typing.Self:    
         self._internal.only_from_this_dashboard = only_from_this_dashboard
     
         return self
     
-    def only_in_time_range(self, only_in_time_range: bool) -> typing.Self:        
+    def only_in_time_range(self, only_in_time_range: bool) -> typing.Self:    
         self._internal.only_in_time_range = only_in_time_range
     
         return self
     
-    def tags(self, tags: list[str]) -> typing.Self:        
+    def tags(self, tags: list[str]) -> typing.Self:    
         self._internal.tags = tags
     
         return self
     
-    def limit(self, limit: int) -> typing.Self:        
+    def limit(self, limit: int) -> typing.Self:    
         self._internal.limit = limit
     
         return self
     
-    def show_user(self, show_user: bool) -> typing.Self:        
+    def show_user(self, show_user: bool) -> typing.Self:    
         self._internal.show_user = show_user
     
         return self
     
-    def show_time(self, show_time: bool) -> typing.Self:        
+    def show_time(self, show_time: bool) -> typing.Self:    
         self._internal.show_time = show_time
     
         return self
     
-    def show_tags(self, show_tags: bool) -> typing.Self:        
+    def show_tags(self, show_tags: bool) -> typing.Self:    
         self._internal.show_tags = show_tags
     
         return self
     
-    def navigate_to_panel(self, navigate_to_panel: bool) -> typing.Self:        
+    def navigate_to_panel(self, navigate_to_panel: bool) -> typing.Self:    
         self._internal.navigate_to_panel = navigate_to_panel
     
         return self
     
-    def navigate_before(self, navigate_before: str) -> typing.Self:        
+    def navigate_before(self, navigate_before: str) -> typing.Self:    
         self._internal.navigate_before = navigate_before
     
         return self
     
-    def navigate_after(self, navigate_after: str) -> typing.Self:        
+    def navigate_after(self, navigate_after: str) -> typing.Self:    
         self._internal.navigate_after = navigate_after
     
         return self

--- a/testdata/jennies/builders/properties/PythonBuilder/builders/properties.py
+++ b/testdata/jennies/builders/properties/PythonBuilder/builders/properties.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import properties
 
 
-class SomeStruct(cogbuilder.Builder[properties.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[properties.SomeStruct]):
     _internal: properties.SomeStruct
     __some_builder_property: str = ""
 
@@ -16,7 +16,7 @@ class SomeStruct(cogbuilder.Builder[properties.SomeStruct]):
         """
         return self._internal    
     
-    def id_val(self, id_val: int) -> typing.Self:        
+    def id_val(self, id_val: int) -> typing.Self:    
         self._internal.id_val = id_val
     
         return self

--- a/testdata/jennies/builders/references/PythonBuilder/builders/some_pkg.py
+++ b/testdata/jennies/builders/references/PythonBuilder/builders/some_pkg.py
@@ -4,7 +4,7 @@ from ..models import some_pkg
 from ..models import other_pkg
 
 
-class Person(cogbuilder.Builder[some_pkg.Person]):    
+class Person(cogbuilder.Builder[some_pkg.Person]):
     _internal: some_pkg.Person
 
     def __init__(self):
@@ -16,7 +16,7 @@ class Person(cogbuilder.Builder[some_pkg.Person]):
         """
         return self._internal    
     
-    def name(self, name: other_pkg.Name) -> typing.Self:        
+    def name(self, name: other_pkg.Name) -> typing.Self:    
         self._internal.name = name
     
         return self

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/PythonBuilder/builders/sandbox.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import sandbox
 
 
-class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):    
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
     _internal: sandbox.SomeStruct
 
     def __init__(self):
@@ -15,7 +15,7 @@ class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
         """
         return self._internal    
     
-    def time(self, from_val: str, to: str) -> typing.Self:        
+    def time(self, from_val: str, to: str) -> typing.Self:    
         if self._internal.time is None:
             self._internal.time = "unknown"
         assert isinstance(self._internal.time, unknown)

--- a/testdata/jennies/builders/struct_with_defaults/PHPBuilder/src/StructWithDefaults/NestedStructBuilder.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPBuilder/src/StructWithDefaults/NestedStructBuilder.php
@@ -29,6 +29,7 @@ class NestedStructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function intVal(int $intVal): static
     {
         $this->internal->intVal = $intVal;

--- a/testdata/jennies/builders/struct_with_defaults/PHPBuilder/src/StructWithDefaults/StructBuilder.php
+++ b/testdata/jennies/builders/struct_with_defaults/PHPBuilder/src/StructWithDefaults/StructBuilder.php
@@ -33,6 +33,7 @@ class StructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\StructWithDefaults\NestedStruct> $partialFields
      */
@@ -43,6 +44,7 @@ class StructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     /**
      * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\StructWithDefaults\NestedStruct> $emptyFields
      */
@@ -53,12 +55,14 @@ class StructBuilder implements \Grafana\Foundation\Cog\Builder
     
         return $this;
     }
+
     public function complexField(unknown $complexField): static
     {
         $this->internal->complexField = $complexField;
     
         return $this;
     }
+
     public function partialComplexField(unknown $partialComplexField): static
     {
         $this->internal->partialComplexField = $partialComplexField;

--- a/testdata/jennies/builders/struct_with_defaults/PythonBuilder/builders/struct_with_defaults.py
+++ b/testdata/jennies/builders/struct_with_defaults/PythonBuilder/builders/struct_with_defaults.py
@@ -3,7 +3,7 @@ from ..cog import builder as cogbuilder
 from ..models import struct_with_defaults
 
 
-class NestedStruct(cogbuilder.Builder[struct_with_defaults.NestedStruct]):    
+class NestedStruct(cogbuilder.Builder[struct_with_defaults.NestedStruct]):
     _internal: struct_with_defaults.NestedStruct
 
     def __init__(self):
@@ -15,18 +15,18 @@ class NestedStruct(cogbuilder.Builder[struct_with_defaults.NestedStruct]):
         """
         return self._internal    
     
-    def string_val(self, string_val: str) -> typing.Self:        
+    def string_val(self, string_val: str) -> typing.Self:    
         self._internal.string_val = string_val
     
         return self
     
-    def int_val(self, int_val: int) -> typing.Self:        
+    def int_val(self, int_val: int) -> typing.Self:    
         self._internal.int_val = int_val
     
         return self
     
 
-class Struct(cogbuilder.Builder[struct_with_defaults.Struct]):    
+class Struct(cogbuilder.Builder[struct_with_defaults.Struct]):
     _internal: struct_with_defaults.Struct
 
     def __init__(self):
@@ -38,30 +38,30 @@ class Struct(cogbuilder.Builder[struct_with_defaults.Struct]):
         """
         return self._internal    
     
-    def all_fields(self, all_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:        
+    def all_fields(self, all_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:    
         all_fields_resource = all_fields.build()
         self._internal.all_fields = all_fields_resource
     
         return self
     
-    def partial_fields(self, partial_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:        
+    def partial_fields(self, partial_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:    
         partial_fields_resource = partial_fields.build()
         self._internal.partial_fields = partial_fields_resource
     
         return self
     
-    def empty_fields(self, empty_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:        
+    def empty_fields(self, empty_fields: cogbuilder.Builder[struct_with_defaults.NestedStruct]) -> typing.Self:    
         empty_fields_resource = empty_fields.build()
         self._internal.empty_fields = empty_fields_resource
     
         return self
     
-    def complex_field(self, complex_field: unknown) -> typing.Self:        
+    def complex_field(self, complex_field: unknown) -> typing.Self:    
         self._internal.complex_field = complex_field
     
         return self
     
-    def partial_complex_field(self, partial_complex_field: unknown) -> typing.Self:        
+    def partial_complex_field(self, partial_complex_field: unknown) -> typing.Self:    
         self._internal.partial_complex_field = partial_complex_field
     
         return self


### PR DESCRIPTION
To make cog more extensible, this PR adds the ability to define custom methods on objects and builders via template blocks.