### PR TITLE
Make semver.ParseTolerant() even more tolerant

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -16,9 +16,11 @@ func Parse(version string) Version {
 	}
 }
 
-// registryToSemver turns a "v10.2.x" input (version string coming from the
+// ParseTolerant turns a "v10.2.x" input (version string coming from the
 // kind-registry) into a semver-compatible version "10.2.0"
 func ParseTolerant(version string) Version {
+	version = strings.TrimPrefix(version, "release-")
+
 	if !strings.HasPrefix(version, "v") {
 		version = "v" + version
 	}


### PR DESCRIPTION
To be able to parse things like: https://github.com/grafana/grafana-foundation-sdk/blob/30676a122045f1c47a058079fc5b52d70e86010a/scripts/release-version.sh#L151-L153