### PR TITLE
Configurable JSON marshalling generation

### DIFF
--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -164,6 +164,7 @@ output:
           - '%__config_dir%/foundation-sdk/.cog/templates/go/extra'
         overrides_templates:
           - '%__config_dir%/foundation-sdk/.cog/templates/go/overrides'
+        generate_json_marshaller: true
         generate_strict_unmarshaller: true
         generate_equal: true
         generate_validate: true

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -172,6 +172,7 @@ output:
     - openapi: {}
     - php:
         namespace_root: '%php_namespace_root%'
+        generate_json_marshaller: true
         extra_files_templates:
           - '%__config_dir%/foundation-sdk/.cog/templates/php/extra'
         overrides_templates:

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -191,6 +191,7 @@ output:
           - '%__config_dir%/foundation-sdk/.cog/templates/typescript/overrides'
     - java:
         package_path: '%java_package_path%'
+        generate_json_marshaller: true
         extra_files_templates:
           - '%__config_dir%/foundation-sdk/.cog/templates/java/extra'
         overrides_templates:

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -178,6 +178,7 @@ output:
           - '%__config_dir%/foundation-sdk/.cog/templates/php/overrides'
     - python:
         path_prefix: grafana_foundation_sdk
+        generate_json_marshaller: true
         extra_files_templates:
           - '%__config_dir%/foundation-sdk/.cog/templates/python/extra'
         overrides_templates:

--- a/config/foundation_sdk.tests.yaml
+++ b/config/foundation_sdk.tests.yaml
@@ -24,6 +24,7 @@ output:
   languages:
     - go:
         package_root: '%go_package_root%'
+        generate_json_marshaller: true
         generate_strict_unmarshaller: true
         generate_equal: true
         generate_validate: true

--- a/helpers.go
+++ b/helpers.go
@@ -191,7 +191,8 @@ type GoConfig struct {
 func (pipeline *SchemaToTypesPipeline) Golang(config GoConfig) *SchemaToTypesPipeline {
 	pipeline.output = &codegen.OutputLanguage{
 		Go: &golang.Config{
-			SkipRuntime: true,
+			SkipRuntime:            true,
+			GenerateJSONMarshaller: true,
 
 			GenerateEqual:  config.GenerateEqual,
 			AnyAsInterface: config.AnyAsInterface,

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -19,7 +19,7 @@ type JSONMarshalling struct {
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func NewJSONMarshalling(config Config, tmpl *template.Template, imports *common.DirectImportMap, packageMapper func(string) string, typeFormatter *typeFormatter, apiRefCollector *common.APIReferenceCollector) JSONMarshalling {
+func newJSONMarshalling(config Config, tmpl *template.Template, imports *common.DirectImportMap, packageMapper func(string) string, typeFormatter *typeFormatter, apiRefCollector *common.APIReferenceCollector) JSONMarshalling {
 	return JSONMarshalling{
 		config: config,
 		tmpl: tmpl.Funcs(template.FuncMap{
@@ -35,7 +35,11 @@ func NewJSONMarshalling(config Config, tmpl *template.Template, imports *common.
 	}
 }
 
-func (jenny JSONMarshalling) generateForObject(buffer *strings.Builder, context languages.Context, schema *ast.Schema, object ast.Object) error {
+func (jenny JSONMarshalling) generateForObject(buffer *strings.Builder, context languages.Context, object ast.Object) error {
+	if !jenny.config.GenerateJSONMarshaller {
+		return nil
+	}
+
 	if jenny.objectNeedsCustomMarshal(object) {
 		jsonMarshal, err := jenny.renderCustomMarshal(object)
 		if err != nil {

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -22,12 +22,13 @@ func TestRawTypes_Generate(t *testing.T) {
 	config := Config{
 		PackageRoot:                "github.com/grafana/cog/generated",
 		GenerateEqual:              true,
+		GenerateJSONMarshaller:     true,
 		GenerateStrictUnmarshaller: true,
 		GenerateValidate:           true,
 	}
 	jenny := RawTypes{
-		Config:          config,
-		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
+		config:          config,
+		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 	compilerPasses := New(config).CompilerPasses()

--- a/internal/jennies/golang/strictjson.go
+++ b/internal/jennies/golang/strictjson.go
@@ -12,14 +12,16 @@ import (
 
 type strictJSONUnmarshal struct {
 	tmpl            *template.Template
+	config          Config
 	imports         *common.DirectImportMap
 	packageMapper   func(string) string
 	typeFormatter   *typeFormatter
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func newStrictJSONUnmarshal(tmpl *template.Template, imports *common.DirectImportMap, packageMapper func(string) string, typeFormatter *typeFormatter, apiRefCollector *common.APIReferenceCollector) strictJSONUnmarshal {
+func newStrictJSONUnmarshal(config Config, tmpl *template.Template, imports *common.DirectImportMap, packageMapper func(string) string, typeFormatter *typeFormatter, apiRefCollector *common.APIReferenceCollector) strictJSONUnmarshal {
 	return strictJSONUnmarshal{
+		config: config,
 		tmpl: tmpl.Funcs(template.FuncMap{
 			"formatType": typeFormatter.formatType,
 			"importStdPkg": func(pkg string) string {
@@ -35,6 +37,10 @@ func newStrictJSONUnmarshal(tmpl *template.Template, imports *common.DirectImpor
 }
 
 func (jenny strictJSONUnmarshal) generateForObject(buffer *strings.Builder, context languages.Context, object ast.Object) error {
+	if !jenny.config.GenerateJSONMarshaller || !jenny.config.GenerateStrictUnmarshaller {
+		return nil
+	}
+
 	if !jenny.objectNeedsUnmarshal(object) {
 		return nil
 	}

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -12,7 +12,7 @@ type JSONMarshaller struct {
 }
 
 func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
-	if !j.config.GenerateBuilders || j.config.SkipRuntime {
+	if !j.config.GenerateJSONMarshaller || !j.config.GenerateBuilders || j.config.SkipRuntime {
 		return ""
 	}
 
@@ -33,7 +33,7 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 }
 
 func (j JSONMarshaller) annotation(t ast.Type) string {
-	if !j.config.GenerateBuilders || j.config.SkipRuntime {
+	if !j.config.GenerateJSONMarshaller || !j.config.GenerateBuilders || j.config.SkipRuntime {
 		return ""
 	}
 

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -15,7 +15,9 @@ func TestRawTypes_Generate(t *testing.T) {
 		Name:         "JavaRawTypes",
 	}
 
-	cfg := Config{}
+	cfg := Config{
+		GenerateJSONMarshaller: true,
+	}
 
 	jenny := RawTypes{config: cfg, tmpl: initTemplates([]string{})}
 	compilerPasses := New(cfg).CompilerPasses()

--- a/internal/jennies/php/jennies.go
+++ b/internal/jennies/php/jennies.go
@@ -19,6 +19,10 @@ type Config struct {
 
 	NamespaceRoot string `yaml:"namespace_root"`
 
+	// GenerateJSONMarshaller controls the generation of `fromArray()` and
+	// `jsonSerialize()` methods on types.
+	GenerateJSONMarshaller bool `yaml:"generate_json_marshaller"`
+
 	// OverridesTemplatesDirectories holds a list of directories containing templates
 	// defining blocks used to override parts of builders/types/....
 	OverridesTemplatesDirectories []string `yaml:"overrides_templates"`
@@ -76,16 +80,16 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	tmpl := initTemplates(language.apiRefCollector, language.config.OverridesTemplatesDirectories)
 	rawTypesJenny := RawTypes{config: config, tmpl: tmpl, apiRefCollector: language.apiRefCollector}
 
-	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
+	jenny := codejen.JennyListWithNamer(func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
 		Runtime{config: config, tmpl: tmpl},
-		common.If[languages.Context](globalConfig.Types, rawTypesJenny),
-		common.If[languages.Context](globalConfig.Builders, &Builder{config: config, tmpl: tmpl, apiRefCollector: language.apiRefCollector}),
-		common.If[languages.Context](globalConfig.Builders && globalConfig.Converters, &Converter{config: config, tmpl: tmpl, nullableConfig: language.NullableKinds()}),
+		common.If(globalConfig.Types, rawTypesJenny),
+		common.If(globalConfig.Builders, &Builder{config: config, tmpl: tmpl, apiRefCollector: language.apiRefCollector}),
+		common.If(globalConfig.Builders && globalConfig.Converters, &Converter{config: config, tmpl: tmpl, nullableConfig: language.NullableKinds()}),
 
-		common.If[languages.Context](globalConfig.APIReference, common.APIReference{
+		common.If(globalConfig.APIReference, common.APIReference{
 			Collector: language.apiRefCollector,
 			Language:  LanguageRef,
 			Formatter: apiReferenceFormatter(tmpl, config),

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -180,7 +180,11 @@ func (jenny RawTypes) formatStructDef(context languages.Context, schema *ast.Sch
 		variant = ", " + jenny.config.fullNamespaceRef("Cog\\"+formatObjectName(object.Type.ImplementedVariant()))
 	}
 
-	buffer.WriteString(fmt.Sprintf("class %s implements \\JsonSerializable%s\n{\n", formatObjectName(object.Name), variant))
+	buffer.WriteString(fmt.Sprintf("class %s", formatObjectName(object.Name)))
+	if jenny.config.GenerateJSONMarshaller {
+		buffer.WriteString(" implements \\JsonSerializable")
+	}
+	buffer.WriteString(fmt.Sprintf("%s\n{\n", variant))
 
 	for _, fieldDef := range object.Type.Struct.Fields {
 		buffer.WriteString(tools.Indent(jenny.typeFormatter.formatField(fieldDef), 4))
@@ -188,16 +192,19 @@ func (jenny RawTypes) formatStructDef(context languages.Context, schema *ast.Sch
 	}
 
 	buffer.WriteString(tools.Indent(jenny.generateConstructor(context, object), 4))
-	buffer.WriteString("\n\n")
 
-	fromJSON, err := jenny.generateFromJSON(context, object)
-	if err != nil {
-		return "", err
+	if jenny.config.GenerateJSONMarshaller {
+		fromJSON, err := jenny.generateFromJSON(context, object)
+		if err != nil {
+			return "", err
+		}
+
+		buffer.WriteString("\n\n")
+		buffer.WriteString(tools.Indent(fromJSON, 4))
+		buffer.WriteString("\n\n")
+
+		buffer.WriteString(tools.Indent(jenny.generateJSONSerialize(object), 4))
 	}
-	buffer.WriteString(tools.Indent(fromJSON, 4))
-	buffer.WriteString("\n\n")
-
-	buffer.WriteString(tools.Indent(jenny.generateJSONSerialize(object), 4))
 
 	if object.Type.ImplementsVariant() {
 		customVariantTmpl := template.CustomObjectVariantBlock(object)

--- a/internal/jennies/php/rawtypes_test.go
+++ b/internal/jennies/php/rawtypes_test.go
@@ -20,7 +20,8 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	config := Config{
-		NamespaceRoot: "Grafana\\Foundation",
+		NamespaceRoot:          "Grafana\\Foundation",
+		GenerateJSONMarshaller: true,
 	}
 	jenny := RawTypes{
 		config:          config,

--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -16,6 +16,7 @@ import (
 )
 
 type RawTypes struct {
+	config          Config
 	tmpl            *template.Template
 	typeFormatter   *typeFormatter
 	importModule    moduleImporter
@@ -94,16 +95,20 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 			buffer.WriteString("\n\n")
 			buffer.WriteString(jenny.generateInitMethod(context.Schemas, object))
 
-			buffer.WriteString("\n\n")
-			buffer.WriteString(jenny.generateToJSONMethod(object))
-
-			buffer.WriteString("\n\n")
-			fromJSON, innerErr := jenny.generateFromJSONMethod(context, object)
-			if innerErr != nil {
-				err = innerErr
-				return
+			if jenny.config.GenerateJSONMarshaller {
+				buffer.WriteString("\n\n")
+				buffer.WriteString(jenny.generateToJSONMethod(object))
 			}
-			buffer.WriteString(fromJSON)
+
+			if jenny.config.GenerateJSONMarshaller {
+				buffer.WriteString("\n\n")
+				fromJSON, innerErr := jenny.generateFromJSONMethod(context, object)
+				if innerErr != nil {
+					err = innerErr
+					return
+				}
+				buffer.WriteString(fromJSON)
+			}
 		}
 
 		customMethodsBlock := template.CustomObjectMethodsBlock(object)

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -20,11 +20,15 @@ func TestRawTypes_Generate(t *testing.T) {
 		},
 	}
 
+	config := Config{
+		GenerateJSONMarshaller: true,
+	}
 	jenny := RawTypes{
+		config:          config,
 		tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(Config{}).CompilerPasses()
+	compilerPasses := New(config).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
 		req := require.New(tc)

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -308,6 +308,10 @@
     },
     "GolangConfig": {
       "properties": {
+        "generate_json_marshaller": {
+          "type": "boolean",
+          "description": "GenerateJSONMarshaller controls the generation of `MarshalJSON()` and\n`UnmarshalJSON()` methods on types."
+        },
         "generate_strict_unmarshaller": {
           "type": "boolean",
           "description": "GenerateStrictUnmarshaller controls the generation of\n`UnmarshalJSONStrict()` methods on types."

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -376,6 +376,10 @@
         "skip_runtime": {
           "type": "boolean",
           "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
+        },
+        "generate_json_marshaller": {
+          "type": "boolean",
+          "description": "GenerateJSONMarshaller controls the generation of `MarshalJSON()` and\n`UnmarshalJSON()` methods on types."
         }
       },
       "additionalProperties": false,

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -406,6 +406,10 @@
         "namespace_root": {
           "type": "string"
         },
+        "generate_json_marshaller": {
+          "type": "boolean",
+          "description": "GenerateJSONMarshaller controls the generation of `fromArray()` and\n`jsonSerialize()` methods on types."
+        },
         "overrides_templates": {
           "items": {
             "type": "string"
@@ -428,6 +432,10 @@
       "properties": {
         "path_prefix": {
           "type": "string"
+        },
+        "generate_json_marshaller": {
+          "type": "boolean",
+          "description": "GenerateJSONMarshaller controls the generation of `to_json()` and\n`from_json()` methods on types."
         },
         "skip_runtime": {
           "type": "boolean",

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -468,6 +468,9 @@
         "object": {
           "type": "string"
         },
+        "builder": {
+          "type": "string"
+        },
         "options": {
           "items": {
             "type": "string"


### PR DESCRIPTION
This PR makes the generation of JSON (un)marshalling-related code configurable.

Note: to be consistent with other `generate_*` configuration options, this effectively introduces a BC-break. We'll need to explicitly enable this in the codegen pipeline used for the Foundation SDK.