### PR TITLE
Delete default to constant veneer

### DIFF
--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -3,7 +3,7 @@ package builder
 import (
 	"fmt"
 	"strings"
-
+	
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 	"github.com/grafana/cog/internal/veneers"
@@ -17,15 +17,15 @@ func mapToSelected(selector Selector, mapFunc func(builders ast.Builders, builde
 			if !selector(schemas, b) {
 				continue
 			}
-
+			
 			newBuilder, err := mapFunc(builders, b)
 			if err != nil {
 				return nil, err
 			}
-
+			
 			builders[i] = newBuilder
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -35,61 +35,61 @@ func mergeBuilderInto(fromBuilder ast.Builder, intoBuilder ast.Builder, underPat
 	if renameOptions == nil {
 		renameOptions = map[string]string{}
 	}
-
+	
 	// copy factories
 	for _, factory := range fromBuilder.Factories {
 		newBuilder.Factories = append(newBuilder.Factories, factory.DeepCopy())
 	}
-
+	
 	// keep constant assignments
 	for _, assignment := range fromBuilder.Constructor.Assignments {
 		if assignment.Value.Constant == nil {
 			continue
 		}
-
+		
 		newAssignment := assignment
 		newAssignment.Path = underPath.Append(assignment.Path)
 		newBuilder.Constructor.Assignments = append(newBuilder.Constructor.Assignments, newAssignment)
 	}
-
+	
 	// copy options
 	for _, opt := range fromBuilder.Options {
 		if tools.ItemInList(opt.Name, excludeOptions) {
 			continue
 		}
-
+		
 		newOpt := opt
 		newOpt.Assignments = nil
-
+		
 		if as, found := renameOptions[newOpt.Name]; found {
 			newOpt.Name = as
 		}
-
+		
 		for _, assignment := range opt.Assignments {
 			newAssignment := assignment
 			newAssignment.Path = underPath.Append(assignment.Path)
-
+			
 			newOpt.Assignments = append(newOpt.Assignments, newAssignment)
 		}
-
+		
 		newBuilder.Options = append(newBuilder.Options, newOpt)
 	}
-
+	
 	return newBuilder, nil
 }
 
 func Omit(selector Selector) RewriteRule {
 	return func(schemas ast.Schemas, builders ast.Builders) (ast.Builders, error) {
 		filteredBuilders := make([]ast.Builder, 0, len(builders))
-
+		
 		for _, builder := range builders {
 			if selector(schemas, builder) {
 				continue
 			}
-
+			
 			filteredBuilders = append(filteredBuilders, builder)
 		}
-
+		
 		return filteredBuilders, nil
 	}
 }
@@ -101,19 +101,19 @@ func MergeInto(selector Selector, sourceBuilderName string, underPath string, ex
 			// We couldn't find the source builder: let's return the selected builder untouched.
 			return destinationBuilder, nil
 		}
-
+		
 		newRoot, err := destinationBuilder.MakePath(builders, underPath)
 		if err != nil {
 			return destinationBuilder, fmt.Errorf("could not apply MergeInto builder veneer: %w", err)
 		}
-
+		
 		newBuilder, err := mergeBuilderInto(sourceBuilder, destinationBuilder, newRoot, excludeOptions, renameOptions)
 		if err != nil {
 			return ast.Builder{}, fmt.Errorf("could not apply MergeInto builder veneer: %w", err)
 		}
-
+		
 		newBuilder.AddToVeneerTrail(fmt.Sprintf("MergeInto[source=%s]", sourceBuilder.Name))
-
+		
 		return newBuilder, nil
 	})
 }
@@ -129,30 +129,30 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 	if config.ComposedBuilderName != "" {
 		newBuilder.Name = config.ComposedBuilderName
 	}
-
+	
 	typeField, ok := sourceBuilder.For.Type.AsStruct().FieldByName(config.PluginDiscriminatorField)
 	if !ok {
 		return nil, fmt.Errorf("could not find plugin discriminator field '%s' in builder", config.PluginDiscriminatorField)
 	}
-
+	
 	typeAssignment := ast.ConstantAssignment(ast.PathFromStructField(typeField), typeDiscriminator)
 	newBuilder.Constructor.Assignments = append(newBuilder.Constructor.Assignments, typeAssignment)
-
+	
 	// re-add options coming from the source builder
 	for _, panelOpt := range sourceBuilder.Options {
 		// this value is now a constant
 		if panelOpt.Name == config.PluginDiscriminatorField {
 			continue
 		}
-
+		
 		// Is the option explicitly excluded?
 		if tools.StringInListEqualFold(panelOpt.Name, config.ExcludeOptions) {
 			continue
 		}
-
+		
 		newBuilder.Options = append(newBuilder.Options, panelOpt)
 	}
-
+	
 	composedBuilders := make([]ast.Builder, 0, len(composableBuilders))
 	for _, composableBuilder := range composableBuilders {
 		underPath, exists := config.CompositionMap[composableBuilder.For.Name]
@@ -163,46 +163,46 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 			composedBuilders = append(composedBuilders, composableBuilder)
 			continue
 		}
-
+		
 		newRoot, err := newBuilder.MakePath(builders, underPath)
 		if err != nil {
 			return nil, err
 		}
-
+		
 		refType := composableBuilder.For.SelfRef.AsType()
 		newRoot[len(newRoot)-1].TypeHint = &refType
-
+		
 		newBuilder, err = mergeBuilderInto(composableBuilder, newBuilder, newRoot, nil, nil)
 		if err != nil {
 			return nil, err
 		}
-
+		
 		// we do this to ensure that the same builder can be composed more than once
 		// ie: dashboard and dashboardv2 packages
 		if config.PreserveOriginalBuilders {
 			composedBuilders = append(composedBuilders, composableBuilder)
 		}
 	}
-
+	
 	if config.CompositionMap["__schema_entrypoint"] != "" {
 		schema, _ := schemas.Locate(composableBuilders[0].Package)
 		if schema.EntryPoint == "" {
 			return nil, fmt.Errorf("schema '%s' does not have an entrypoint", schema.Package)
 		}
-
+		
 		newRoot, err := newBuilder.MakePath(builders, config.CompositionMap["__schema_entrypoint"])
 		if err != nil {
 			return nil, err
 		}
-
+		
 		resolvedEntrypointType := schemas.ResolveToType(schema.EntryPointType)
-
+		
 		switch {
 		case resolvedEntrypointType.IsStructGeneratedFromDisjunction():
 			for _, field := range resolvedEntrypointType.Struct.Fields {
 				newRoot[len(newRoot)-1].TypeHint = &schema.EntryPointType
 				arg := ast.Argument{Name: field.Name, Type: field.Type}
-
+				
 				branchOpt := ast.Option{
 					Name: field.Name,
 					Args: []ast.Argument{arg},
@@ -211,14 +211,14 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 					},
 					VeneerTrail: []string{"ComposeBuilders[created]"},
 				}
-
+				
 				newBuilder.Options = append(newBuilder.Options, branchOpt)
 			}
 		case resolvedEntrypointType.IsDisjunction():
 			for _, branch := range resolvedEntrypointType.Disjunction.Branches {
 				newRoot[len(newRoot)-1].TypeHint = &schema.EntryPointType
 				arg := ast.Argument{Name: ast.TypeName(branch), Type: branch}
-
+				
 				branchOpt := ast.Option{
 					Name: ast.TypeName(branch),
 					Args: []ast.Argument{arg},
@@ -227,7 +227,7 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 					},
 					VeneerTrail: []string{"ComposeBuilders[created]"},
 				}
-
+				
 				newBuilder.Options = append(newBuilder.Options, branchOpt)
 			}
 		case resolvedEntrypointType.IsStruct():
@@ -237,7 +237,7 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 			} else {
 				refType := entrypointBuilder.For.SelfRef.AsType()
 				newRoot[len(newRoot)-1].TypeHint = &refType
-
+				
 				newBuilder, err = mergeBuilderInto(entrypointBuilder, newBuilder, newRoot, nil, nil)
 				if err != nil {
 					return nil, err
@@ -247,9 +247,9 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 			return nil, fmt.Errorf("entrypoint '%s.%s' is a %s: not implemented", schema.Package, schema.EntryPoint, resolvedEntrypointType.Kind)
 		}
 	}
-
+	
 	composedBuilders = append(composedBuilders, newBuilder)
-
+	
 	return composedBuilders, nil
 }
 
@@ -261,12 +261,12 @@ type CompositionConfig struct {
 	// Note: The builder name must follow the [package].[builder_name] pattern.
 	// Example: "dashboard.Panel"
 	SourceBuilderName string
-
+	
 	// PluginDiscriminatorField contains the name of the field used to identify
 	// the plugin implementing this object.
 	// Example: "type", "kind", ...
 	PluginDiscriminatorField string
-
+	
 	// Composition map describes how to perform the composition.
 	// Each entry in this map associates a builder (referenced by its name)
 	// to a path under witch the assignments should be performed.
@@ -279,15 +279,15 @@ type CompositionConfig struct {
 	// }
 	// ```
 	CompositionMap map[string]string
-
+	
 	// ExcludeOptions lists option names to exclude in the resulting
 	// composed builders.
 	ExcludeOptions []string
-
+	
 	// ComposedBuilderName configures the name of the newly composed builders.
 	// If left empty, the name is taken from SourceBuilderName.
 	ComposedBuilderName string
-
+	
 	// PreserveOriginalBuilders ensures that builders used as part of the
 	// composition process are preserved.
 	// It is useful when the same builders need to be composed more than once
@@ -302,50 +302,50 @@ func ComposeBuilders(selector Selector, config CompositionConfig) RewriteRule {
 		if !found {
 			return nil, fmt.Errorf("could not apply ComposeBuilders builder veneer: SourceBuilderName '%s' is incorrect: no package found", sourceBuilderPkg)
 		}
-
+		
 		sourceBuilder, found := builders.LocateByObject(sourceBuilderPkg, sourceBuilderNameWithoutPkg)
 		if !found {
 			return builders, nil
 		}
-
+		
 		// - add to newBuilders all the builders that are not composable (ie: don't comply to the selector)
 		// - build a map of composable builders, indexed by type
 		// - aggregate the composable builders into a new, composed builder
 		// - add the new composed builders to newBuilders
-
+		
 		newBuilders := make([]ast.Builder, 0, len(builders))
 		composableBuilders := make(map[string]ast.Builders)
-
+		
 		for _, builder := range builders {
 			// the builder isn't selected: let's leave it untouched
 			if !selector(schemas, builder) {
 				newBuilders = append(newBuilders, builder)
 				continue
 			}
-
+			
 			schema, found := schemas.Locate(builder.For.SelfRef.ReferredPkg)
 			if !found {
 				continue
 			}
-
+			
 			panelType := schema.Metadata.Identifier
 			composableBuilders[panelType] = append(composableBuilders[panelType], builder)
 		}
-
+		
 		for panelType, buildersForType := range composableBuilders {
 			composedBuilders, err := composeBuilderForType(schemas, builders, config, panelType, sourceBuilder, buildersForType)
 			if err != nil {
 				return nil, fmt.Errorf("could not apply ComposeBuilders builder veneer: %w", err)
 			}
-
+			
 			for i, b := range composedBuilders {
 				b.AddToVeneerTrail(fmt.Sprintf("ComposeBuilders[source=%s]", config.SourceBuilderName))
 				composedBuilders[i] = b
 			}
-
+			
 			newBuilders = append(newBuilders, composedBuilders...)
 		}
-
+		
 		return newBuilders, nil
 	}
 }
@@ -356,11 +356,11 @@ func Rename(selector Selector, newName string) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			builders[i].Name = newName
 			builders[i].AddToVeneerTrail("Rename")
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -371,14 +371,14 @@ func VeneerTrailAsComments(selector Selector) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			veneerTrail := tools.Map(builder.VeneerTrail, func(veneer string) string {
 				return fmt.Sprintf("Modified by veneer '%s'", veneer)
 			})
-
+			
 			builders[i].For.Comments = append(builders[i].For.Comments, veneerTrail...)
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -389,11 +389,11 @@ func Properties(selector Selector, properties []ast.StructField) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			builders[i].Properties = append(builders[i].Properties, properties...)
 			builders[i].AddToVeneerTrail("Properties")
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -401,25 +401,25 @@ func Properties(selector Selector, properties []ast.StructField) RewriteRule {
 func Duplicate(selector Selector, duplicateName string, excludeOptions []string) RewriteRule {
 	return func(schemas ast.Schemas, builders ast.Builders) (ast.Builders, error) {
 		var newBuilders ast.Builders
-
+		
 		for _, builder := range builders {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			duplicatedBuilder := builder.DeepCopy()
 			duplicatedBuilder.Name = duplicateName
 			duplicatedBuilder.AddToVeneerTrail(fmt.Sprintf("Duplicate[%s.%s]", builder.Package, builder.Name))
-
+			
 			if len(excludeOptions) != 0 {
 				duplicatedBuilder.Options = tools.Filter(duplicatedBuilder.Options, func(option ast.Option) bool {
 					return !tools.StringInListEqualFold(option.Name, excludeOptions)
 				})
 			}
-
+			
 			newBuilders = append(newBuilders, duplicatedBuilder)
 		}
-
+		
 		return append(builders, newBuilders...), nil
 	}
 }
@@ -435,20 +435,20 @@ func Initialize(selector Selector, statements []Initialization) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			veneerDebug := make([]string, 0, len(statements))
 			for _, statement := range statements {
 				path, err := builders[i].MakePath(builders, statement.PropertyPath)
 				if err != nil {
 					return nil, fmt.Errorf("could not apply Initialize builder veneer: %w", err)
 				}
-
+				
 				builders[i].Constructor.Assignments = append(builders[i].Constructor.Assignments, ast.ConstantAssignment(path, statement.Value))
 				veneerDebug = append(veneerDebug, fmt.Sprintf("%s = %v", statement.PropertyPath, statement.Value))
 			}
 			builders[i].AddToVeneerTrail(fmt.Sprintf("Initialize[%s]", strings.Join(veneerDebug, ", ")))
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -462,28 +462,28 @@ func PromoteOptionsToConstructor(selector Selector, optionNames []string) Rewrit
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			if len(builder.Factories) != 0 {
 				return nil, fmt.Errorf("could not apply PromoteOptionsToConstructor builder veneer: constructor arguments can not be added to builders that have factories")
 			}
-
+			
 			for _, optName := range optionNames {
 				opt, ok := builder.OptionByName(optName)
 				if !ok {
 					continue
 				}
-
+				
 				// TODO: do it for every argument/assignment?
 				arg := opt.Args[0].DeepCopy()
 				arg.Type.Nullable = false
-
+				
 				builders[i].Constructor.Args = append(builders[i].Constructor.Args, arg)
 				builders[i].Constructor.Assignments = append(builders[i].Constructor.Assignments, opt.Assignments[0])
-
+				
 				builders[i].AddToVeneerTrail(fmt.Sprintf("PromoteOptionsToConstructor[%s]", optName))
 			}
 		}
-
+		
 		return builders, nil
 	}
 }
@@ -495,53 +495,16 @@ func AddOption(selector Selector, newOption veneers.Option) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			newOpt, err := newOption.AsIR(schemas, builders, builder)
 			if err != nil {
 				return nil, fmt.Errorf("could not apply AddOption builder veneer: %w", err)
 			}
-
+			
 			newOpt.AddToVeneerTrail("AddOption")
 			builders[i].Options = append(builders[i].Options, newOpt)
 		}
-
-		return builders, nil
-	}
-}
-
-// DefaultToConstant sets a default value into a constant.
-// When we unfold a value, omit an option, or any other action; we can lose the default value in the Builder struct.
-// If we parse the defaults using the Builder and not the Schema, we might not have all the defaults and with this rule,
-// we set these defaults as constants inside the constructor.
-func DefaultToConstant(selector Selector, options []string) RewriteRule {
-	return func(schemas ast.Schemas, builders ast.Builders) (ast.Builders, error) {
-		for i, builder := range builders {
-			if !selector(schemas, builder) {
-				continue
-			}
-
-			for _, option := range options {
-				opt, ok := builder.OptionByName(option)
-				if !ok {
-					continue
-				}
-
-				values := make([]any, 0)
-				for _, args := range opt.Args {
-					if args.Type.Default != nil {
-						values = append(values, args.Type.Default)
-					}
-				}
-
-				for v := range opt.Assignments {
-					opt.Assignments[v].Value.Argument = nil
-					opt.Assignments[v].Value.Constant = values[v]
-				}
-
-				builders[i].Constructor.Assignments = append(builders[i].Constructor.Assignments, opt.Assignments...)
-			}
-		}
-
+		
 		return builders, nil
 	}
 }
@@ -555,14 +518,14 @@ func AddFactory(selector Selector, factory ast.BuilderFactory) RewriteRule {
 			if !selector(schemas, builder) {
 				continue
 			}
-
+			
 			if len(builder.Constructor.Args) != 0 {
 				return nil, fmt.Errorf("could not apply AddFactory builder veneer: builder factories can not be defined on builders that accept parameters in their constructor")
 			}
-
+			
 			builders[i].Factories = append(builders[i].Factories, factory)
 		}
-
+		
 		return builders, nil
 	}
 }

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -2,7 +2,7 @@ package yaml
 
 import (
 	"fmt"
-
+	
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 	"github.com/grafana/cog/internal/veneers"
@@ -23,7 +23,6 @@ type BuilderRule struct {
 	Initialize               *Initialize               `yaml:"initialize"`
 	PromoteOptsToConstructor *PromoteOptsToConstructor `yaml:"promote_options_to_constructor"`
 	AddOption                *AddOption                `yaml:"add_option"`
-	DefaultToConstant        *DefaultToConstant        `yaml:"default_to_constant"`
 	AddFactory               *AddFactory               `yaml:"add_factory"`
 }
 
@@ -33,56 +32,52 @@ func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 		if err != nil {
 			return nil, err
 		}
-
+		
 		return builder.Omit(selector), nil
 	}
-
+	
 	if rule.Rename != nil {
 		return rule.Rename.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.MergeInto != nil {
 		return rule.MergeInto.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.ComposeBuilders != nil {
 		return rule.ComposeBuilders.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.Properties != nil {
 		return rule.Properties.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.Duplicate != nil {
 		return rule.Duplicate.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.Initialize != nil {
 		return rule.Initialize.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.PromoteOptsToConstructor != nil {
 		return rule.PromoteOptsToConstructor.AsRewriteRule(pkg)
 	}
-
+	
 	if rule.AddOption != nil {
 		return rule.AddOption.AsRewriteRule(pkg)
 	}
-
-	if rule.DefaultToConstant != nil {
-		return rule.DefaultToConstant.AsRewriteRule(pkg)
-	}
-
+	
 	if rule.AddFactory != nil {
 		return rule.AddFactory.AsRewriteRule(pkg)
 	}
-
+	
 	return nil, fmt.Errorf("empty rule")
 }
 
 type RenameBuilder struct {
 	BuilderSelector `yaml:",inline"`
-
+	
 	As string `yaml:"as"`
 }
 
@@ -91,7 +86,7 @@ func (rule RenameBuilder) AsRewriteRule(pkg string) (builder.RewriteRule, error)
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.Rename(selector, rule.As), nil
 }
 
@@ -115,7 +110,7 @@ func (rule MergeInto) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 type ComposeBuilders struct {
 	BuilderSelector `yaml:",inline"`
-
+	
 	SourceBuilderName        string            `yaml:"source_builder_name"`
 	PluginDiscriminatorField string            `yaml:"plugin_discriminator_field"`
 	ExcludeOptions           []string          `yaml:"exclude_options"`
@@ -129,7 +124,7 @@ func (rule ComposeBuilders) AsRewriteRule(pkg string) (builder.RewriteRule, erro
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.ComposeBuilders(
 		selector,
 		builder.CompositionConfig{
@@ -153,7 +148,7 @@ func (rule Properties) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.Properties(
 		selector,
 		rule.Set,
@@ -171,7 +166,7 @@ func (rule Duplicate) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.Duplicate(
 		selector,
 		rule.As,
@@ -194,7 +189,7 @@ func (rule Initialize) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.Initialize(
 		selector,
 		tools.Map(rule.Set, func(init Initialization) builder.Initialization {
@@ -213,7 +208,7 @@ func (rule PromoteOptsToConstructor) AsRewriteRule(pkg string) (builder.RewriteR
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.PromoteOptionsToConstructor(selector, rule.Options), nil
 }
 
@@ -227,22 +222,8 @@ func (rule AddOption) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.AddOption(selector, rule.Option), nil
-}
-
-type DefaultToConstant struct {
-	BuilderSelector `yaml:",inline"`
-	Options         []string `yaml:"options"`
-}
-
-func (rule DefaultToConstant) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
-	selector, err := rule.AsSelector(pkg)
-	if err != nil {
-		return nil, err
-	}
-
-	return builder.DefaultToConstant(selector, rule.Options), nil
 }
 
 type AddFactory struct {
@@ -255,7 +236,7 @@ func (rule AddFactory) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return builder.AddFactory(selector, rule.Factory), nil
 }
 
@@ -266,9 +247,9 @@ func (rule AddFactory) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 type BuilderSelector struct {
 	ByObject *string `yaml:"by_object"`
 	ByName   *string `yaml:"by_name"`
-
+	
 	ByVariant *string `yaml:"by_variant"`
-
+	
 	GeneratedFromDisjunction *bool `yaml:"generated_from_disjunction"` // noop?
 }
 
@@ -276,18 +257,18 @@ func (selector BuilderSelector) AsSelector(pkg string) (builder.Selector, error)
 	if selector.ByObject != nil {
 		return builder.ByObjectName(pkg, *selector.ByObject), nil
 	}
-
+	
 	if selector.ByName != nil {
 		return builder.ByName(pkg, *selector.ByName), nil
 	}
-
+	
 	if selector.ByVariant != nil {
 		return builder.ByVariant(ast.SchemaVariant(*selector.ByVariant)), nil
 	}
-
+	
 	if selector.GeneratedFromDisjunction != nil {
 		return builder.StructGeneratedFromDisjunction(), nil
 	}
-
+	
 	return nil, fmt.Errorf("empty selector")
 }

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -2,7 +2,7 @@ package yaml
 
 import (
 	"fmt"
-	
+
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 	"github.com/grafana/cog/internal/veneers"
@@ -32,52 +32,52 @@ func (rule BuilderRule) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 		if err != nil {
 			return nil, err
 		}
-		
+
 		return builder.Omit(selector), nil
 	}
-	
+
 	if rule.Rename != nil {
 		return rule.Rename.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.MergeInto != nil {
 		return rule.MergeInto.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.ComposeBuilders != nil {
 		return rule.ComposeBuilders.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.Properties != nil {
 		return rule.Properties.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.Duplicate != nil {
 		return rule.Duplicate.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.Initialize != nil {
 		return rule.Initialize.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.PromoteOptsToConstructor != nil {
 		return rule.PromoteOptsToConstructor.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.AddOption != nil {
 		return rule.AddOption.AsRewriteRule(pkg)
 	}
-	
+
 	if rule.AddFactory != nil {
 		return rule.AddFactory.AsRewriteRule(pkg)
 	}
-	
+
 	return nil, fmt.Errorf("empty rule")
 }
 
 type RenameBuilder struct {
 	BuilderSelector `yaml:",inline"`
-	
+
 	As string `yaml:"as"`
 }
 
@@ -86,7 +86,7 @@ func (rule RenameBuilder) AsRewriteRule(pkg string) (builder.RewriteRule, error)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Rename(selector, rule.As), nil
 }
 
@@ -110,7 +110,7 @@ func (rule MergeInto) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 
 type ComposeBuilders struct {
 	BuilderSelector `yaml:",inline"`
-	
+
 	SourceBuilderName        string            `yaml:"source_builder_name"`
 	PluginDiscriminatorField string            `yaml:"plugin_discriminator_field"`
 	ExcludeOptions           []string          `yaml:"exclude_options"`
@@ -124,7 +124,7 @@ func (rule ComposeBuilders) AsRewriteRule(pkg string) (builder.RewriteRule, erro
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.ComposeBuilders(
 		selector,
 		builder.CompositionConfig{
@@ -148,7 +148,7 @@ func (rule Properties) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Properties(
 		selector,
 		rule.Set,
@@ -166,7 +166,7 @@ func (rule Duplicate) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Duplicate(
 		selector,
 		rule.As,
@@ -189,7 +189,7 @@ func (rule Initialize) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.Initialize(
 		selector,
 		tools.Map(rule.Set, func(init Initialization) builder.Initialization {
@@ -208,7 +208,7 @@ func (rule PromoteOptsToConstructor) AsRewriteRule(pkg string) (builder.RewriteR
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.PromoteOptionsToConstructor(selector, rule.Options), nil
 }
 
@@ -222,7 +222,7 @@ func (rule AddOption) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.AddOption(selector, rule.Option), nil
 }
 
@@ -236,7 +236,7 @@ func (rule AddFactory) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	return builder.AddFactory(selector, rule.Factory), nil
 }
 
@@ -247,9 +247,9 @@ func (rule AddFactory) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
 type BuilderSelector struct {
 	ByObject *string `yaml:"by_object"`
 	ByName   *string `yaml:"by_name"`
-	
+
 	ByVariant *string `yaml:"by_variant"`
-	
+
 	GeneratedFromDisjunction *bool `yaml:"generated_from_disjunction"` // noop?
 }
 
@@ -257,18 +257,18 @@ func (selector BuilderSelector) AsSelector(pkg string) (builder.Selector, error)
 	if selector.ByObject != nil {
 		return builder.ByObjectName(pkg, *selector.ByObject), nil
 	}
-	
+
 	if selector.ByName != nil {
 		return builder.ByName(pkg, *selector.ByName), nil
 	}
-	
+
 	if selector.ByVariant != nil {
 		return builder.ByVariant(ast.SchemaVariant(*selector.ByVariant)), nil
 	}
-	
+
 	if selector.GeneratedFromDisjunction != nil {
 		return builder.StructGeneratedFromDisjunction(), nil
 	}
-	
+
 	return nil, fmt.Errorf("empty selector")
 }


### PR DESCRIPTION
`DefaultToConstant` was an action added to set missing defaults in the builder. It happens in Java in Go because we didn't have default constructors that set defaults information.

After move all defaults into default constructors in types, we don't have to deal with this issue anymore, so we don't need the action.

Closes https://github.com/grafana/cog/issues/552
Depends on: https://github.com/grafana/grafana-foundation-sdk/pull/638