### PR TITLE
Fix CI security recommendations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -28,7 +30,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run golangci-lint
@@ -40,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #4.2.3
@@ -54,7 +58,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Tests
@@ -66,11 +70,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Docs
@@ -88,6 +94,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #4.2.3
@@ -102,7 +109,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Clone kind-registry
@@ -114,7 +121,7 @@ jobs:
             --config ./config/foundation_sdk.dev.yaml \
             --parameters grafana_version=${{ matrix.kind_version == 'next' && 'main' || matrix.kind_version }},kind_registry_version=${{ matrix.kind_version }}
         env:
-          GOGC: 'off'
+          GOGC: "off"
 
       - name: Compile generated Go code
         run: devbox run ./scripts/ci/build-go.sh
@@ -161,6 +168,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #4.2.3
@@ -175,7 +183,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Clone kind-registry
@@ -184,7 +192,7 @@ jobs:
       - name: Run code generation
         run: make gen-sdk-dev
         env:
-          GOGC: 'off'
+          GOGC: "off"
 
       - name: Run the Go example
         run: make run-go-example

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,12 +3,7 @@ name: Publish documentation
 on:
   workflow_dispatch: ~
   push:
-    tags: ['v*']
-
-permissions:
-  contents: read
-  pages: write      # to deploy to Pages
-  id-token: write   # to verify the deployment originates from an appropriate source
+    tags: ["v*"]
 
 env:
   DEVBOX_VERSION: 0.14.0
@@ -23,14 +18,20 @@ jobs:
   build_docs:
     name: Build documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Build documentation website
@@ -45,6 +46,9 @@ jobs:
 
   deploy:
     needs: build_docs
+    permissions:
+      contents: read
+      id-token: write
 
     name: Deploy documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
+++ b/.github/workflows/grafana-foundation-sdk-diff-preview.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -29,7 +30,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Build cog with current branch
@@ -50,16 +51,17 @@ jobs:
         env:
           CODEGEN_PIPELINE_CONFIG: ./config/foundation_sdk.dev.yaml
           WORKSPACE_PATH: /tmp/foundation-workspace-current
-          CLEANUP_WORKSPACE: 'no'
-          SKIP_VALIDATION: 'yes'
-          LOG_LEVEL: '7' # debug
-          GOGC: 'off'
+          CLEANUP_WORKSPACE: "no"
+          SKIP_VALIDATION: "yes"
+          LOG_LEVEL: "7" # debug
+          GOGC: "off"
 
       - name: Checkout main branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           ref: main
           submodules: recursive
+          persist-credentials: false
 
       - name: Build cog with main branch
         shell: bash
@@ -77,28 +79,28 @@ jobs:
         env:
           CODEGEN_PIPELINE_CONFIG: ./config/foundation_sdk.dev.yaml
           WORKSPACE_PATH: /tmp/foundation-workspace-main
-          CLEANUP_WORKSPACE: 'no'
-          SKIP_VALIDATION: 'yes'
-          LOG_LEVEL: '7' # debug
-          GOGC: 'off'
+          CLEANUP_WORKSPACE: "no"
+          SKIP_VALIDATION: "yes"
+          LOG_LEVEL: "7" # debug
+          GOGC: "off"
 
       - name: Preview diff
         run: |
           cat <<'EOF' > preview.md
           <!-- grafana-foundation-sdk-diff-preview-marker -->
-          
+
           **Note:** the diff show code changes that would be introduced by this PR to the output of the `config/foundation_sdk.dev.yaml` codegen pipeline (dev version of the Foundation SDK).
-          
+
           <details>
           <summary>
-          
+
           ### 🔎 Changes to `config/foundation_sdk.dev.yaml`
-          
+
           </summary>
-          
+
           ```patch
           EOF
-          
+
           diff \
             --new-file \
             --unidirectional-new-file \
@@ -111,7 +113,7 @@ jobs:
             --exclude='package.json' \
             --exclude='*.md' \
             /tmp/foundation-workspace-main/foundation-sdk/ /tmp/foundation-workspace-current/foundation-sdk/ >> preview.md || true # diff returns 1 if the two targets have differences
-          
+
           cat <<'EOF' >> preview.md
           ```
           </details>
@@ -123,8 +125,8 @@ jobs:
         if: "!contains(github.actor, 'dependabot') && github.repository == 'grafana/cog'" # only run on main repo, and not on dependabot PRs
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'grafana-foundation-sdk-diff-preview-marker'
+          comment-author: "github-actions[bot]"
+          body-includes: "grafana-foundation-sdk-diff-preview-marker"
 
       - name: Upsert preview comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
@@ -133,4 +135,4 @@ jobs:
           comment-id: ${{ steps.preview-comment-find.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
-          body-path: './preview.md'
+          body-path: "./preview.md"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,10 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
 
 permissions:
-  contents: write   # To create a GitHub release
+  contents: write # To create a GitHub release
 
 env:
   DEVBOX_VERSION: 0.14.0
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -40,7 +41,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run GoReleaser


### PR DESCRIPTION
Fixing findings from running zizmor against the CI configurations. After this is merged in we can re-enable CI for the repo.

There is a potential that the permissions for docs is not properly done, but we can fix that in the future.