### PR TITLE
Generate an empty value for required arrays/maps in Go

### DIFF
--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -249,6 +249,8 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 		needsExplicitDefault := field.Type.Default != nil ||
 			extraDefaults[field.Name] != nil ||
 			(field.Required && field.Type.IsRef() && resolvedFieldType.IsStruct()) ||
+			(field.Required && field.Type.IsArray()) ||
+			(field.Required && field.Type.IsMap()) ||
 			field.Type.IsConcreteScalar() ||
 			field.Type.IsConstantRef()
 		if !needsExplicitDefault {
@@ -345,6 +347,10 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 			if referredPkg != "" {
 				defaultValue = referredPkg + "." + defaultValue
 			}
+		} else if field.Type.IsArray() {
+			defaultValue = "[]" + jenny.typeFormatter.formatType(field.Type.Array.ValueType) + "{}"
+		} else if field.Type.IsMap() {
+			defaultValue = "map[" + jenny.typeFormatter.formatType(field.Type.Map.IndexType) + "]" + jenny.typeFormatter.formatType(field.Type.Map.ValueType) + "{}"
 		} else {
 			defaultValue = "\"unsupported default value case: this is likely a bug in cog\""
 		}

--- a/internal/jennies/golang/tools.go
+++ b/internal/jennies/golang/tools.go
@@ -52,6 +52,10 @@ func escapeVarName(varName string) string {
 }
 
 func formatScalar(val any) string {
+	if val == nil {
+		return "nil"
+	}
+
 	if list, ok := val.([]any); ok {
 		items := make([]string, 0, len(list))
 

--- a/testdata/generated/equality/types_gen.go
+++ b/testdata/generated/equality/types_gen.go
@@ -347,7 +347,14 @@ type Arrays struct {
 
 // NewArrays creates a new Arrays object.
 func NewArrays() *Arrays {
-	return &Arrays{}
+	return &Arrays{
+		Ints:             []int64{},
+		Strings:          []string{},
+		ArrayOfArray:     [][]string{},
+		Refs:             []Variable{},
+		AnonymousStructs: []EqualityArraysAnonymousStructs{},
+		ArrayOfAny:       []any{},
+	}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Arrays` from JSON.
@@ -593,7 +600,13 @@ type Maps struct {
 
 // NewMaps creates a new Maps object.
 func NewMaps() *Maps {
-	return &Maps{}
+	return &Maps{
+		Ints:             map[string]int64{},
+		Strings:          map[string]string{},
+		Refs:             map[string]Variable{},
+		AnonymousStructs: map[string]EqualityMapsAnonymousStructs{},
+		StringToAny:      map[string]any{},
+	}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Maps` from JSON.

--- a/testdata/generated/validation/types_gen.go
+++ b/testdata/generated/validation/types_gen.go
@@ -27,7 +27,11 @@ type Dashboard struct {
 
 // NewDashboard creates a new Dashboard object.
 func NewDashboard() *Dashboard {
-	return &Dashboard{}
+	return &Dashboard{
+		Tags:   []string{},
+		Labels: map[string]string{},
+		Panels: []Panel{},
+	}
 }
 
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Dashboard` from JSON.

--- a/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
+++ b/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
@@ -181,6 +181,8 @@ type RefStruct struct {
 // NewRefStruct creates a new RefStruct object.
 func NewRefStruct() *RefStruct {
 	return &RefStruct{
+		Labels: map[string]string{},
+		Tags: []string{},
 }
 }
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `RefStruct` from JSON.

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -329,6 +329,7 @@ type DefaultsStructComplexField struct {
 func NewDefaultsStructComplexField() *DefaultsStructComplexField {
 	return &DefaultsStructComplexField{
 		Nested: *NewDefaultsStructComplexFieldNested(),
+		Array: []string{},
 }
 }
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `DefaultsStructComplexField` from JSON.

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -27,6 +27,8 @@ func NewSomeStruct() *SomeStruct {
 		FieldRef: *NewSomeOtherStruct(),
 		FieldDisjunctionOfScalars: *NewStringOrBool(),
 		FieldMixedDisjunction: *NewStringOrSomeOtherStruct(),
+		FieldArrayOfStrings: []string{},
+		FieldMapOfStringToString: map[string]string{},
 		FieldAnonymousStruct: *NewStructComplexFieldsSomeStructFieldAnonymousStruct(),
 }
 }


### PR DESCRIPTION
When the schema indicates a field as required (or at least "not optional"), we need to make sure it has a value. We already did that in most cases, but somehow not for arrays and maps.