### PR TITLE
Update examples for changes in kind-registry next

### DIFF
--- a/examples/_go/main.go
+++ b/examples/_go/main.go
@@ -18,8 +18,7 @@ func dashboardBuilder() []byte {
 		Timezone(common.TimeZoneBrowser).
 		Timepicker(
 			dashboard.NewTimePickerBuilder().
-				RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}).
-				TimeOptions([]string{"5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"}),
+				RefreshIntervals([]string{"5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"}),
 		).
 		Tooltip(dashboard.DashboardCursorSyncCrosshair).
 		// "Data Source" variable

--- a/examples/java/src/main/java/test/Main.java
+++ b/examples/java/src/main/java/test/Main.java
@@ -27,8 +27,7 @@ public class Main {
                 .tags(List.of("generated", "raspberrypi-node-integration")).refresh("30s")
                 .time(new DashboardDashboardTimeBuilder().from("now-30m").to("now")).timezone("browser")
                 .timepicker(new TimePickerBuilder()
-                        .refreshIntervals(List.of("5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"))
-                        .timeOptions(List.of("5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d")))
+                        .refreshIntervals(List.of("5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d")))
                 .tooltip(DashboardCursorSync.CROSSHAIR).withVariable(datasourceVariable()).withVariable(queryVariable())
                 .
                 // CPU

--- a/examples/php/index.php
+++ b/examples/php/index.php
@@ -27,9 +27,7 @@ $builder = (new DashboardBuilder(title: '[TEST] Node Exporter / Raspberry'))
     ->time('now-30m', 'now')
     ->timezone(Common\Constants::TIME_ZONE_BROWSER)
     ->timepicker(
-        (new TimePickerBuilder())
-            ->refreshIntervals(['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'])
-            ->timeOptions(['5m', '15m', '1h', '6h', '12h', '24h', '2d', '7d', '30d'])
+        (new TimePickerBuilder())->refreshIntervals(['5s', '10s', '30s', '1m', '5m', '15m', '30m', '1h', '2h', '1d'])
     )
     ->tooltip(DashboardCursorSync::crosshair())
     // 'Data Source' variable

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -37,9 +37,7 @@ def build_dashboard() -> Dashboard:
         .timezone(TimeZoneBrowser)
         .timezone("browser")
         .timepicker(
-            TimePicker()
-            .refresh_intervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"])
-            .time_options(["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"])
+            TimePicker().refresh_intervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"])
         )
         .tooltip(DashboardCursorSync.CROSSHAIR)
         # "Data Source" variable

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -24,9 +24,7 @@ const builder = new DashboardBuilder("[TEST] Node Exporter / Raspberry")
     .timezone("browser")
 
     .timepicker(
-        new TimePickerBuilder()
-            .refreshIntervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"])
-            .timeOptions(["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]),
+        new TimePickerBuilder().refreshIntervals(["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]),
     )
 
     .tooltip(DashboardCursorSync.Crosshair)


### PR DESCRIPTION
https://github.com/grafana/grafana/commit/d1dee968c38791ed8fc4e1ae71229064b0e5bd96#diff-abdfd6a9318ae27ef245c1da7557b327ca1e4e6a10ee220b76e162c6865eeb28 removed the time_options field from dashboards :shrug: 