### PR TITLE
Only target the latest version of each major grafana branch in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,9 @@ jobs:
 
     strategy:
       matrix:
-        kind_version: [next, v11.4.x, v11.0.x, v10.4.x]
+        # Focus on the latest version of each supported major Grafana version
+        # Note: `next` isn't included here as it will be covered by the `examples` job
+        kind_version: [v11.6.x, v10.4.x]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2


### PR DESCRIPTION
To save some compute cycles and avoid redundant jobs