### PR TITLE
Remove validation checks in (un)marshal functions generated in Go

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -185,10 +185,6 @@ type GoConfig struct {
 
 	// AnyAsInterface instructs cog to emit `interface{}` instead of `any`.
 	AnyAsInterface bool
-
-	// AllowMarshalEmptyDisjunctions makes generated `MarshalJSON()`
-	// ignore errors when marshaling an empty disjunction.
-	AllowMarshalEmptyDisjunctions bool
 }
 
 // Golang sets the output to Golang types.
@@ -198,9 +194,8 @@ func (pipeline *SchemaToTypesPipeline) Golang(config GoConfig) *SchemaToTypesPip
 			SkipRuntime:            true,
 			GenerateJSONMarshaller: true,
 
-			GenerateEqual:                 config.GenerateEqual,
-			AnyAsInterface:                config.AnyAsInterface,
-			AllowMarshalEmptyDisjunctions: config.AllowMarshalEmptyDisjunctions,
+			GenerateEqual:  config.GenerateEqual,
+			AnyAsInterface: config.AnyAsInterface,
 		},
 	}
 	return pipeline

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -60,12 +60,6 @@ type Config struct {
 
 	// AnyAsInterface instructs this jenny to emit `interface{}` instead of `any`.
 	AnyAsInterface bool `yaml:"any_as_interface"`
-
-	// AllowMarshalEmptyDisjunctions makes generated `MarshalJSON()`
-	// ignore errors when marshaling an empty disjunction.
-	// No-op if `GenerateJSONMarshaller` is disabled.
-	// Does not affect strict marshaling & unmarshalling.
-	AllowMarshalEmptyDisjunctions bool `yaml:"allow_marshal_empty_disjunctions"`
 }
 
 func (config *Config) InterpolateParameters(interpolator func(input string) string) {

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -83,15 +83,13 @@ func (jenny JSONMarshalling) renderCustomMarshal(obj ast.Object) (string, error)
 	// 	  structs and these structs have a common "discriminator" field.
 	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDisjunctionOfScalars) {
 		return jenny.tmpl.Render("types/disjunction_of_scalars.json_marshal.tmpl", map[string]any{
-			"def":        obj,
-			"allowEmpty": jenny.config.AllowMarshalEmptyDisjunctions,
+			"def": obj,
 		})
 	}
 
 	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) {
 		return jenny.tmpl.Render("types/disjunction_of_refs.json_marshal.tmpl", map[string]any{
-			"def":        obj,
-			"allowEmpty": jenny.config.AllowMarshalEmptyDisjunctions,
+			"def": obj,
 		})
 	}
 

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -58,9 +58,8 @@ func TestRawTypes_Generate_AllowMarshalEmptyDisjunctions(t *testing.T) {
 	req := require.New(t)
 
 	config := Config{
-		PackageRoot:                   "github.com/grafana/cog/generated",
-		GenerateJSONMarshaller:        true,
-		AllowMarshalEmptyDisjunctions: true,
+		PackageRoot:            "github.com/grafana/cog/generated",
+		GenerateJSONMarshaller: true,
 	}
 	jenny := RawTypes{
 		config:          config,

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -8,9 +8,5 @@ func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 	}
 {{- end }}
 
-{{- if .allowEmpty }}
 	return []byte("null"), nil
-{{- else }}
-	return nil, fmt.Errorf("no value for disjunction of refs")
-{{- end }}
 }

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
@@ -16,7 +16,7 @@ func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) erro
 
 	discriminator, found := parsedAsMap["{{ .hint.Discriminator }}"]
 	if !found {
-		return errors.New("discriminator field '{{ .hint.Discriminator }}' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -36,6 +36,6 @@ func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) erro
 {{- end }}
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `{{ .hint.Discriminator }} = %v`", discriminator)
+	return nil
 }
 

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
@@ -8,9 +8,5 @@ func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 	}
 {{ end }}
 
-{{- if .allowEmpty }}
 	return []byte("null"), nil
-{{- else }}
-	return nil, fmt.Errorf("no value for disjunction of scalars")
-{{- end }}
 }

--- a/testdata/generated/defaults/types_gen.go
+++ b/testdata/generated/defaults/types_gen.go
@@ -280,7 +280,7 @@ func (resource BoolOrString) MarshalJSON() ([]byte, error) {
 		return json.Marshal(resource.String)
 	}
 
-	return nil, fmt.Errorf("no value for disjunction of scalars")
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `BoolOrString` from JSON.
@@ -404,7 +404,7 @@ func (resource StringOrArrayOfString) MarshalJSON() ([]byte, error) {
 		return json.Marshal(resource.ArrayOfString)
 	}
 
-	return nil, fmt.Errorf("no value for disjunction of scalars")
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `StringOrArrayOfString` from JSON.

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -287,7 +287,8 @@ func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 		return json.Marshal(resource.Bool)
 	}
 
-	return nil, fmt.Errorf("no value for disjunction of scalars")
+
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `StringOrBool` from JSON.
@@ -517,7 +518,8 @@ func (resource SomeStructOrSomeOtherStructOrYetAnotherStruct) MarshalJSON() ([]b
 	if resource.YetAnotherStruct != nil {
 		return json.Marshal(resource.YetAnotherStruct)
 	}
-	return nil, fmt.Errorf("no value for disjunction of refs")
+
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `SomeStructOrSomeOtherStructOrYetAnotherStruct` from JSON.
@@ -534,7 +536,7 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 
 	discriminator, found := parsedAsMap["Type"]
 	if !found {
-		return errors.New("discriminator field 'Type' not found in payload")
+		return nil
 	}
 
 	switch discriminator {
@@ -564,7 +566,7 @@ func (resource *SomeStructOrSomeOtherStructOrYetAnotherStruct) UnmarshalJSON(raw
 		return nil
 	}
 
-	return fmt.Errorf("could not unmarshal resource with `Type = %v`", discriminator)
+	return nil
 }
 
 

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -98,7 +98,8 @@ func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 		return json.Marshal(resource.Bool)
 	}
 
-	return nil, fmt.Errorf("no value for disjunction of scalars")
+
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `StringOrBool` from JSON.

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -405,7 +405,8 @@ func (resource StringOrBool) MarshalJSON() ([]byte, error) {
 		return json.Marshal(resource.Bool)
 	}
 
-	return nil, fmt.Errorf("no value for disjunction of scalars")
+
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `StringOrBool` from JSON.


### PR DESCRIPTION
I agree with the assessment made in #793 stating that (un)marshalling shouldn't perform validation checks.

With that in mind, this PR removes any code related to validating disjunctions when marshalling or unmarshalling them.

`UnmarshalJSONStrict()` functions are left unchanged.

**Note:** this PR introduces a BC-break since the `AllowMarshalEmptyDisjunctions` config option that controlled the removal of validation in some cases is now removed.