### PR TITLE
Cue: Constant discriminators

### DIFF
--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -330,14 +330,20 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 			constRef := field.Type.AsConstantRef()
 			t := context.ResolveRefs(ast.NewRef(constRef.ReferredPkg, constRef.ReferredType))
 
-			if !t.IsEnum() {
+			if !t.IsEnum() && !t.IsScalar() {
 				break
 			}
 
-			for _, member := range t.AsEnum().Values {
-				if member.Value == constRef.ReferenceValue {
-					defaultValue = member.Name
-					break
+			if t.IsScalar() && t.AsScalar().ScalarKind == ast.KindString {
+				defaultValue = constRef.ReferredType
+			}
+
+			if t.IsEnum() {
+				for _, member := range t.AsEnum().Values {
+					if member.Value == constRef.ReferenceValue {
+						defaultValue = member.Name
+						break
+					}
 				}
 			}
 

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -65,6 +65,8 @@ func (formatter *typeFormatter) formatTypeDeclaration(def ast.Object) string {
 		buffer.WriteString(fmt.Sprintf("type %s = %s", defName, formatter.formatType(def.Type)))
 	case ast.KindMap, ast.KindArray, ast.KindStruct, ast.KindIntersection:
 		buffer.WriteString(fmt.Sprintf("type %s %s", defName, formatter.formatType(def.Type)))
+	case ast.KindConstantRef:
+		buffer.WriteString(fmt.Sprintf("const %s = %s", defName, formatScalar(def.Type.AsConstantRef().ReferenceValue)))
 	default:
 		return fmt.Sprintf("unhandled type def kind: %s", def.Type.Kind)
 	}
@@ -271,6 +273,16 @@ func (formatter *typeFormatter) formatRef(def ast.Type, resolveBuilders bool) st
 
 func (formatter *typeFormatter) formatConstantRef(def ast.Type) string {
 	constRef := def.AsConstantRef()
+
+	obj, ok := formatter.context.LocateObject(constRef.ReferredPkg, constRef.ReferredType)
+	if !ok {
+		return "unknown"
+	}
+
+	if obj.Type.IsScalar() {
+		return string(obj.Type.AsScalar().ScalarKind)
+	}
+
 	referredPkg := formatter.packageMapper(constRef.ReferredPkg)
 	typeName := formatObjectName(constRef.ReferredType)
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -281,7 +281,7 @@ func (jenny RawTypes) constructors(object ast.Object) []ConstructorTemplate {
 			assign := ConstructorAssignmentTemplate{
 				Name:  name,
 				Type:  field.Type,
-				Value: jenny.typeFormatter.enumFromConstantRef(field.Type.AsConstantRef()),
+				Value: jenny.typeFormatter.constantRefValue(field.Type.AsConstantRef()),
 			}
 			assignments = append(assignments, assign)
 			defaultConstructorAssignments = append(defaultConstructorAssignments, assign)

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -289,7 +289,7 @@ func (jenny RawTypes) generateConstructor(context languages.Context, def ast.Obj
 
 		// values with enums that we don't want to add in the constructor
 		if field.Type.IsConstantRef() {
-			val := jenny.typeFormatter.enumFromConstantRef(field.Type.AsConstantRef())
+			val := jenny.typeFormatter.constantRefValue(field.Type.AsConstantRef())
 			assignments = append(assignments, fmt.Sprintf("    $this->%s = %s;", fieldName, val))
 			continue
 		}

--- a/internal/jennies/php/types.go
+++ b/internal/jennies/php/types.go
@@ -243,10 +243,14 @@ func (formatter *typeFormatter) formatConstantReference(def ast.Type) string {
 		return formatter.config.fullNamespaceRef(referredPkg + "\\" + formatObjectName(ref.ReferredType))
 	}
 
+	if obj.Type.IsScalar() {
+		return formatter.formatScalar(obj.Type)
+	}
+
 	return "unknown"
 }
 
-func (formatter *typeFormatter) enumFromConstantRef(def ast.ConstantReferenceType) string {
+func (formatter *typeFormatter) constantRefValue(def ast.ConstantReferenceType) string {
 	obj, ok := formatter.context.LocateObject(def.ReferredPkg, def.ReferredType)
 	if !ok {
 		return "unknown"
@@ -254,6 +258,9 @@ func (formatter *typeFormatter) enumFromConstantRef(def ast.ConstantReferenceTyp
 
 	if obj.Type.IsEnum() {
 		return formatter.formatEnumValue(obj, def)
+	}
+	if obj.Type.IsScalar() {
+		return formatter.config.fullNamespaceRef(formatPackageName(def.ReferredPkg) + "\\" + formatObjectName(def.ReferredType))
 	}
 
 	return "unknown"

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -327,6 +327,14 @@ func (formatter *typeFormatter) formatConstantReference(def ast.ConstantReferenc
 		return "unknown"
 	}
 
+	if referredObject.Type.IsScalar() {
+		if shouldSetValue {
+			return def.ReferredType
+		}
+
+		return formatter.formatScalarKind(referredObject.Type.AsScalar().ScalarKind)
+	}
+
 	if !referredObject.Type.IsEnum() {
 		return "unknown"
 	}

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -369,6 +369,10 @@ func (jenny RawTypes) defaultValueForConstantReferences(def ast.ConstantReferenc
 		return raw(jenny.typeFormatter.enums.formatValue(referredType, def.ReferenceValue))
 	}
 
+	if referredType.Type.IsScalar() {
+		return raw(def.ReferredType)
+	}
+
 	return "unknown"
 }
 

--- a/internal/jennies/typescript/types.go
+++ b/internal/jennies/typescript/types.go
@@ -318,6 +318,9 @@ func (formatter *typeFormatter) formatConstantReferences(def ast.ConstantReferen
 	if referredType.Type.IsEnum() {
 		return formatter.enums.formatValue(referredType, def.ReferenceValue)
 	}
+	if referredType.Type.IsScalar() {
+		return formatValue(def.ReferenceValue)
+	}
 
 	return "unknown"
 }

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -491,6 +491,18 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 			})), nil
 		}
 
+		if v.Kind() == cue.StringKind || v.Kind() == cue.NumberKind {
+			var referenceValue any
+			referenceValue, err = v.String()
+			if err != nil {
+				referenceValue, err = v.Int64()
+				if err != nil {
+					return ast.Type{}, errorWithCueRef(v, err.Error())
+				}
+			}
+			return ast.NewConstantReferenceType(refPkg, refType, referenceValue), nil
+		}
+
 		// ensure that referenced objects are explored (in case they're not
 		// defined within the "root" cue value given to cog as parsing input)
 		if refPkg == g.schema.Package && !g.schema.Objects.Has(refType) {

--- a/testdata/generated/constant_reference_discriminator/types_gen.go
+++ b/testdata/generated/constant_reference_discriminator/types_gen.go
@@ -1,0 +1,642 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     GoRawTypes
+
+package constant_reference_discriminator
+
+import (
+	"encoding/json"
+	cog "github.com/grafana/cog/testdata/generated/cog"
+	"errors"
+	"fmt"
+)
+
+type LayoutWithValue = GridLayoutUsingValueOrRowsLayoutUsingValue /* DisjunctionToType[disjunction → ref] */
+
+// NewLayoutWithValue creates a new LayoutWithValue object.
+func NewLayoutWithValue() *LayoutWithValue {
+	return NewGridLayoutUsingValueOrRowsLayoutUsingValue()
+}
+type GridLayoutUsingValue struct {
+    Kind string `json:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty"`
+}
+
+// NewGridLayoutUsingValue creates a new GridLayoutUsingValue object.
+func NewGridLayoutUsingValue() *GridLayoutUsingValue {
+	return &GridLayoutUsingValue{
+		Kind: GridLayoutKindType,
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutUsingValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutUsingValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "gridLayoutProperty"
+	if fields["gridLayoutProperty"] != nil {
+		if string(fields["gridLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["gridLayoutProperty"], &resource.GridLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "gridLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("GridLayoutUsingValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `GridLayoutUsingValue` objects.
+func (resource GridLayoutUsingValue) Equals(other GridLayoutUsingValue) bool {
+        if resource.Kind != other.Kind {
+            return false
+        }
+		if resource.GridLayoutProperty != other.GridLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutUsingValue` fields for violations and returns them.
+func (resource GridLayoutUsingValue) Validate() error {
+	return nil
+}
+
+
+type RowsLayoutUsingValue struct {
+    Kind string `json:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+}
+
+// NewRowsLayoutUsingValue creates a new RowsLayoutUsingValue object.
+func NewRowsLayoutUsingValue() *RowsLayoutUsingValue {
+	return &RowsLayoutUsingValue{
+		Kind: RowsLayoutKindType,
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RowsLayoutUsingValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *RowsLayoutUsingValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "rowsLayoutProperty"
+	if fields["rowsLayoutProperty"] != nil {
+		if string(fields["rowsLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["rowsLayoutProperty"], &resource.RowsLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "rowsLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("RowsLayoutUsingValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `RowsLayoutUsingValue` objects.
+func (resource RowsLayoutUsingValue) Equals(other RowsLayoutUsingValue) bool {
+        if resource.Kind != other.Kind {
+            return false
+        }
+		if resource.RowsLayoutProperty != other.RowsLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `RowsLayoutUsingValue` fields for violations and returns them.
+func (resource RowsLayoutUsingValue) Validate() error {
+	return nil
+}
+
+
+type LayoutWithoutValue = GridLayoutWithoutValueOrRowsLayoutWithoutValue /* DisjunctionToType[disjunction → ref] */
+
+// NewLayoutWithoutValue creates a new LayoutWithoutValue object.
+func NewLayoutWithoutValue() *LayoutWithoutValue {
+	return NewGridLayoutWithoutValueOrRowsLayoutWithoutValue()
+}
+type GridLayoutWithoutValue struct {
+    Kind string `json:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty"`
+}
+
+// NewGridLayoutWithoutValue creates a new GridLayoutWithoutValue object.
+func NewGridLayoutWithoutValue() *GridLayoutWithoutValue {
+	return &GridLayoutWithoutValue{
+		Kind: GridLayoutKindType,
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutWithoutValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutWithoutValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "gridLayoutProperty"
+	if fields["gridLayoutProperty"] != nil {
+		if string(fields["gridLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["gridLayoutProperty"], &resource.GridLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "gridLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("GridLayoutWithoutValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `GridLayoutWithoutValue` objects.
+func (resource GridLayoutWithoutValue) Equals(other GridLayoutWithoutValue) bool {
+        if resource.Kind != other.Kind {
+            return false
+        }
+		if resource.GridLayoutProperty != other.GridLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutWithoutValue` fields for violations and returns them.
+func (resource GridLayoutWithoutValue) Validate() error {
+	return nil
+}
+
+
+type RowsLayoutWithoutValue struct {
+    Kind string `json:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+}
+
+// NewRowsLayoutWithoutValue creates a new RowsLayoutWithoutValue object.
+func NewRowsLayoutWithoutValue() *RowsLayoutWithoutValue {
+	return &RowsLayoutWithoutValue{
+		Kind: RowsLayoutKindType,
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RowsLayoutWithoutValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *RowsLayoutWithoutValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "rowsLayoutProperty"
+	if fields["rowsLayoutProperty"] != nil {
+		if string(fields["rowsLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["rowsLayoutProperty"], &resource.RowsLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "rowsLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("RowsLayoutWithoutValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `RowsLayoutWithoutValue` objects.
+func (resource RowsLayoutWithoutValue) Equals(other RowsLayoutWithoutValue) bool {
+        if resource.Kind != other.Kind {
+            return false
+        }
+		if resource.RowsLayoutProperty != other.RowsLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `RowsLayoutWithoutValue` fields for violations and returns them.
+func (resource RowsLayoutWithoutValue) Validate() error {
+	return nil
+}
+
+
+const GridLayoutKindType = "GridLayout"
+
+const RowsLayoutKindType = "RowsLayout"
+
+// Modified by compiler pass 'DisjunctionToType[created]'
+type GridLayoutUsingValueOrRowsLayoutUsingValue struct {
+    GridLayoutUsingValue *GridLayoutUsingValue `json:"GridLayoutUsingValue,omitempty"`
+    RowsLayoutUsingValue *RowsLayoutUsingValue `json:"RowsLayoutUsingValue,omitempty"`
+}
+
+// NewGridLayoutUsingValueOrRowsLayoutUsingValue creates a new GridLayoutUsingValueOrRowsLayoutUsingValue object.
+func NewGridLayoutUsingValueOrRowsLayoutUsingValue() *GridLayoutUsingValueOrRowsLayoutUsingValue {
+	return &GridLayoutUsingValueOrRowsLayoutUsingValue{
+}
+}
+// MarshalJSON implements a custom JSON marshalling logic to encode `GridLayoutUsingValueOrRowsLayoutUsingValue` as JSON.
+func (resource GridLayoutUsingValueOrRowsLayoutUsingValue) MarshalJSON() ([]byte, error) {
+	if resource.GridLayoutUsingValue != nil {
+		return json.Marshal(resource.GridLayoutUsingValue)
+	}
+	if resource.RowsLayoutUsingValue != nil {
+		return json.Marshal(resource.RowsLayoutUsingValue)
+	}
+	return nil, fmt.Errorf("no value for disjunction of refs")
+}
+
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `GridLayoutUsingValueOrRowsLayoutUsingValue` from JSON.
+func (resource *GridLayoutUsingValueOrRowsLayoutUsingValue) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
+	parsedAsMap := make(map[string]any)
+	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
+		return err
+	}
+
+	discriminator, found := parsedAsMap["kind"]
+	if !found {
+		return errors.New("discriminator field 'kind' not found in payload")
+	}
+
+	switch discriminator {
+	case "GridLayout":
+		var gridLayoutUsingValue GridLayoutUsingValue
+		if err := json.Unmarshal(raw, &gridLayoutUsingValue); err != nil {
+			return err
+		}
+
+		resource.GridLayoutUsingValue = &gridLayoutUsingValue
+		return nil
+	case "RowsLayout":
+		var rowsLayoutUsingValue RowsLayoutUsingValue
+		if err := json.Unmarshal(raw, &rowsLayoutUsingValue); err != nil {
+			return err
+		}
+
+		resource.RowsLayoutUsingValue = &rowsLayoutUsingValue
+		return nil
+	}
+
+	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+}
+
+
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutUsingValueOrRowsLayoutUsingValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutUsingValueOrRowsLayoutUsingValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
+	parsedAsMap := make(map[string]any)
+	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
+		return err
+	}
+
+	discriminator, found := parsedAsMap["kind"]
+	if !found {
+		return fmt.Errorf("discriminator field 'kind' not found in payload")
+	}
+
+	switch discriminator {
+		case "GridLayout":
+		gridLayoutUsingValue := &GridLayoutUsingValue{}
+		if err := gridLayoutUsingValue.UnmarshalJSONStrict(raw); err != nil {
+			return err
+		}
+
+		resource.GridLayoutUsingValue = gridLayoutUsingValue
+		return nil
+		case "RowsLayout":
+		rowsLayoutUsingValue := &RowsLayoutUsingValue{}
+		if err := rowsLayoutUsingValue.UnmarshalJSONStrict(raw); err != nil {
+			return err
+		}
+
+		resource.RowsLayoutUsingValue = rowsLayoutUsingValue
+		return nil
+	}
+
+	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+}
+
+// Equals tests the equality of two `GridLayoutUsingValueOrRowsLayoutUsingValue` objects.
+func (resource GridLayoutUsingValueOrRowsLayoutUsingValue) Equals(other GridLayoutUsingValueOrRowsLayoutUsingValue) bool {
+		if resource.GridLayoutUsingValue == nil && other.GridLayoutUsingValue != nil || resource.GridLayoutUsingValue != nil && other.GridLayoutUsingValue == nil {
+			return false
+		}
+
+		if resource.GridLayoutUsingValue != nil {
+		if !resource.GridLayoutUsingValue.Equals(*other.GridLayoutUsingValue) {
+			return false
+		}
+		}
+		if resource.RowsLayoutUsingValue == nil && other.RowsLayoutUsingValue != nil || resource.RowsLayoutUsingValue != nil && other.RowsLayoutUsingValue == nil {
+			return false
+		}
+
+		if resource.RowsLayoutUsingValue != nil {
+		if !resource.RowsLayoutUsingValue.Equals(*other.RowsLayoutUsingValue) {
+			return false
+		}
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutUsingValueOrRowsLayoutUsingValue` fields for violations and returns them.
+func (resource GridLayoutUsingValueOrRowsLayoutUsingValue) Validate() error {
+	var errs cog.BuildErrors
+		if resource.GridLayoutUsingValue != nil {
+		if err := resource.GridLayoutUsingValue.Validate(); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("GridLayoutUsingValue", err)...)
+		}
+		}
+		if resource.RowsLayoutUsingValue != nil {
+		if err := resource.RowsLayoutUsingValue.Validate(); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("RowsLayoutUsingValue", err)...)
+		}
+		}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Modified by compiler pass 'DisjunctionToType[created]'
+type GridLayoutWithoutValueOrRowsLayoutWithoutValue struct {
+    GridLayoutWithoutValue *GridLayoutWithoutValue `json:"GridLayoutWithoutValue,omitempty"`
+    RowsLayoutWithoutValue *RowsLayoutWithoutValue `json:"RowsLayoutWithoutValue,omitempty"`
+}
+
+// NewGridLayoutWithoutValueOrRowsLayoutWithoutValue creates a new GridLayoutWithoutValueOrRowsLayoutWithoutValue object.
+func NewGridLayoutWithoutValueOrRowsLayoutWithoutValue() *GridLayoutWithoutValueOrRowsLayoutWithoutValue {
+	return &GridLayoutWithoutValueOrRowsLayoutWithoutValue{
+}
+}
+// MarshalJSON implements a custom JSON marshalling logic to encode `GridLayoutWithoutValueOrRowsLayoutWithoutValue` as JSON.
+func (resource GridLayoutWithoutValueOrRowsLayoutWithoutValue) MarshalJSON() ([]byte, error) {
+	if resource.GridLayoutWithoutValue != nil {
+		return json.Marshal(resource.GridLayoutWithoutValue)
+	}
+	if resource.RowsLayoutWithoutValue != nil {
+		return json.Marshal(resource.RowsLayoutWithoutValue)
+	}
+	return nil, fmt.Errorf("no value for disjunction of refs")
+}
+
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode `GridLayoutWithoutValueOrRowsLayoutWithoutValue` from JSON.
+func (resource *GridLayoutWithoutValueOrRowsLayoutWithoutValue) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+
+	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
+	parsedAsMap := make(map[string]any)
+	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
+		return err
+	}
+
+	discriminator, found := parsedAsMap["kind"]
+	if !found {
+		return errors.New("discriminator field 'kind' not found in payload")
+	}
+
+	switch discriminator {
+	case "GridLayout":
+		var gridLayoutWithoutValue GridLayoutWithoutValue
+		if err := json.Unmarshal(raw, &gridLayoutWithoutValue); err != nil {
+			return err
+		}
+
+		resource.GridLayoutWithoutValue = &gridLayoutWithoutValue
+		return nil
+	case "RowsLayout":
+		var rowsLayoutWithoutValue RowsLayoutWithoutValue
+		if err := json.Unmarshal(raw, &rowsLayoutWithoutValue); err != nil {
+			return err
+		}
+
+		resource.RowsLayoutWithoutValue = &rowsLayoutWithoutValue
+		return nil
+	}
+
+	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+}
+
+
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutWithoutValueOrRowsLayoutWithoutValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutWithoutValueOrRowsLayoutWithoutValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	// FIXME: this is wasteful, we need to find a more efficient way to unmarshal this.
+	parsedAsMap := make(map[string]any)
+	if err := json.Unmarshal(raw, &parsedAsMap); err != nil {
+		return err
+	}
+
+	discriminator, found := parsedAsMap["kind"]
+	if !found {
+		return fmt.Errorf("discriminator field 'kind' not found in payload")
+	}
+
+	switch discriminator {
+		case "GridLayout":
+		gridLayoutWithoutValue := &GridLayoutWithoutValue{}
+		if err := gridLayoutWithoutValue.UnmarshalJSONStrict(raw); err != nil {
+			return err
+		}
+
+		resource.GridLayoutWithoutValue = gridLayoutWithoutValue
+		return nil
+		case "RowsLayout":
+		rowsLayoutWithoutValue := &RowsLayoutWithoutValue{}
+		if err := rowsLayoutWithoutValue.UnmarshalJSONStrict(raw); err != nil {
+			return err
+		}
+
+		resource.RowsLayoutWithoutValue = rowsLayoutWithoutValue
+		return nil
+	}
+
+	return fmt.Errorf("could not unmarshal resource with `kind = %v`", discriminator)
+}
+
+// Equals tests the equality of two `GridLayoutWithoutValueOrRowsLayoutWithoutValue` objects.
+func (resource GridLayoutWithoutValueOrRowsLayoutWithoutValue) Equals(other GridLayoutWithoutValueOrRowsLayoutWithoutValue) bool {
+		if resource.GridLayoutWithoutValue == nil && other.GridLayoutWithoutValue != nil || resource.GridLayoutWithoutValue != nil && other.GridLayoutWithoutValue == nil {
+			return false
+		}
+
+		if resource.GridLayoutWithoutValue != nil {
+		if !resource.GridLayoutWithoutValue.Equals(*other.GridLayoutWithoutValue) {
+			return false
+		}
+		}
+		if resource.RowsLayoutWithoutValue == nil && other.RowsLayoutWithoutValue != nil || resource.RowsLayoutWithoutValue != nil && other.RowsLayoutWithoutValue == nil {
+			return false
+		}
+
+		if resource.RowsLayoutWithoutValue != nil {
+		if !resource.RowsLayoutWithoutValue.Equals(*other.RowsLayoutWithoutValue) {
+			return false
+		}
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutWithoutValueOrRowsLayoutWithoutValue` fields for violations and returns them.
+func (resource GridLayoutWithoutValueOrRowsLayoutWithoutValue) Validate() error {
+	var errs cog.BuildErrors
+		if resource.GridLayoutWithoutValue != nil {
+		if err := resource.GridLayoutWithoutValue.Validate(); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("GridLayoutWithoutValue", err)...)
+		}
+		}
+		if resource.RowsLayoutWithoutValue != nil {
+		if err := resource.RowsLayoutWithoutValue.Validate(); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("RowsLayoutWithoutValue", err)...)
+		}
+		}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+

--- a/testdata/generated/src/main/java/com/grafana/foundation/cog/Builder.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/cog/Builder.java
@@ -1,0 +1,10 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRuntime
+
+package com.grafana.foundation.cog;
+
+public interface Builder<T> {
+    public T build();
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/Constants.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/Constants.java
@@ -1,0 +1,11 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+public class Constants {
+    public static final String GridLayoutKindType = "GridLayout";
+    public static final String RowsLayoutKindType = "RowsLayout";
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/GridLayoutUsingValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/GridLayoutUsingValue.java
@@ -1,0 +1,19 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class GridLayoutUsingValue {
+    public String kind;
+    public String gridLayoutProperty;
+    public GridLayoutUsingValue() {
+        this.kind = GridLayoutKindType;
+    }
+    public GridLayoutUsingValue(String gridLayoutProperty) {
+        this.kind = GridLayoutKindType;
+        this.gridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/GridLayoutWithoutValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/GridLayoutWithoutValue.java
@@ -1,0 +1,19 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class GridLayoutWithoutValue {
+    public String kind;
+    public String gridLayoutProperty;
+    public GridLayoutWithoutValue() {
+        this.kind = GridLayoutKindType;
+    }
+    public GridLayoutWithoutValue(String gridLayoutProperty) {
+        this.kind = GridLayoutKindType;
+        this.gridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/LayoutWithValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/LayoutWithValue.java
@@ -1,0 +1,23 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class LayoutWithValue {
+    protected GridLayoutUsingValue gridLayoutUsingValue;
+    protected RowsLayoutUsingValue rowsLayoutUsingValue;
+    protected LayoutWithValue() {}
+    public static LayoutWithValue createGridLayoutUsingValue(GridLayoutUsingValue gridLayoutUsingValue) {
+        LayoutWithValue layoutWithValue = new LayoutWithValue();
+        layoutWithValue.gridLayoutUsingValue = gridLayoutUsingValue;
+        return layoutWithValue;
+    }
+    public static LayoutWithValue createRowsLayoutUsingValue(RowsLayoutUsingValue rowsLayoutUsingValue) {
+        LayoutWithValue layoutWithValue = new LayoutWithValue();
+        layoutWithValue.rowsLayoutUsingValue = rowsLayoutUsingValue;
+        return layoutWithValue;
+    }
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/LayoutWithoutValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/LayoutWithoutValue.java
@@ -1,0 +1,23 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class LayoutWithoutValue {
+    protected GridLayoutWithoutValue gridLayoutWithoutValue;
+    protected RowsLayoutWithoutValue rowsLayoutWithoutValue;
+    protected LayoutWithoutValue() {}
+    public static LayoutWithoutValue createGridLayoutWithoutValue(GridLayoutWithoutValue gridLayoutWithoutValue) {
+        LayoutWithoutValue layoutWithoutValue = new LayoutWithoutValue();
+        layoutWithoutValue.gridLayoutWithoutValue = gridLayoutWithoutValue;
+        return layoutWithoutValue;
+    }
+    public static LayoutWithoutValue createRowsLayoutWithoutValue(RowsLayoutWithoutValue rowsLayoutWithoutValue) {
+        LayoutWithoutValue layoutWithoutValue = new LayoutWithoutValue();
+        layoutWithoutValue.rowsLayoutWithoutValue = rowsLayoutWithoutValue;
+        return layoutWithoutValue;
+    }
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/RowsLayoutUsingValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/RowsLayoutUsingValue.java
@@ -1,0 +1,19 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class RowsLayoutUsingValue {
+    public String kind;
+    public String rowsLayoutProperty;
+    public RowsLayoutUsingValue() {
+        this.kind = RowsLayoutKindType;
+    }
+    public RowsLayoutUsingValue(String rowsLayoutProperty) {
+        this.kind = RowsLayoutKindType;
+        this.rowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/RowsLayoutWithoutValue.java
+++ b/testdata/generated/src/main/java/com/grafana/foundation/constant_reference_discriminator/RowsLayoutWithoutValue.java
@@ -1,0 +1,19 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+//
+// Using jennies:
+//     JavaRawTypes
+
+package com.grafana.foundation.constant_reference_discriminator;
+
+
+public class RowsLayoutWithoutValue {
+    public String kind;
+    public String rowsLayoutProperty;
+    public RowsLayoutWithoutValue() {
+        this.kind = RowsLayoutKindType;
+    }
+    public RowsLayoutWithoutValue(String rowsLayoutProperty) {
+        this.kind = RowsLayoutKindType;
+        this.rowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/GoRawTypes/constant_reference_discriminator/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/GoRawTypes/constant_reference_discriminator/types_gen.go
@@ -1,0 +1,327 @@
+package constant_reference_discriminator
+
+import (
+	"encoding/json"
+	cog "github.com/grafana/cog/generated/cog"
+	"errors"
+	"fmt"
+)
+
+type LayoutWithValue any
+
+type GridLayoutUsingValue struct {
+    Kind string `json:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty"`
+}
+
+// NewGridLayoutUsingValue creates a new GridLayoutUsingValue object.
+func NewGridLayoutUsingValue() *GridLayoutUsingValue {
+	return &GridLayoutUsingValue{
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutUsingValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutUsingValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "gridLayoutProperty"
+	if fields["gridLayoutProperty"] != nil {
+		if string(fields["gridLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["gridLayoutProperty"], &resource.GridLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "gridLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("GridLayoutUsingValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `GridLayoutUsingValue` objects.
+func (resource GridLayoutUsingValue) Equals(other GridLayoutUsingValue) bool {
+		if resource.Kind != other.Kind {
+			return false
+		}
+		if resource.GridLayoutProperty != other.GridLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutUsingValue` fields for violations and returns them.
+func (resource GridLayoutUsingValue) Validate() error {
+	return nil
+}
+
+
+const GridLayoutKindType = "GridLayout"
+
+type RowsLayoutUsingValue struct {
+    Kind string `json:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+}
+
+// NewRowsLayoutUsingValue creates a new RowsLayoutUsingValue object.
+func NewRowsLayoutUsingValue() *RowsLayoutUsingValue {
+	return &RowsLayoutUsingValue{
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RowsLayoutUsingValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *RowsLayoutUsingValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "rowsLayoutProperty"
+	if fields["rowsLayoutProperty"] != nil {
+		if string(fields["rowsLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["rowsLayoutProperty"], &resource.RowsLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "rowsLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("RowsLayoutUsingValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `RowsLayoutUsingValue` objects.
+func (resource RowsLayoutUsingValue) Equals(other RowsLayoutUsingValue) bool {
+		if resource.Kind != other.Kind {
+			return false
+		}
+		if resource.RowsLayoutProperty != other.RowsLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `RowsLayoutUsingValue` fields for violations and returns them.
+func (resource RowsLayoutUsingValue) Validate() error {
+	return nil
+}
+
+
+const RowsLayoutKindType = "RowsLayout"
+
+type LayoutWithoutValue any
+
+type GridLayoutWithoutValue struct {
+    Kind string `json:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty"`
+}
+
+// NewGridLayoutWithoutValue creates a new GridLayoutWithoutValue object.
+func NewGridLayoutWithoutValue() *GridLayoutWithoutValue {
+	return &GridLayoutWithoutValue{
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `GridLayoutWithoutValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *GridLayoutWithoutValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "gridLayoutProperty"
+	if fields["gridLayoutProperty"] != nil {
+		if string(fields["gridLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["gridLayoutProperty"], &resource.GridLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "gridLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("gridLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("GridLayoutWithoutValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `GridLayoutWithoutValue` objects.
+func (resource GridLayoutWithoutValue) Equals(other GridLayoutWithoutValue) bool {
+		if resource.Kind != other.Kind {
+			return false
+		}
+		if resource.GridLayoutProperty != other.GridLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `GridLayoutWithoutValue` fields for violations and returns them.
+func (resource GridLayoutWithoutValue) Validate() error {
+	return nil
+}
+
+
+type RowsLayoutWithoutValue struct {
+    Kind string `json:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+}
+
+// NewRowsLayoutWithoutValue creates a new RowsLayoutWithoutValue object.
+func NewRowsLayoutWithoutValue() *RowsLayoutWithoutValue {
+	return &RowsLayoutWithoutValue{
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RowsLayoutWithoutValue` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *RowsLayoutWithoutValue) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "kind"
+	if fields["kind"] != nil {
+		if string(fields["kind"]) != "null" {
+			if err := json.Unmarshal(fields["kind"], &resource.Kind); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("kind", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "kind")
+	} else {errs = append(errs, cog.MakeBuildErrors("kind", errors.New("required field is missing from input"))...)
+	}
+	// Field "rowsLayoutProperty"
+	if fields["rowsLayoutProperty"] != nil {
+		if string(fields["rowsLayoutProperty"]) != "null" {
+			if err := json.Unmarshal(fields["rowsLayoutProperty"], &resource.RowsLayoutProperty); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "rowsLayoutProperty")
+	} else {errs = append(errs, cog.MakeBuildErrors("rowsLayoutProperty", errors.New("required field is missing from input"))...)
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("RowsLayoutWithoutValue", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `RowsLayoutWithoutValue` objects.
+func (resource RowsLayoutWithoutValue) Equals(other RowsLayoutWithoutValue) bool {
+		if resource.Kind != other.Kind {
+			return false
+		}
+		if resource.RowsLayoutProperty != other.RowsLayoutProperty {
+			return false
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `RowsLayoutWithoutValue` fields for violations and returns them.
+func (resource RowsLayoutWithoutValue) Validate() error {
+	return nil
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JSONSchema/constant_reference_discriminator.jsonschema.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JSONSchema/constant_reference_discriminator.jsonschema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "LayoutWithValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GridLayoutUsingValue"
+        },
+        {
+          "$ref": "#/definitions/RowsLayoutUsingValue"
+        }
+      ]
+    },
+    "GridLayoutUsingValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "gridLayoutProperty"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/GridLayoutKindType"
+        },
+        "gridLayoutProperty": {
+          "type": "string"
+        }
+      }
+    },
+    "GridLayoutKindType": {
+      "type": "string",
+      "const": "GridLayout"
+    },
+    "RowsLayoutUsingValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "rowsLayoutProperty"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/RowsLayoutKindType"
+        },
+        "rowsLayoutProperty": {
+          "type": "string"
+        }
+      }
+    },
+    "RowsLayoutKindType": {
+      "type": "string",
+      "const": "RowsLayout"
+    },
+    "LayoutWithoutValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GridLayoutWithoutValue"
+        },
+        {
+          "$ref": "#/definitions/RowsLayoutWithoutValue"
+        }
+      ]
+    },
+    "GridLayoutWithoutValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "gridLayoutProperty"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/GridLayoutKindType"
+        },
+        "gridLayoutProperty": {
+          "type": "string"
+        }
+      }
+    },
+    "RowsLayoutWithoutValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "rowsLayoutProperty"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/RowsLayoutKindType"
+        },
+        "rowsLayoutProperty": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/Constants.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/Constants.java
@@ -1,0 +1,6 @@
+package constant_reference_discriminator;
+
+public class Constants {
+    public static final String GridLayoutKindType = "GridLayout";
+    public static final String RowsLayoutKindType = "RowsLayout";
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutUsingValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutUsingValue.java
@@ -5,6 +5,7 @@ public class GridLayoutUsingValue {
     public String kind;
     public String gridLayoutProperty;
     public GridLayoutUsingValue() {
+        this.kind = GridLayoutKindType;
     }
     public GridLayoutUsingValue(String gridLayoutProperty) {
         this.kind = GridLayoutKindType;

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutUsingValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutUsingValue.java
@@ -1,0 +1,13 @@
+package constant_reference_discriminator;
+
+
+public class GridLayoutUsingValue {
+    public String kind;
+    public String gridLayoutProperty;
+    public GridLayoutUsingValue() {
+    }
+    public GridLayoutUsingValue(String gridLayoutProperty) {
+        this.kind = GridLayoutKindType;
+        this.gridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutWithoutValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutWithoutValue.java
@@ -1,0 +1,13 @@
+package constant_reference_discriminator;
+
+
+public class GridLayoutWithoutValue {
+    public String kind;
+    public String gridLayoutProperty;
+    public GridLayoutWithoutValue() {
+    }
+    public GridLayoutWithoutValue(String gridLayoutProperty) {
+        this.kind = GridLayoutKindType;
+        this.gridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutWithoutValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/GridLayoutWithoutValue.java
@@ -5,6 +5,7 @@ public class GridLayoutWithoutValue {
     public String kind;
     public String gridLayoutProperty;
     public GridLayoutWithoutValue() {
+        this.kind = GridLayoutKindType;
     }
     public GridLayoutWithoutValue(String gridLayoutProperty) {
         this.kind = GridLayoutKindType;

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/LayoutWithValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/LayoutWithValue.java
@@ -1,0 +1,18 @@
+package constant_reference_discriminator;
+
+
+public class LayoutWithValue {
+    protected GridLayoutUsingValue gridLayoutUsingValue;
+    protected RowsLayoutUsingValue rowsLayoutUsingValue;
+    protected LayoutWithValue() {}
+    public static LayoutWithValue createGridLayoutUsingValue(GridLayoutUsingValue gridLayoutUsingValue) {
+        LayoutWithValue layoutWithValue = new LayoutWithValue();
+        layoutWithValue.gridLayoutUsingValue = gridLayoutUsingValue;
+        return layoutWithValue;
+    }
+    public static LayoutWithValue createRowsLayoutUsingValue(RowsLayoutUsingValue rowsLayoutUsingValue) {
+        LayoutWithValue layoutWithValue = new LayoutWithValue();
+        layoutWithValue.rowsLayoutUsingValue = rowsLayoutUsingValue;
+        return layoutWithValue;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/LayoutWithoutValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/LayoutWithoutValue.java
@@ -1,0 +1,18 @@
+package constant_reference_discriminator;
+
+
+public class LayoutWithoutValue {
+    protected GridLayoutWithoutValue gridLayoutWithoutValue;
+    protected RowsLayoutWithoutValue rowsLayoutWithoutValue;
+    protected LayoutWithoutValue() {}
+    public static LayoutWithoutValue createGridLayoutWithoutValue(GridLayoutWithoutValue gridLayoutWithoutValue) {
+        LayoutWithoutValue layoutWithoutValue = new LayoutWithoutValue();
+        layoutWithoutValue.gridLayoutWithoutValue = gridLayoutWithoutValue;
+        return layoutWithoutValue;
+    }
+    public static LayoutWithoutValue createRowsLayoutWithoutValue(RowsLayoutWithoutValue rowsLayoutWithoutValue) {
+        LayoutWithoutValue layoutWithoutValue = new LayoutWithoutValue();
+        layoutWithoutValue.rowsLayoutWithoutValue = rowsLayoutWithoutValue;
+        return layoutWithoutValue;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutUsingValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutUsingValue.java
@@ -1,0 +1,13 @@
+package constant_reference_discriminator;
+
+
+public class RowsLayoutUsingValue {
+    public String kind;
+    public String rowsLayoutProperty;
+    public RowsLayoutUsingValue() {
+    }
+    public RowsLayoutUsingValue(String rowsLayoutProperty) {
+        this.kind = RowsLayoutKindType;
+        this.rowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutUsingValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutUsingValue.java
@@ -5,6 +5,7 @@ public class RowsLayoutUsingValue {
     public String kind;
     public String rowsLayoutProperty;
     public RowsLayoutUsingValue() {
+        this.kind = RowsLayoutKindType;
     }
     public RowsLayoutUsingValue(String rowsLayoutProperty) {
         this.kind = RowsLayoutKindType;

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutWithoutValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutWithoutValue.java
@@ -1,0 +1,13 @@
+package constant_reference_discriminator;
+
+
+public class RowsLayoutWithoutValue {
+    public String kind;
+    public String rowsLayoutProperty;
+    public RowsLayoutWithoutValue() {
+    }
+    public RowsLayoutWithoutValue(String rowsLayoutProperty) {
+        this.kind = RowsLayoutKindType;
+        this.rowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutWithoutValue.java
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JavaRawTypes/constant_reference_discriminator/RowsLayoutWithoutValue.java
@@ -5,6 +5,7 @@ public class RowsLayoutWithoutValue {
     public String kind;
     public String rowsLayoutProperty;
     public RowsLayoutWithoutValue() {
+        this.kind = RowsLayoutKindType;
     }
     public RowsLayoutWithoutValue(String rowsLayoutProperty) {
         this.kind = RowsLayoutKindType;

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/OpenAPI/constant_reference_discriminator.openapi.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/OpenAPI/constant_reference_discriminator.openapi.json
@@ -1,0 +1,106 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "constant_reference_discriminator",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "LayoutWithValue": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/GridLayoutUsingValue"
+          },
+          {
+            "$ref": "#/components/schemas/RowsLayoutUsingValue"
+          }
+        ]
+      },
+      "GridLayoutUsingValue": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "gridLayoutProperty"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/GridLayoutKindType"
+          },
+          "gridLayoutProperty": {
+            "type": "string"
+          }
+        }
+      },
+      "GridLayoutKindType": {
+        "type": "string",
+        "const": "GridLayout"
+      },
+      "RowsLayoutUsingValue": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "rowsLayoutProperty"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/RowsLayoutKindType"
+          },
+          "rowsLayoutProperty": {
+            "type": "string"
+          }
+        }
+      },
+      "RowsLayoutKindType": {
+        "type": "string",
+        "const": "RowsLayout"
+      },
+      "LayoutWithoutValue": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/GridLayoutWithoutValue"
+          },
+          {
+            "$ref": "#/components/schemas/RowsLayoutWithoutValue"
+          }
+        ]
+      },
+      "GridLayoutWithoutValue": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "gridLayoutProperty"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/GridLayoutKindType"
+          },
+          "gridLayoutProperty": {
+            "type": "string"
+          }
+        }
+      },
+      "RowsLayoutWithoutValue": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "rowsLayoutProperty"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/RowsLayoutKindType"
+          },
+          "rowsLayoutProperty": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/Constants.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/Constants.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceDiscriminator;
+
+final class Constants
+{
+    const GRID_LAYOUT_KIND_TYPE = "GridLayout";
+    const ROWS_LAYOUT_KIND_TYPE = "RowsLayout";
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutUsingValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutUsingValue.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceDiscriminator;
+
+class GridLayoutUsingValue implements \JsonSerializable
+{
+    public string $kind;
+
+    public string $gridLayoutProperty;
+
+    /**
+     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType|null $kind
+     * @param string|null $gridLayoutProperty
+     */
+    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType $kind = null, ?string $gridLayoutProperty = null)
+    {
+        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
+        $this->gridLayoutProperty = $gridLayoutProperty ?: "";
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        /** @var array{kind?: string, gridLayoutProperty?: string} $inputData */
+        $data = $inputData;
+        return new self(
+            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
+            gridLayoutProperty: $data["gridLayoutProperty"] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            "kind" => $this->kind,
+            "gridLayoutProperty" => $this->gridLayoutProperty,
+        ];
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutUsingValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutUsingValue.php
@@ -9,12 +9,11 @@ class GridLayoutUsingValue implements \JsonSerializable
     public string $gridLayoutProperty;
 
     /**
-     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType|null $kind
      * @param string|null $gridLayoutProperty
      */
-    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType $kind = null, ?string $gridLayoutProperty = null)
+    public function __construct(?string $gridLayoutProperty = null)
     {
-        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
+        $this->kind = \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
         $this->gridLayoutProperty = $gridLayoutProperty ?: "";
     }
 
@@ -23,10 +22,9 @@ class GridLayoutUsingValue implements \JsonSerializable
      */
     public static function fromArray(array $inputData): self
     {
-        /** @var array{kind?: string, gridLayoutProperty?: string} $inputData */
+        /** @var array{kind?: "GridLayout", gridLayoutProperty?: string} $inputData */
         $data = $inputData;
         return new self(
-            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
             gridLayoutProperty: $data["gridLayoutProperty"] ?? null,
         );
     }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutWithoutValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutWithoutValue.php
@@ -9,12 +9,11 @@ class GridLayoutWithoutValue implements \JsonSerializable
     public string $gridLayoutProperty;
 
     /**
-     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType|null $kind
      * @param string|null $gridLayoutProperty
      */
-    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType $kind = null, ?string $gridLayoutProperty = null)
+    public function __construct(?string $gridLayoutProperty = null)
     {
-        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
+        $this->kind = \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
         $this->gridLayoutProperty = $gridLayoutProperty ?: "";
     }
 
@@ -23,10 +22,9 @@ class GridLayoutWithoutValue implements \JsonSerializable
      */
     public static function fromArray(array $inputData): self
     {
-        /** @var array{kind?: string, gridLayoutProperty?: string} $inputData */
+        /** @var array{kind?: "GridLayout", gridLayoutProperty?: string} $inputData */
         $data = $inputData;
         return new self(
-            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
             gridLayoutProperty: $data["gridLayoutProperty"] ?? null,
         );
     }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutWithoutValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/GridLayoutWithoutValue.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceDiscriminator;
+
+class GridLayoutWithoutValue implements \JsonSerializable
+{
+    public string $kind;
+
+    public string $gridLayoutProperty;
+
+    /**
+     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType|null $kind
+     * @param string|null $gridLayoutProperty
+     */
+    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType $kind = null, ?string $gridLayoutProperty = null)
+    {
+        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\GridLayoutKindType;
+        $this->gridLayoutProperty = $gridLayoutProperty ?: "";
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        /** @var array{kind?: string, gridLayoutProperty?: string} $inputData */
+        $data = $inputData;
+        return new self(
+            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
+            gridLayoutProperty: $data["gridLayoutProperty"] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            "kind" => $this->kind,
+            "gridLayoutProperty" => $this->gridLayoutProperty,
+        ];
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutUsingValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutUsingValue.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceDiscriminator;
+
+class RowsLayoutUsingValue implements \JsonSerializable
+{
+    public string $kind;
+
+    public string $rowsLayoutProperty;
+
+    /**
+     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType|null $kind
+     * @param string|null $rowsLayoutProperty
+     */
+    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType $kind = null, ?string $rowsLayoutProperty = null)
+    {
+        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
+        $this->rowsLayoutProperty = $rowsLayoutProperty ?: "";
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        /** @var array{kind?: string, rowsLayoutProperty?: string} $inputData */
+        $data = $inputData;
+        return new self(
+            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
+            rowsLayoutProperty: $data["rowsLayoutProperty"] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            "kind" => $this->kind,
+            "rowsLayoutProperty" => $this->rowsLayoutProperty,
+        ];
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutUsingValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutUsingValue.php
@@ -9,12 +9,11 @@ class RowsLayoutUsingValue implements \JsonSerializable
     public string $rowsLayoutProperty;
 
     /**
-     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType|null $kind
      * @param string|null $rowsLayoutProperty
      */
-    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType $kind = null, ?string $rowsLayoutProperty = null)
+    public function __construct(?string $rowsLayoutProperty = null)
     {
-        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
+        $this->kind = \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
         $this->rowsLayoutProperty = $rowsLayoutProperty ?: "";
     }
 
@@ -23,10 +22,9 @@ class RowsLayoutUsingValue implements \JsonSerializable
      */
     public static function fromArray(array $inputData): self
     {
-        /** @var array{kind?: string, rowsLayoutProperty?: string} $inputData */
+        /** @var array{kind?: "RowsLayout", rowsLayoutProperty?: string} $inputData */
         $data = $inputData;
         return new self(
-            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
             rowsLayoutProperty: $data["rowsLayoutProperty"] ?? null,
         );
     }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceDiscriminator;
+
+class RowsLayoutWithoutValue implements \JsonSerializable
+{
+    public string $kind;
+
+    public string $rowsLayoutProperty;
+
+    /**
+     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType|null $kind
+     * @param string|null $rowsLayoutProperty
+     */
+    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType $kind = null, ?string $rowsLayoutProperty = null)
+    {
+        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
+        $this->rowsLayoutProperty = $rowsLayoutProperty ?: "";
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        /** @var array{kind?: string, rowsLayoutProperty?: string} $inputData */
+        $data = $inputData;
+        return new self(
+            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
+            rowsLayoutProperty: $data["rowsLayoutProperty"] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            "kind" => $this->kind,
+            "rowsLayoutProperty" => $this->rowsLayoutProperty,
+        ];
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.php
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PHPRawTypes/src/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.php
@@ -9,12 +9,11 @@ class RowsLayoutWithoutValue implements \JsonSerializable
     public string $rowsLayoutProperty;
 
     /**
-     * @param \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType|null $kind
      * @param string|null $rowsLayoutProperty
      */
-    public function __construct(?\Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType $kind = null, ?string $rowsLayoutProperty = null)
+    public function __construct(?string $rowsLayoutProperty = null)
     {
-        $this->kind = $kind ?: \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
+        $this->kind = \Grafana\Foundation\ConstantReferenceDiscriminator\RowsLayoutKindType;
         $this->rowsLayoutProperty = $rowsLayoutProperty ?: "";
     }
 
@@ -23,10 +22,9 @@ class RowsLayoutWithoutValue implements \JsonSerializable
      */
     public static function fromArray(array $inputData): self
     {
-        /** @var array{kind?: string, rowsLayoutProperty?: string} $inputData */
+        /** @var array{kind?: "RowsLayout", rowsLayoutProperty?: string} $inputData */
         $data = $inputData;
         return new self(
-            kind: isset($data["kind"]) ? /* ref to a non-struct, non-enum, this should have been inlined */ (function(array $input) { return $input; })($data["kind"]) : null,
             rowsLayoutProperty: $data["rowsLayoutProperty"] ?? null,
         );
     }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PythonRawTypes/models/constant_reference_discriminator.py
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PythonRawTypes/models/constant_reference_discriminator.py
@@ -5,11 +5,11 @@ LayoutWithValue: typing.TypeAlias = typing.Union['GridLayoutUsingValue', 'RowsLa
 
 
 class GridLayoutUsingValue:
-    kind: typing.Literal["GridLayout"]
+    kind: str
     grid_layout_property: str
 
-    def __init__(self, kind: typing.Optional[typing.Literal["GridLayout"]] = None, grid_layout_property: str = ""):
-        self.kind = kind if kind is not None else GridLayoutKindType
+    def __init__(self, grid_layout_property: str = ""):
+        self.kind = GridLayoutKindType
         self.grid_layout_property = grid_layout_property
 
     def to_json(self) -> dict[str, object]:
@@ -23,23 +23,18 @@ class GridLayoutUsingValue:
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
         args: dict[str, typing.Any] = {}
         
-        if "kind" in data:
-            args["kind"] = data["kind"]
         if "gridLayoutProperty" in data:
             args["grid_layout_property"] = data["gridLayoutProperty"]        
 
         return cls(**args)
 
 
-GridLayoutKindType: typing.Literal["GridLayout"] = "GridLayout"
-
-
 class RowsLayoutUsingValue:
-    kind: typing.Literal["RowsLayout"]
+    kind: str
     rows_layout_property: str
 
-    def __init__(self, kind: typing.Optional[typing.Literal["RowsLayout"]] = None, rows_layout_property: str = ""):
-        self.kind = kind if kind is not None else RowsLayoutKindType
+    def __init__(self, rows_layout_property: str = ""):
+        self.kind = RowsLayoutKindType
         self.rows_layout_property = rows_layout_property
 
     def to_json(self) -> dict[str, object]:
@@ -53,26 +48,21 @@ class RowsLayoutUsingValue:
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
         args: dict[str, typing.Any] = {}
         
-        if "kind" in data:
-            args["kind"] = data["kind"]
         if "rowsLayoutProperty" in data:
             args["rows_layout_property"] = data["rowsLayoutProperty"]        
 
         return cls(**args)
 
 
-RowsLayoutKindType: typing.Literal["RowsLayout"] = "RowsLayout"
-
-
 LayoutWithoutValue: typing.TypeAlias = typing.Union['GridLayoutWithoutValue', 'RowsLayoutWithoutValue']
 
 
 class GridLayoutWithoutValue:
-    kind: typing.Literal["GridLayout"]
+    kind: str
     grid_layout_property: str
 
-    def __init__(self, kind: typing.Optional[typing.Literal["GridLayout"]] = None, grid_layout_property: str = ""):
-        self.kind = kind if kind is not None else GridLayoutKindType
+    def __init__(self, grid_layout_property: str = ""):
+        self.kind = GridLayoutKindType
         self.grid_layout_property = grid_layout_property
 
     def to_json(self) -> dict[str, object]:
@@ -86,8 +76,6 @@ class GridLayoutWithoutValue:
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
         args: dict[str, typing.Any] = {}
         
-        if "kind" in data:
-            args["kind"] = data["kind"]
         if "gridLayoutProperty" in data:
             args["grid_layout_property"] = data["gridLayoutProperty"]        
 
@@ -95,11 +83,11 @@ class GridLayoutWithoutValue:
 
 
 class RowsLayoutWithoutValue:
-    kind: typing.Literal["RowsLayout"]
+    kind: str
     rows_layout_property: str
 
-    def __init__(self, kind: typing.Optional[typing.Literal["RowsLayout"]] = None, rows_layout_property: str = ""):
-        self.kind = kind if kind is not None else RowsLayoutKindType
+    def __init__(self, rows_layout_property: str = ""):
+        self.kind = RowsLayoutKindType
         self.rows_layout_property = rows_layout_property
 
     def to_json(self) -> dict[str, object]:
@@ -113,9 +101,13 @@ class RowsLayoutWithoutValue:
     def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
         args: dict[str, typing.Any] = {}
         
-        if "kind" in data:
-            args["kind"] = data["kind"]
         if "rowsLayoutProperty" in data:
             args["rows_layout_property"] = data["rowsLayoutProperty"]        
 
         return cls(**args)
+
+
+GridLayoutKindType: typing.Literal["GridLayout"] = "GridLayout"
+
+
+RowsLayoutKindType: typing.Literal["RowsLayout"] = "RowsLayout"

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/PythonRawTypes/models/constant_reference_discriminator.py
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/PythonRawTypes/models/constant_reference_discriminator.py
@@ -1,0 +1,121 @@
+import typing
+
+
+LayoutWithValue: typing.TypeAlias = typing.Union['GridLayoutUsingValue', 'RowsLayoutUsingValue']
+
+
+class GridLayoutUsingValue:
+    kind: typing.Literal["GridLayout"]
+    grid_layout_property: str
+
+    def __init__(self, kind: typing.Optional[typing.Literal["GridLayout"]] = None, grid_layout_property: str = ""):
+        self.kind = kind if kind is not None else GridLayoutKindType
+        self.grid_layout_property = grid_layout_property
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "kind": self.kind,
+            "gridLayoutProperty": self.grid_layout_property,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "kind" in data:
+            args["kind"] = data["kind"]
+        if "gridLayoutProperty" in data:
+            args["grid_layout_property"] = data["gridLayoutProperty"]        
+
+        return cls(**args)
+
+
+GridLayoutKindType: typing.Literal["GridLayout"] = "GridLayout"
+
+
+class RowsLayoutUsingValue:
+    kind: typing.Literal["RowsLayout"]
+    rows_layout_property: str
+
+    def __init__(self, kind: typing.Optional[typing.Literal["RowsLayout"]] = None, rows_layout_property: str = ""):
+        self.kind = kind if kind is not None else RowsLayoutKindType
+        self.rows_layout_property = rows_layout_property
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "kind": self.kind,
+            "rowsLayoutProperty": self.rows_layout_property,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "kind" in data:
+            args["kind"] = data["kind"]
+        if "rowsLayoutProperty" in data:
+            args["rows_layout_property"] = data["rowsLayoutProperty"]        
+
+        return cls(**args)
+
+
+RowsLayoutKindType: typing.Literal["RowsLayout"] = "RowsLayout"
+
+
+LayoutWithoutValue: typing.TypeAlias = typing.Union['GridLayoutWithoutValue', 'RowsLayoutWithoutValue']
+
+
+class GridLayoutWithoutValue:
+    kind: typing.Literal["GridLayout"]
+    grid_layout_property: str
+
+    def __init__(self, kind: typing.Optional[typing.Literal["GridLayout"]] = None, grid_layout_property: str = ""):
+        self.kind = kind if kind is not None else GridLayoutKindType
+        self.grid_layout_property = grid_layout_property
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "kind": self.kind,
+            "gridLayoutProperty": self.grid_layout_property,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "kind" in data:
+            args["kind"] = data["kind"]
+        if "gridLayoutProperty" in data:
+            args["grid_layout_property"] = data["gridLayoutProperty"]        
+
+        return cls(**args)
+
+
+class RowsLayoutWithoutValue:
+    kind: typing.Literal["RowsLayout"]
+    rows_layout_property: str
+
+    def __init__(self, kind: typing.Optional[typing.Literal["RowsLayout"]] = None, rows_layout_property: str = ""):
+        self.kind = kind if kind is not None else RowsLayoutKindType
+        self.rows_layout_property = rows_layout_property
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "kind": self.kind,
+            "rowsLayoutProperty": self.rows_layout_property,
+        }
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "kind" in data:
+            args["kind"] = data["kind"]
+        if "rowsLayoutProperty" in data:
+            args["rows_layout_property"] = data["rowsLayoutProperty"]        
+
+        return cls(**args)

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/TypescriptRawTypes/src/constantReferenceDiscriminator/types.gen.ts
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/TypescriptRawTypes/src/constantReferenceDiscriminator/types.gen.ts
@@ -1,0 +1,51 @@
+export type LayoutWithValue = GridLayoutUsingValue | RowsLayoutUsingValue;
+
+export const defaultLayoutWithValue = (): LayoutWithValue => (defaultGridLayoutUsingValue());
+
+export interface GridLayoutUsingValue {
+	kind: "GridLayout";
+	gridLayoutProperty: string;
+}
+
+export const defaultGridLayoutUsingValue = (): GridLayoutUsingValue => ({
+	kind: GridLayoutKindType,
+	gridLayoutProperty: "",
+});
+
+export const GridLayoutKindType = "GridLayout";
+
+export interface RowsLayoutUsingValue {
+	kind: "RowsLayout";
+	rowsLayoutProperty: string;
+}
+
+export const defaultRowsLayoutUsingValue = (): RowsLayoutUsingValue => ({
+	kind: RowsLayoutKindType,
+	rowsLayoutProperty: "",
+});
+
+export const RowsLayoutKindType = "RowsLayout";
+
+export type LayoutWithoutValue = GridLayoutWithoutValue | RowsLayoutWithoutValue;
+
+export const defaultLayoutWithoutValue = (): LayoutWithoutValue => (defaultGridLayoutWithoutValue());
+
+export interface GridLayoutWithoutValue {
+	kind: "GridLayout";
+	gridLayoutProperty: string;
+}
+
+export const defaultGridLayoutWithoutValue = (): GridLayoutWithoutValue => ({
+	kind: GridLayoutKindType,
+	gridLayoutProperty: "",
+});
+
+export interface RowsLayoutWithoutValue {
+	kind: "RowsLayout";
+	rowsLayoutProperty: string;
+}
+
+export const defaultRowsLayoutWithoutValue = (): RowsLayoutWithoutValue => ({
+	kind: RowsLayoutKindType,
+	rowsLayoutProperty: "",
+});

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/TypescriptRawTypes/src/constantReferenceDiscriminator/types.gen.ts
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/TypescriptRawTypes/src/constantReferenceDiscriminator/types.gen.ts
@@ -12,8 +12,6 @@ export const defaultGridLayoutUsingValue = (): GridLayoutUsingValue => ({
 	gridLayoutProperty: "",
 });
 
-export const GridLayoutKindType = "GridLayout";
-
 export interface RowsLayoutUsingValue {
 	kind: "RowsLayout";
 	rowsLayoutProperty: string;
@@ -23,8 +21,6 @@ export const defaultRowsLayoutUsingValue = (): RowsLayoutUsingValue => ({
 	kind: RowsLayoutKindType,
 	rowsLayoutProperty: "",
 });
-
-export const RowsLayoutKindType = "RowsLayout";
 
 export type LayoutWithoutValue = GridLayoutWithoutValue | RowsLayoutWithoutValue;
 
@@ -49,3 +45,7 @@ export const defaultRowsLayoutWithoutValue = (): RowsLayoutWithoutValue => ({
 	kind: RowsLayoutKindType,
 	rowsLayoutProperty: "",
 });
+
+export const GridLayoutKindType = "GridLayout";
+
+export const RowsLayoutKindType = "RowsLayout";

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/ir.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/ir.json
@@ -1,0 +1,254 @@
+{
+  "Package": "constant_reference_discriminator",
+  "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
+  "Objects": {
+    "LayoutWithValue": {
+      "Name": "LayoutWithValue",
+      "Type": {
+        "Kind": "disjunction",
+        "Nullable": false,
+        "Disjunction": {
+          "Branches": [
+            {
+              "Kind": "ref",
+              "Nullable": false,
+              "Ref": {
+                "ReferredPkg": "constant_reference_discriminator",
+                "ReferredType": "GridLayoutUsingValue"
+              }
+            },
+            {
+              "Kind": "ref",
+              "Nullable": false,
+              "Ref": {
+                "ReferredPkg": "constant_reference_discriminator",
+                "ReferredType": "RowsLayoutUsingValue"
+              }
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "LayoutWithValue"
+      }
+    },
+    "GridLayoutUsingValue": {
+      "Name": "GridLayoutUsingValue",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "kind",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "constant_reference_discriminator",
+                  "ReferredType": "GridLayoutKindType"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "gridLayoutProperty",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "GridLayoutUsingValue"
+      }
+    },
+    "GridLayoutKindType": {
+      "Name": "GridLayoutKindType",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "string",
+          "Value": "GridLayout"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "GridLayoutKindType"
+      }
+    },
+    "RowsLayoutUsingValue": {
+      "Name": "RowsLayoutUsingValue",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "kind",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "constant_reference_discriminator",
+                  "ReferredType": "RowsLayoutKindType"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "rowsLayoutProperty",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "RowsLayoutUsingValue"
+      }
+    },
+    "RowsLayoutKindType": {
+      "Name": "RowsLayoutKindType",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "string",
+          "Value": "RowsLayout"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "RowsLayoutKindType"
+      }
+    },
+    "LayoutWithoutValue": {
+      "Name": "LayoutWithoutValue",
+      "Type": {
+        "Kind": "disjunction",
+        "Nullable": false,
+        "Disjunction": {
+          "Branches": [
+            {
+              "Kind": "ref",
+              "Nullable": false,
+              "Ref": {
+                "ReferredPkg": "constant_reference_discriminator",
+                "ReferredType": "GridLayoutWithoutValue"
+              }
+            },
+            {
+              "Kind": "ref",
+              "Nullable": false,
+              "Ref": {
+                "ReferredPkg": "constant_reference_discriminator",
+                "ReferredType": "RowsLayoutWithoutValue"
+              }
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "LayoutWithoutValue"
+      }
+    },
+    "GridLayoutWithoutValue": {
+      "Name": "GridLayoutWithoutValue",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "kind",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "constant_reference_discriminator",
+                  "ReferredType": "GridLayoutKindType"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "gridLayoutProperty",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "GridLayoutWithoutValue"
+      }
+    },
+    "RowsLayoutWithoutValue": {
+      "Name": "RowsLayoutWithoutValue",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "kind",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "constant_reference_discriminator",
+                  "ReferredType": "RowsLayoutKindType"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "rowsLayoutProperty",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_discriminator",
+        "ReferredType": "RowsLayoutWithoutValue"
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/ir.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/ir.json
@@ -1,254 +1,258 @@
-{
-  "Package": "constant_reference_discriminator",
-  "Metadata": {},
-  "EntryPointType": {
-    "Kind": "",
-    "Nullable": false
-  },
-  "Objects": {
-    "LayoutWithValue": {
-      "Name": "LayoutWithValue",
-      "Type": {
-        "Kind": "disjunction",
-        "Nullable": false,
-        "Disjunction": {
-          "Branches": [
-            {
-              "Kind": "ref",
-              "Nullable": false,
-              "Ref": {
-                "ReferredPkg": "constant_reference_discriminator",
-                "ReferredType": "GridLayoutUsingValue"
-              }
-            },
-            {
-              "Kind": "ref",
-              "Nullable": false,
-              "Ref": {
-                "ReferredPkg": "constant_reference_discriminator",
-                "ReferredType": "RowsLayoutUsingValue"
-              }
-            }
-          ]
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "LayoutWithValue"
-      }
+ {
+    "Package": "constant_reference_discriminator",
+    "Metadata": {},
+    "EntryPointType": {
+      "Kind": "",
+      "Nullable": false
     },
-    "GridLayoutUsingValue": {
-      "Name": "GridLayoutUsingValue",
-      "Type": {
-        "Kind": "struct",
-        "Nullable": false,
-        "Struct": {
-          "Fields": [
-            {
-              "Name": "kind",
-              "Type": {
+    "Objects": {
+      "LayoutWithValue": {
+        "Name": "LayoutWithValue",
+        "Type": {
+          "Kind": "disjunction",
+          "Nullable": false,
+          "Disjunction": {
+            "Branches": [
+              {
                 "Kind": "ref",
                 "Nullable": false,
                 "Ref": {
                   "ReferredPkg": "constant_reference_discriminator",
-                  "ReferredType": "GridLayoutKindType"
+                  "ReferredType": "GridLayoutUsingValue"
                 }
               },
-              "Required": true
-            },
-            {
-              "Name": "gridLayoutProperty",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": true
-            }
-          ]
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "GridLayoutUsingValue"
-      }
-    },
-    "GridLayoutKindType": {
-      "Name": "GridLayoutKindType",
-      "Type": {
-        "Kind": "scalar",
-        "Nullable": false,
-        "Scalar": {
-          "ScalarKind": "string",
-          "Value": "GridLayout"
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "GridLayoutKindType"
-      }
-    },
-    "RowsLayoutUsingValue": {
-      "Name": "RowsLayoutUsingValue",
-      "Type": {
-        "Kind": "struct",
-        "Nullable": false,
-        "Struct": {
-          "Fields": [
-            {
-              "Name": "kind",
-              "Type": {
+              {
                 "Kind": "ref",
                 "Nullable": false,
                 "Ref": {
                   "ReferredPkg": "constant_reference_discriminator",
-                  "ReferredType": "RowsLayoutKindType"
+                  "ReferredType": "RowsLayoutUsingValue"
                 }
-              },
-              "Required": true
-            },
-            {
-              "Name": "rowsLayoutProperty",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": true
-            }
-          ]
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "RowsLayoutUsingValue"
-      }
-    },
-    "RowsLayoutKindType": {
-      "Name": "RowsLayoutKindType",
-      "Type": {
-        "Kind": "scalar",
-        "Nullable": false,
-        "Scalar": {
-          "ScalarKind": "string",
-          "Value": "RowsLayout"
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "RowsLayoutKindType"
-      }
-    },
-    "LayoutWithoutValue": {
-      "Name": "LayoutWithoutValue",
-      "Type": {
-        "Kind": "disjunction",
-        "Nullable": false,
-        "Disjunction": {
-          "Branches": [
-            {
-              "Kind": "ref",
-              "Nullable": false,
-              "Ref": {
-                "ReferredPkg": "constant_reference_discriminator",
-                "ReferredType": "GridLayoutWithoutValue"
               }
-            },
-            {
-              "Kind": "ref",
-              "Nullable": false,
-              "Ref": {
-                "ReferredPkg": "constant_reference_discriminator",
-                "ReferredType": "RowsLayoutWithoutValue"
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "LayoutWithValue"
+        }
+      },
+      "GridLayoutUsingValue": {
+        "Name": "GridLayoutUsingValue",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "constant_ref",
+                  "Nullable": false,
+                  "ConstantReference": {
+                    "ReferredPkg": "constant_reference_discriminator",
+                    "ReferredType": "GridLayoutKindType",
+                    "ReferenceValue": "GridLayout"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "gridLayoutProperty",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
               }
-            }
-          ]
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "GridLayoutUsingValue"
         }
       },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "LayoutWithoutValue"
-      }
-    },
-    "GridLayoutWithoutValue": {
-      "Name": "GridLayoutWithoutValue",
-      "Type": {
-        "Kind": "struct",
-        "Nullable": false,
-        "Struct": {
-          "Fields": [
-            {
-              "Name": "kind",
-              "Type": {
+      "RowsLayoutUsingValue": {
+        "Name": "RowsLayoutUsingValue",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "constant_ref",
+                  "Nullable": false,
+                  "ConstantReference": {
+                    "ReferredPkg": "constant_reference_discriminator",
+                    "ReferredType": "RowsLayoutKindType",
+                    "ReferenceValue": "RowsLayout"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "rowsLayoutProperty",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "RowsLayoutUsingValue"
+        }
+      },
+      "LayoutWithoutValue": {
+        "Name": "LayoutWithoutValue",
+        "Type": {
+          "Kind": "disjunction",
+          "Nullable": false,
+          "Disjunction": {
+            "Branches": [
+              {
                 "Kind": "ref",
                 "Nullable": false,
                 "Ref": {
                   "ReferredPkg": "constant_reference_discriminator",
-                  "ReferredType": "GridLayoutKindType"
+                  "ReferredType": "GridLayoutWithoutValue"
                 }
               },
-              "Required": true
-            },
-            {
-              "Name": "gridLayoutProperty",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": true
-            }
-          ]
-        }
-      },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "GridLayoutWithoutValue"
-      }
-    },
-    "RowsLayoutWithoutValue": {
-      "Name": "RowsLayoutWithoutValue",
-      "Type": {
-        "Kind": "struct",
-        "Nullable": false,
-        "Struct": {
-          "Fields": [
-            {
-              "Name": "kind",
-              "Type": {
+              {
                 "Kind": "ref",
                 "Nullable": false,
                 "Ref": {
                   "ReferredPkg": "constant_reference_discriminator",
-                  "ReferredType": "RowsLayoutKindType"
+                  "ReferredType": "RowsLayoutWithoutValue"
                 }
-              },
-              "Required": true
-            },
-            {
-              "Name": "rowsLayoutProperty",
-              "Type": {
-                "Kind": "scalar",
-                "Nullable": false,
-                "Scalar": {
-                  "ScalarKind": "string"
-                }
-              },
-              "Required": true
-            }
-          ]
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "LayoutWithoutValue"
         }
       },
-      "SelfRef": {
-        "ReferredPkg": "constant_reference_discriminator",
-        "ReferredType": "RowsLayoutWithoutValue"
+      "GridLayoutWithoutValue": {
+        "Name": "GridLayoutWithoutValue",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "constant_ref",
+                  "Nullable": false,
+                  "ConstantReference": {
+                    "ReferredPkg": "constant_reference_discriminator",
+                    "ReferredType": "GridLayoutKindType",
+                    "ReferenceValue": "GridLayout"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "gridLayoutProperty",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "GridLayoutWithoutValue"
+        }
+      },
+      "RowsLayoutWithoutValue": {
+        "Name": "RowsLayoutWithoutValue",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "constant_ref",
+                  "Nullable": false,
+                  "ConstantReference": {
+                    "ReferredPkg": "constant_reference_discriminator",
+                    "ReferredType": "RowsLayoutKindType",
+                    "ReferenceValue": "RowsLayout"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "rowsLayoutProperty",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "RowsLayoutWithoutValue"
+        }
+      },
+      "GridLayoutKindType": {
+        "Name": "GridLayoutKindType",
+        "Type": {
+          "Kind": "scalar",
+          "Nullable": false,
+          "Scalar": {
+            "ScalarKind": "string",
+            "Value": "GridLayout"
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "GridLayoutKindType"
+        }
+      },
+      "RowsLayoutKindType": {
+        "Name": "RowsLayoutKindType",
+        "Type": {
+          "Kind": "scalar",
+          "Nullable": false,
+          "Scalar": {
+            "ScalarKind": "string",
+            "Value": "RowsLayout"
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "constant_reference_discriminator",
+          "ReferredType": "RowsLayoutKindType"
+        }
       }
     }
   }
-}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/schema.cue
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/schema.cue
@@ -1,0 +1,28 @@
+package constant_reference_discriminator
+
+LayoutWithValue: GridLayoutUsingValue | RowsLayoutUsingValue
+LayoutWithoutValue: GridLayoutWithoutValue | RowsLayoutWithoutValue
+
+#GridLayoutKindType: "GridLayout"
+#RowsLayoutKindType: "RowsLayout"
+
+GridLayoutUsingValue: {
+    kind: #GridLayoutKindType & "GridLayout"
+    gridLayoutProperty: string
+}
+
+RowsLayoutUsingValue: {
+    kind: #RowsLayoutKindType & "RowsLayout"
+    rowsLayoutProperty: string
+}
+
+GridLayoutWithoutValue: {
+    kind: #GridLayoutKindType
+    gridLayoutProperty: string
+}
+
+RowsLayoutWithoutValue: {
+    kind: #RowsLayoutKindType
+    rowsLayoutProperty: string
+}
+


### PR DESCRIPTION
Closes: https://github.com/grafana/cog/issues/788

When a reference only has a constant, it was managed as a reference instead of a constant reference.