### PR TITLE
Add OpenAPI output to the SchemaToTypesPipeline

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -6,7 +6,6 @@ import (
 
 	"cuelang.org/go/cue"
 	"github.com/grafana/codejen"
-
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/codegen"
 	"github.com/grafana/cog/internal/jennies/golang"

--- a/helpers.go
+++ b/helpers.go
@@ -6,9 +6,11 @@ import (
 
 	"cuelang.org/go/cue"
 	"github.com/grafana/codejen"
+
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/codegen"
 	"github.com/grafana/cog/internal/jennies/golang"
+	"github.com/grafana/cog/internal/jennies/openapi"
 	"github.com/grafana/cog/internal/jennies/typescript"
 	"github.com/grafana/cog/internal/simplecue"
 )
@@ -232,6 +234,23 @@ func (pipeline *SchemaToTypesPipeline) Typescript(config TypescriptConfig) *Sche
 			SkipIndex:         true,
 			PackagesImportMap: config.ImportsMap,
 			EnumsAsUnionTypes: config.EnumsAsUnionTypes,
+		},
+	}
+	return pipeline
+}
+
+// OpenAPIGenerationConfig defines a set of configuration options specific to OpenAPI outputs.
+type OpenAPIGenerationConfig struct {
+	// Compact controls whether the generated JSON should be pretty printed or
+	// not.
+	Compact bool `yaml:"compact"`
+}
+
+// GenerateOpenAPI sets the output to OpenAPI types.
+func (pipeline *SchemaToTypesPipeline) GenerateOpenAPI(config OpenAPIGenerationConfig) *SchemaToTypesPipeline {
+	pipeline.output = &codegen.OutputLanguage{
+		OpenAPI: &openapi.Config{
+			Compact: config.Compact,
 		},
 	}
 	return pipeline

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -169,7 +169,7 @@ Container: {
   }
 }`
 
-	t.Run("generating typescript from cue", func(t *testing.T) {
+	t.Run("generating openAPI from cue", func(t *testing.T) {
 		req := require.New(t)
 
 		cueValue := cuecontext.New().CompileString(schema)
@@ -182,7 +182,7 @@ Container: {
 		req.NoError(err)
 
 		req.Len(files, 1, "expected a single file")
-		testutils.TrimSpacesDiffComparator(t, []byte(expectedCode), files[0].Data, "test.go")
+		testutils.TrimSpacesDiffComparator(t, []byte(expectedCode), files[0].Data, "test.json")
 	})
 }
 


### PR DESCRIPTION
This PR adds the ability to output OpenAPI JSON from the `SchemasToTypesPipline` type, using the `GenerateOpenAPI` method. Method is named `GenerateOpenAPI` rather than `OpenAPI` (like the go and TypeScript variants), as I wanted to make sure it was distinct from a possible future input type of OpenAPI (like the current `CUEValue` method that sets the input). 

OpenAPI output can be used by the [grafana-app-sdk](https://github.com/grafana/grafana-app-sdk) instead of CUE's openAPI encoder to allow the app-sdk to parse recursive types from CUE (which CUE's openAPI encoder fails on).