### PR TITLE
Support disabling post-formatting in Go jenny

### DIFF
--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -38,6 +38,10 @@ type Config struct {
 	// rely on the runtime to function.
 	SkipRuntime bool `yaml:"skip_runtime"`
 
+	// SkipPostFormatting disables formatting of Go files done with go imports
+	// after code generation.
+	SkipPostFormatting bool `yaml:"skip_post_formatting"`
+
 	// OverridesTemplatesDirectories holds a list of directories containing templates
 	// defining blocks used to override parts of builders/types/....
 	OverridesTemplatesDirectories []string `yaml:"overrides_templates"`
@@ -138,7 +142,10 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 			TmplFuncs: formattingTemplateFuncs(config),
 		},
 	)
-	jenny.AddPostprocessors(formatGoFiles, common.GeneratedCommentHeader(globalConfig))
+	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+	if !config.SkipPostFormatting {
+		jenny.AddPostprocessors(formatGoFiles)
+	}
 
 	return jenny
 }

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -328,6 +328,10 @@
           "type": "boolean",
           "description": "SkipRuntime disables runtime-related code generation when enabled.\nNote: builders can NOT be generated with this flag turned on, as they\nrely on the runtime to function."
         },
+        "skip_post_formatting": {
+          "type": "boolean",
+          "description": "SkipPostFormatting disables formatting of Go files done with go imports\nafter code generation."
+        },
         "overrides_templates": {
           "items": {
             "type": "string"


### PR DESCRIPTION
If the generated Go code isn't valid, post-formatting will fail and prevent the code from being written to disk.

To make debugging these cases easier, this PR adds an option to disable this formatting.