### PR TITLE
Fix discovery of types referenced by constant refs when parsing from …

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f?lastModified=1741037377&narHash=sha256-SvtvVKHaUX4Owb%2BPasySwZsoc5VUeTf1px34BByiOxw%3D"
+    },
     "go@1.23": {
       "last_modified": "2024-12-23T21:10:33Z",
       "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#go",


### PR DESCRIPTION
…a CUE envelope

Fixes #770

This is the smallest fix that discovers the missing types. The cue parser would however need a bit of refactoring to properly support these cases as we currently discover "constant" references partly within the "string" parsing logic :|