### PR TITLE
Fix PHP jsonSerialize() methods to return correct outputs for empty objects

### DIFF
--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -604,22 +604,20 @@ func (jenny RawTypes) generateJSONSerialize(def ast.Object) string {
 	var buffer strings.Builder
 
 	buffer.WriteString("/**\n")
-	buffer.WriteString(" * @return array<string, mixed>\n")
+	buffer.WriteString(" * @return mixed\n")
 	buffer.WriteString(" */\n")
-	buffer.WriteString("public function jsonSerialize(): array\n")
+	buffer.WriteString("public function jsonSerialize(): mixed\n")
 	buffer.WriteString("{\n")
 
-	buffer.WriteString("    $data = [\n")
+	buffer.WriteString("    $data = new \\stdClass;\n")
 
 	for _, field := range def.Type.AsStruct().Fields {
 		if field.Type.Nullable {
 			continue
 		}
 
-		buffer.WriteString(fmt.Sprintf(`        "%s" => $this->%s,`+"\n", field.Name, formatFieldName(field.Name)))
+		buffer.WriteString(fmt.Sprintf(`    $data->%s = $this->%s;`+"\n", field.Name, formatFieldName(field.Name)))
 	}
-
-	buffer.WriteString("    ];\n")
 
 	for _, field := range def.Type.AsStruct().Fields {
 		if !field.Type.Nullable {
@@ -629,7 +627,7 @@ func (jenny RawTypes) generateJSONSerialize(def ast.Object) string {
 		fieldName := formatFieldName(field.Name)
 
 		buffer.WriteString(fmt.Sprintf("    if (isset($this->%s)) {\n", fieldName))
-		buffer.WriteString(fmt.Sprintf(`        $data["%s"] = $this->%s;`+"\n", field.Name, fieldName))
+		buffer.WriteString(fmt.Sprintf(`        $data->%s = $this->%s;`+"\n", field.Name, fieldName))
 		buffer.WriteString("    }\n")
 	}
 

--- a/testdata/jennies/rawtypes/arrays/PHPRawTypes/src/Arrays/SomeStruct.php
+++ b/testdata/jennies/rawtypes/arrays/PHPRawTypes/src/Arrays/SomeStruct.php
@@ -30,13 +30,12 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/ParentStruct.php
+++ b/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/ParentStruct.php
@@ -27,13 +27,12 @@ class ParentStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "myEnum" => $this->myEnum,
-        ];
+        $data = new \stdClass;
+        $data->myEnum = $this->myEnum;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/Struct.php
+++ b/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/Struct.php
@@ -32,14 +32,13 @@ class Struct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "myValue" => $this->myValue,
-            "myEnum" => $this->myEnum,
-        ];
+        $data = new \stdClass;
+        $data->myValue = $this->myValue;
+        $data->myEnum = $this->myEnum;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/StructA.php
+++ b/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/StructA.php
@@ -21,13 +21,12 @@ class StructA implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "myEnum" => $this->myEnum,
-        ];
+        $data = new \stdClass;
+        $data->myEnum = $this->myEnum;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/StructB.php
+++ b/testdata/jennies/rawtypes/constant_references/PHPRawTypes/src/ConstantReferences/StructB.php
@@ -30,14 +30,13 @@ class StructB implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "myEnum" => $this->myEnum,
-            "myValue" => $this->myValue,
-        ];
+        $data = new \stdClass;
+        $data->myEnum = $this->myEnum;
+        $data->myValue = $this->myValue;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constraints/PHPRawTypes/src/Constraints/RefStruct.php
+++ b/testdata/jennies/rawtypes/constraints/PHPRawTypes/src/Constraints/RefStruct.php
@@ -38,14 +38,13 @@ class RefStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "labels" => $this->labels,
-            "tags" => $this->tags,
-        ];
+        $data = new \stdClass;
+        $data->labels = $this->labels;
+        $data->tags = $this->tags;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/constraints/PHPRawTypes/src/Constraints/SomeStruct.php
+++ b/testdata/jennies/rawtypes/constraints/PHPRawTypes/src/Constraints/SomeStruct.php
@@ -46,19 +46,18 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "id" => $this->id,
-            "title" => $this->title,
-        ];
+        $data = new \stdClass;
+        $data->id = $this->id;
+        $data->title = $this->title;
         if (isset($this->maybeId)) {
-            $data["maybeId"] = $this->maybeId;
+            $data->maybeId = $this->maybeId;
         }
         if (isset($this->refStruct)) {
-            $data["refStruct"] = $this->refStruct;
+            $data->refStruct = $this->refStruct;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/Dashboard.php
+++ b/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/Dashboard.php
@@ -39,15 +39,14 @@ class Dashboard implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "title" => $this->title,
-        ];
+        $data = new \stdClass;
+        $data->title = $this->title;
         if (isset($this->panels)) {
-            $data["panels"] = $this->panels;
+            $data->panels = $this->panels;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/DataSourceRef.php
+++ b/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/DataSourceRef.php
@@ -32,17 +32,16 @@ class DataSourceRef implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-        ];
+        $data = new \stdClass;
         if (isset($this->type)) {
-            $data["type"] = $this->type;
+            $data->type = $this->type;
         }
         if (isset($this->uid)) {
-            $data["uid"] = $this->uid;
+            $data->uid = $this->uid;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/FieldConfig.php
+++ b/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/FieldConfig.php
@@ -35,17 +35,16 @@ class FieldConfig implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-        ];
+        $data = new \stdClass;
         if (isset($this->unit)) {
-            $data["unit"] = $this->unit;
+            $data->unit = $this->unit;
         }
         if (isset($this->custom)) {
-            $data["custom"] = $this->custom;
+            $data->custom = $this->custom;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/FieldConfigSource.php
+++ b/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/FieldConfigSource.php
@@ -31,14 +31,13 @@ class FieldConfigSource implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-        ];
+        $data = new \stdClass;
         if (isset($this->defaults)) {
-            $data["defaults"] = $this->defaults;
+            $data->defaults = $this->defaults;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/Panel.php
+++ b/testdata/jennies/rawtypes/dashboard/PHPRawTypes/src/Dashboard/Panel.php
@@ -66,25 +66,24 @@ class Panel implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "title" => $this->title,
-            "type" => $this->type,
-        ];
+        $data = new \stdClass;
+        $data->title = $this->title;
+        $data->type = $this->type;
         if (isset($this->datasource)) {
-            $data["datasource"] = $this->datasource;
+            $data->datasource = $this->datasource;
         }
         if (isset($this->options)) {
-            $data["options"] = $this->options;
+            $data->options = $this->options;
         }
         if (isset($this->targets)) {
-            $data["targets"] = $this->targets;
+            $data->targets = $this->targets;
         }
         if (isset($this->fieldConfig)) {
-            $data["fieldConfig"] = $this->fieldConfig;
+            $data->fieldConfig = $this->fieldConfig;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/SomeOtherStruct.php
+++ b/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/SomeOtherStruct.php
@@ -31,14 +31,13 @@ class SomeOtherStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "Type" => $this->type,
-            "Foo" => $this->foo,
-        ];
+        $data = new \stdClass;
+        $data->Type = $this->type;
+        $data->Foo = $this->foo;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/SomeStruct.php
+++ b/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/SomeStruct.php
@@ -34,14 +34,13 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "Type" => $this->type,
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->Type = $this->type;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/YetAnotherStruct.php
+++ b/testdata/jennies/rawtypes/disjunctions/PHPRawTypes/src/Disjunctions/YetAnotherStruct.php
@@ -31,14 +31,13 @@ class YetAnotherStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "Type" => $this->type,
-            "Bar" => $this->bar,
-        ];
+        $data = new \stdClass;
+        $data->Type = $this->type;
+        $data->Bar = $this->bar;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructComplexField.php
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructComplexField.php
@@ -44,15 +44,14 @@ class DefaultsStructComplexField implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "uid" => $this->uid,
-            "nested" => $this->nested,
-            "array" => $this->array,
-        ];
+        $data = new \stdClass;
+        $data->uid = $this->uid;
+        $data->nested = $this->nested;
+        $data->array = $this->array;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructComplexFieldNested.php
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructComplexFieldNested.php
@@ -27,13 +27,12 @@ class DefaultsStructComplexFieldNested implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "nestedVal" => $this->nestedVal,
-        ];
+        $data = new \stdClass;
+        $data->nestedVal = $this->nestedVal;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructPartialComplexField.php
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/DefaultsStructPartialComplexField.php
@@ -32,14 +32,13 @@ class DefaultsStructPartialComplexField implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "uid" => $this->uid,
-            "intVal" => $this->intVal,
-        ];
+        $data = new \stdClass;
+        $data->uid = $this->uid;
+        $data->intVal = $this->intVal;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/NestedStruct.php
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/NestedStruct.php
@@ -32,14 +32,13 @@ class NestedStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "stringVal" => $this->stringVal,
-            "intVal" => $this->intVal,
-        ];
+        $data = new \stdClass;
+        $data->stringVal = $this->stringVal;
+        $data->intVal = $this->intVal;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/Struct.php
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/PHPRawTypes/src/Defaults/Struct.php
@@ -67,17 +67,16 @@ class Struct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "allFields" => $this->allFields,
-            "partialFields" => $this->partialFields,
-            "emptyFields" => $this->emptyFields,
-            "complexField" => $this->complexField,
-            "partialComplexField" => $this->partialComplexField,
-        ];
+        $data = new \stdClass;
+        $data->allFields = $this->allFields;
+        $data->partialFields = $this->partialFields;
+        $data->emptyFields = $this->emptyFields;
+        $data->complexField = $this->complexField;
+        $data->partialComplexField = $this->partialComplexField;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/maps/PHPRawTypes/src/Maps/SomeStruct.php
+++ b/testdata/jennies/rawtypes/maps/PHPRawTypes/src/Maps/SomeStruct.php
@@ -30,13 +30,12 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/PHPRawTypes/src/Withdashes/SomeStruct.php
+++ b/testdata/jennies/rawtypes/package-with-dashes/PHPRawTypes/src/Withdashes/SomeStruct.php
@@ -30,13 +30,12 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/SomeStruct.php
+++ b/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/SomeStruct.php
@@ -30,13 +30,12 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/SomeOtherStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/SomeOtherStruct.php
@@ -30,13 +30,12 @@ class SomeOtherStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/SomeStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/SomeStruct.php
@@ -107,22 +107,21 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldRef" => $this->fieldRef,
-            "FieldDisjunctionOfScalars" => $this->fieldDisjunctionOfScalars,
-            "FieldMixedDisjunction" => $this->fieldMixedDisjunction,
-            "Operator" => $this->operator,
-            "FieldArrayOfStrings" => $this->fieldArrayOfStrings,
-            "FieldMapOfStringToString" => $this->fieldMapOfStringToString,
-            "FieldAnonymousStruct" => $this->fieldAnonymousStruct,
-            "fieldRefToConstant" => $this->fieldRefToConstant,
-        ];
+        $data = new \stdClass;
+        $data->FieldRef = $this->fieldRef;
+        $data->FieldDisjunctionOfScalars = $this->fieldDisjunctionOfScalars;
+        $data->FieldMixedDisjunction = $this->fieldMixedDisjunction;
+        $data->Operator = $this->operator;
+        $data->FieldArrayOfStrings = $this->fieldArrayOfStrings;
+        $data->FieldMapOfStringToString = $this->fieldMapOfStringToString;
+        $data->FieldAnonymousStruct = $this->fieldAnonymousStruct;
+        $data->fieldRefToConstant = $this->fieldRefToConstant;
         if (isset($this->fieldDisjunctionWithNull)) {
-            $data["FieldDisjunctionWithNull"] = $this->fieldDisjunctionWithNull;
+            $data->FieldDisjunctionWithNull = $this->fieldDisjunctionWithNull;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/StructComplexFieldsSomeStructFieldAnonymousStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/PHPRawTypes/src/StructComplexFields/StructComplexFieldsSomeStructFieldAnonymousStruct.php
@@ -30,13 +30,12 @@ class StructComplexFieldsSomeStructFieldAnonymousStruct implements \JsonSerializ
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_defaults/PHPRawTypes/src/Defaults/SomeStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_defaults/PHPRawTypes/src/Defaults/SomeStruct.php
@@ -46,17 +46,16 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "fieldBool" => $this->fieldBool,
-            "fieldString" => $this->fieldString,
-            "FieldStringWithConstantValue" => $this->fieldStringWithConstantValue,
-            "FieldFloat32" => $this->fieldFloat32,
-            "FieldInt32" => $this->fieldInt32,
-        ];
+        $data = new \stdClass;
+        $data->fieldBool = $this->fieldBool;
+        $data->fieldString = $this->fieldString;
+        $data->FieldStringWithConstantValue = $this->fieldStringWithConstantValue;
+        $data->FieldFloat32 = $this->fieldFloat32;
+        $data->FieldInt32 = $this->fieldInt32;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/SomeOtherStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/SomeOtherStruct.php
@@ -30,13 +30,12 @@ class SomeOtherStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/SomeStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/SomeStruct.php
@@ -58,26 +58,25 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-        ];
+        $data = new \stdClass;
         if (isset($this->fieldRef)) {
-            $data["FieldRef"] = $this->fieldRef;
+            $data->FieldRef = $this->fieldRef;
         }
         if (isset($this->fieldString)) {
-            $data["FieldString"] = $this->fieldString;
+            $data->FieldString = $this->fieldString;
         }
         if (isset($this->operator)) {
-            $data["Operator"] = $this->operator;
+            $data->Operator = $this->operator;
         }
         if (isset($this->fieldArrayOfStrings)) {
-            $data["FieldArrayOfStrings"] = $this->fieldArrayOfStrings;
+            $data->FieldArrayOfStrings = $this->fieldArrayOfStrings;
         }
         if (isset($this->fieldAnonymousStruct)) {
-            $data["FieldAnonymousStruct"] = $this->fieldAnonymousStruct;
+            $data->FieldAnonymousStruct = $this->fieldAnonymousStruct;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/StructOptionalFieldsSomeStructFieldAnonymousStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/PHPRawTypes/src/StructOptionalFields/StructOptionalFieldsSomeStructFieldAnonymousStruct.php
@@ -30,13 +30,12 @@ class StructOptionalFieldsSomeStructFieldAnonymousStruct implements \JsonSeriali
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/PHPRawTypes/src/Basic/SomeStruct.php
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/PHPRawTypes/src/Basic/SomeStruct.php
@@ -107,27 +107,26 @@ class SomeStruct implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "FieldAny" => $this->fieldAny,
-            "FieldBool" => $this->fieldBool,
-            "FieldBytes" => $this->fieldBytes,
-            "FieldString" => $this->fieldString,
-            "FieldStringWithConstantValue" => $this->fieldStringWithConstantValue,
-            "FieldFloat32" => $this->fieldFloat32,
-            "FieldFloat64" => $this->fieldFloat64,
-            "FieldUint8" => $this->fieldUint8,
-            "FieldUint16" => $this->fieldUint16,
-            "FieldUint32" => $this->fieldUint32,
-            "FieldUint64" => $this->fieldUint64,
-            "FieldInt8" => $this->fieldInt8,
-            "FieldInt16" => $this->fieldInt16,
-            "FieldInt32" => $this->fieldInt32,
-            "FieldInt64" => $this->fieldInt64,
-        ];
+        $data = new \stdClass;
+        $data->FieldAny = $this->fieldAny;
+        $data->FieldBool = $this->fieldBool;
+        $data->FieldBytes = $this->fieldBytes;
+        $data->FieldString = $this->fieldString;
+        $data->FieldStringWithConstantValue = $this->fieldStringWithConstantValue;
+        $data->FieldFloat32 = $this->fieldFloat32;
+        $data->FieldFloat64 = $this->fieldFloat64;
+        $data->FieldUint8 = $this->fieldUint8;
+        $data->FieldUint16 = $this->fieldUint16;
+        $data->FieldUint32 = $this->fieldUint32;
+        $data->FieldUint64 = $this->fieldUint64;
+        $data->FieldInt8 = $this->fieldInt8;
+        $data->FieldInt16 = $this->fieldInt16;
+        $data->FieldInt32 = $this->fieldInt32;
+        $data->FieldInt64 = $this->fieldInt64;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/time_hint/PHPRawTypes/src/TimeHint/ObjWithTimeField.php
+++ b/testdata/jennies/rawtypes/time_hint/PHPRawTypes/src/TimeHint/ObjWithTimeField.php
@@ -27,13 +27,12 @@ class ObjWithTimeField implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "registeredAt" => $this->registeredAt,
-        ];
+        $data = new \stdClass;
+        $data->registeredAt = $this->registeredAt;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/variant_dataquery/PHPRawTypes/src/VariantDataquery/Query.php
+++ b/testdata/jennies/rawtypes/variant_dataquery/PHPRawTypes/src/VariantDataquery/Query.php
@@ -32,15 +32,14 @@ class Query implements \JsonSerializable, \Grafana\Foundation\Cog\Dataquery
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "expr" => $this->expr,
-        ];
+        $data = new \stdClass;
+        $data->expr = $this->expr;
         if (isset($this->instant)) {
-            $data["instant"] = $this->instant;
+            $data->instant = $this->instant;
         }
         return $data;
     }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/FieldConfig.php
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/FieldConfig.php
@@ -27,13 +27,12 @@ class FieldConfig implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "timeseries_field_config_option" => $this->timeseriesFieldConfigOption,
-        ];
+        $data = new \stdClass;
+        $data->timeseries_field_config_option = $this->timeseriesFieldConfigOption;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/Options.php
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/PHPRawTypes/src/VariantPanelcfgFull/Options.php
@@ -27,13 +27,12 @@ class Options implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "timeseries_option" => $this->timeseriesOption,
-        ];
+        $data = new \stdClass;
+        $data->timeseries_option = $this->timeseriesOption;
         return $data;
     }
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/PHPRawTypes/src/VariantPanelcfgOnlyOptions/Options.php
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/PHPRawTypes/src/VariantPanelcfgOnlyOptions/Options.php
@@ -27,13 +27,12 @@ class Options implements \JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
-        $data = [
-            "content" => $this->content,
-        ];
+        $data = new \stdClass;
+        $data->content = $this->content;
         return $data;
     }
 }


### PR DESCRIPTION
Storing data in an array in `jsonSerialize()` methods is convenient, but it has the nasty side-effect of not allowing the `json_encode()` function to distinguish between empty arrays and empty objects. Both get encoded as `[]`.

For example, we get the following error when validating a dashboard that doesn't have annotations:

```
`Dashboard.dashboard.grafana.app \"test-dashboard\" is invalid: spec.annotations: Invalid value: conflicting values [] and {list?:[...#AnnotationQuery]} (mismatched types list and struct)`
```

That's because within the generated dashboard JSON, the `annotations` field is defined as `"annotations": []` instead of `"annotations": {}`.

This PR fixes that issue by storing the data in a [`stdClass`](https://www.php.net/manual/en/class.stdclass.php) object, so that even if they're empty `json_encode()` will know to encode them as objects.