### PR TITLE
Support defining comments in "add_object" compiler pass

### DIFF
--- a/docs/reference/schema_transformations.md
+++ b/docs/reference/schema_transformations.md
@@ -28,6 +28,7 @@ AddObject adds a new object to a schema.
 add_object:
   object: string
   as: Type
+  comments: []string
 ```
 
 ## `anonymous_structs_to_named`

--- a/internal/ast/compiler/add_object.go
+++ b/internal/ast/compiler/add_object.go
@@ -8,8 +8,9 @@ var _ Pass = (*AddObject)(nil)
 
 // AddObject adds a new object to a schema.
 type AddObject struct {
-	Object ObjectReference
-	As     ast.Type
+	Object   ObjectReference
+	As       ast.Type
+	Comments []string
 }
 
 func (pass *AddObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
@@ -26,6 +27,7 @@ func (pass *AddObject) processSchema(visitor *Visitor, schema *ast.Schema) (*ast
 	}
 
 	newObject := ast.NewObject(pass.Object.Package, pass.Object.Object, pass.As)
+	newObject.Comments = pass.Comments
 	newObject.AddToPassesTrail("AddObject[created]")
 
 	visitor.RegisterNewObject(newObject)

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -338,8 +338,9 @@ func (pass DuplicateObject) AsCompilerPass() (*compiler.DuplicateObject, error) 
 }
 
 type AddObject struct {
-	Object string // Expected format: [package].[object]
-	As     ast.Type
+	Object   string // Expected format: [package].[object]
+	As       ast.Type
+	Comments []string
 }
 
 func (pass AddObject) AsCompilerPass() (*compiler.AddObject, error) {
@@ -349,8 +350,9 @@ func (pass AddObject) AsCompilerPass() (*compiler.AddObject, error) {
 	}
 
 	return &compiler.AddObject{
-		Object: objectRef,
-		As:     pass.As,
+		Object:   objectRef,
+		As:       pass.As,
+		Comments: pass.Comments,
 	}, nil
 }
 

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -273,6 +273,12 @@
         },
         "as": {
           "$ref": "#/$defs/AstType"
+        },
+        "comments": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Objects can have comments, yet the `add_objects` compiler pass didn't support their definition.

This PR addresses that.