### PR TITLE
Python: Adjust the builder's contained type to be covariant

### DIFF
--- a/internal/jennies/python/templates/runtime/builder.tmpl
+++ b/internal/jennies/python/templates/runtime/builder.tmpl
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 
 
 class Builder(Generic[T], ABC):


### PR DESCRIPTION
## The problem
As of currently, the `grafana_foundation_sdk` does not [pass typechecking in its example](https://github.com/grafana/grafana-foundation-sdk/blob/main/.mkdocs/docs/index.md).

This is because the `with_target` function expects a `cogbuilder.Builder[cogvariants.Dataquery]` type to be passed, but the prometheus query returns a Dataquery, which inherits from `cogbuilder.Builder[prometheus.Dataquery]`.

This doesn't type check, because they are not the same type, and the generic type is not marked as [covariant](https://peps.python.org/pep-0483/#covariance-and-contravariance). 

## Solution
Given the implementation of `build`, I believe the type is in practice covariant.
Marking it as such fixes the type checking of the dashboard.