### PR TITLE
Emit empty values for required fields with no explicit defaults

### DIFF
--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -135,6 +135,14 @@ inputs:
       cue_imports:
         - '%kind_registry_path%/grafana/%kind_registry_version%/common:github.com/grafana/grafana/packages/grafana-schema/src/common'
 
+  # The schema for units
+  - cue:
+      entrypoint: '%__config_dir%/schemas/units'
+
+  # The schema for resource manifests
+  - cue:
+      entrypoint: '%__config_dir%/schemas/resource'
+
 transformations:
   schemas:
     - '%__config_dir%/foundation-sdk/.cog/compiler/common_passes.yaml'

--- a/config/foundation_sdk.dev.yaml
+++ b/config/foundation_sdk.dev.yaml
@@ -137,11 +137,11 @@ inputs:
 
   # The schema for units
   - cue:
-      entrypoint: '%__config_dir%/schemas/units'
+      entrypoint: '%__config_dir%/foundation-sdk/.cog/schemas/units'
 
   # The schema for resource manifests
   - cue:
-      entrypoint: '%__config_dir%/schemas/resource'
+      entrypoint: '%__config_dir%/foundation-sdk/.cog/schemas/resource'
 
 transformations:
   schemas:

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -246,8 +246,9 @@ func (jenny RawTypes) constructors(object ast.Object) []ConstructorTemplate {
 		})
 
 		assignments = append(assignments, ConstructorAssignmentTemplate{
-			Name: name,
-			Type: field.Type,
+			Name:         name,
+			Type:         field.Type,
+			ValueFromArg: name,
 		})
 
 		if field.Type.Default != nil {
@@ -255,6 +256,12 @@ func (jenny RawTypes) constructors(object ast.Object) []ConstructorTemplate {
 				Name:  name,
 				Type:  field.Type,
 				Value: jenny.genDefaultForType(field.Type, field.Type.Default),
+			})
+		} else if field.Required && !field.Type.Nullable { // Fields without an explicit default, but that aren't allowed to be null
+			defaultConstructorAssignments = append(defaultConstructorAssignments, ConstructorAssignmentTemplate{
+				Name:  name,
+				Type:  field.Type,
+				Value: jenny.typeFormatter.emptyValueForType(field.Type),
 			})
 		}
 	}

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -32,10 +32,10 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- range .Constructors }}
     public {{ $.Name }}({{- template "args" dict "Arguments" .Args "IsBuilder" false }}) {
         {{- range .Assignments }}
-        {{- if .Value }}
-        this.{{ .Name }} = {{ .Value }};
+        {{- if .ValueFromArg }}
+        this.{{ .Name }} = {{ .ValueFromArg }};
         {{- else }}
-        this.{{ .Name }} = {{ .Name }};
+        this.{{ .Name }} = {{ .Value }};
         {{- end }}
         {{- end }}
     }

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -149,14 +149,16 @@ type ClassTemplate struct {
 }
 
 type ConstructorTemplate struct {
+	IsDefault   bool
 	Args        []ast.Argument
 	Assignments []ConstructorAssignmentTemplate
 }
 
 type ConstructorAssignmentTemplate struct {
-	Name  string
-	Type  ast.Type
-	Value any
+	Name         string
+	Type         ast.Type
+	Value        any
+	ValueFromArg string
 }
 
 type ConstantTemplate struct {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -149,7 +149,6 @@ type ClassTemplate struct {
 }
 
 type ConstructorTemplate struct {
-	IsDefault   bool
 	Args        []ast.Argument
 	Assignments []ConstructorAssignmentTemplate
 }

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -182,13 +182,9 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 
 		referredObj, found := tf.context.LocateObjectByRef(def.AsRef())
 		if found && referredObj.Type.IsEnum() {
-			enum := referredObj.Type.AsEnum()
-			enumValue, _ := enum.MemberForValue(0)
-			if enum.Values[0].Type.Kind == ast.KindScalar {
-				enumValue, _ = enum.MemberForValue("")
-			}
+			defaultMember := referredObj.Type.AsEnum().Values[0]
 
-			return fmt.Sprintf("%s.%s", referredObj.Name, tools.UpperSnakeCase(enumValue.Name))
+			return fmt.Sprintf("%s.%s", referredObj.Name, tools.UpperSnakeCase(defaultMember.Name))
 		}
 
 		return fmt.Sprintf("new %s()", tf.config.formatPackage(refDef))
@@ -210,6 +206,8 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 			return `""`
 		case ast.KindBytes:
 			return "(byte) 0"
+		case ast.KindAny:
+			return "new Object()"
 		default:
 			return "unknown"
 		}

--- a/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
+++ b/testdata/jennies/rawtypes/arrays/JavaRawTypes/arrays/SomeStruct.java
@@ -4,6 +4,7 @@ package arrays;
 public class SomeStruct {
     public Object fieldAny;
     public SomeStruct() {
+        this.fieldAny = new Object();
     }
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/ParentStruct.java
+++ b/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/ParentStruct.java
@@ -4,6 +4,7 @@ package constant_references;
 public class ParentStruct {
     public Enum myEnum;
     public ParentStruct() {
+        this.myEnum = Enum.VALUE_A;
     }
     public ParentStruct(Enum myEnum) {
         this.myEnum = myEnum;

--- a/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/Struct.java
+++ b/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/Struct.java
@@ -5,6 +5,8 @@ public class Struct {
     public String myValue;
     public Enum myEnum;
     public Struct() {
+        this.myValue = "";
+        this.myEnum = Enum.VALUE_A;
     }
     public Struct(String myValue,Enum myEnum) {
         this.myValue = myValue;

--- a/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/StructB.java
+++ b/testdata/jennies/rawtypes/constant_references/JavaRawTypes/constant_references/StructB.java
@@ -6,6 +6,7 @@ public class StructB {
     public String myValue;
     public StructB() {
         this.myEnum = Enum.VALUE_B;
+        this.myValue = "";
     }
     public StructB(String myValue) {
         this.myEnum = Enum.VALUE_B;

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/RefStruct.java
@@ -1,5 +1,7 @@
 package constraints;
 
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.List;
 
@@ -7,6 +9,8 @@ public class RefStruct {
     public Map<String, String> labels;
     public List<String> tags;
     public RefStruct() {
+        this.labels = new HashMap<>();
+        this.tags = new LinkedList<>();
     }
     public RefStruct(Map<String, String> labels,List<String> tags) {
         this.labels = labels;

--- a/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
+++ b/testdata/jennies/rawtypes/constraints/JavaRawTypes/constraints/SomeStruct.java
@@ -7,6 +7,8 @@ public class SomeStruct {
     public String title;
     public RefStruct refStruct;
     public SomeStruct() {
+        this.id = 0L;
+        this.title = "";
     }
     public SomeStruct(Long id,Long maybeId,String title,RefStruct refStruct) {
         this.id = id;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Dashboard.java
@@ -6,6 +6,7 @@ public class Dashboard {
     public String title;
     public List<Panel> panels;
     public Dashboard() {
+        this.title = "";
     }
     public Dashboard(String title,List<Panel> panels) {
         this.title = title;

--- a/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
+++ b/testdata/jennies/rawtypes/dashboard/JavaRawTypes/dashboard/Panel.java
@@ -11,6 +11,8 @@ public class Panel {
     public List<Dataquery> targets;
     public FieldConfigSource fieldConfig;
     public Panel() {
+        this.title = "";
+        this.type = "";
     }
     public Panel(String title,String type,DataSourceRef datasource,Object options,List<Dataquery> targets,FieldConfigSource fieldConfig) {
         this.title = title;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeOtherStruct.java
@@ -5,6 +5,8 @@ public class SomeOtherStruct {
     public String type;
     public Byte foo;
     public SomeOtherStruct() {
+        this.type = "";
+        this.foo = (byte) 0;
     }
     public SomeOtherStruct(String type,Byte foo) {
         this.type = type;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/SomeStruct.java
@@ -5,6 +5,8 @@ public class SomeStruct {
     public String type;
     public Object fieldAny;
     public SomeStruct() {
+        this.type = "";
+        this.fieldAny = new Object();
     }
     public SomeStruct(String type,Object fieldAny) {
         this.type = type;

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/YetAnotherStruct.java
@@ -5,6 +5,8 @@ public class YetAnotherStruct {
     public String type;
     public Integer bar;
     public YetAnotherStruct() {
+        this.type = "";
+        this.bar = 0;
     }
     public YetAnotherStruct(String type,Integer bar) {
         this.type = type;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexField.java
@@ -1,5 +1,6 @@
 package defaults;
 
+import java.util.LinkedList;
 import java.util.List;
 
 public class DefaultsStructComplexField {
@@ -7,6 +8,9 @@ public class DefaultsStructComplexField {
     public DefaultsStructComplexFieldNested nested;
     public List<String> array;
     public DefaultsStructComplexField() {
+        this.uid = "";
+        this.nested = new defaults.DefaultsStructComplexFieldNested();
+        this.array = new LinkedList<>();
     }
     public DefaultsStructComplexField(String uid,DefaultsStructComplexFieldNested nested,List<String> array) {
         this.uid = uid;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructComplexFieldNested.java
@@ -4,6 +4,7 @@ package defaults;
 public class DefaultsStructComplexFieldNested {
     public String nestedVal;
     public DefaultsStructComplexFieldNested() {
+        this.nestedVal = "";
     }
     public DefaultsStructComplexFieldNested(String nestedVal) {
         this.nestedVal = nestedVal;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/DefaultsStructPartialComplexField.java
@@ -5,6 +5,8 @@ public class DefaultsStructPartialComplexField {
     public String uid;
     public Long intVal;
     public DefaultsStructPartialComplexField() {
+        this.uid = "";
+        this.intVal = 0L;
     }
     public DefaultsStructPartialComplexField(String uid,Long intVal) {
         this.uid = uid;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/NestedStruct.java
@@ -5,6 +5,8 @@ public class NestedStruct {
     public String stringVal;
     public Long intVal;
     public NestedStruct() {
+        this.stringVal = "";
+        this.intVal = 0L;
     }
     public NestedStruct(String stringVal,Long intVal) {
         this.stringVal = stringVal;

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/JavaRawTypes/defaults/Struct.java
@@ -10,6 +10,7 @@ public class Struct {
     public Struct() {
         this.allFields = new NestedStruct("hello", 3L);
         this.partialFields = new NestedStruct("", 3L);
+        this.emptyFields = new defaults.NestedStruct();
         this.complexField = new DefaultsStructComplexField("myUID", new DefaultsStructComplexFieldNested("nested"), List.of("hello"));
         this.partialComplexField = new DefaultsStructPartialComplexField("", 0L);
     }

--- a/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
+++ b/testdata/jennies/rawtypes/maps/JavaRawTypes/maps/SomeStruct.java
@@ -4,6 +4,7 @@ package maps;
 public class SomeStruct {
     public Object fieldAny;
     public SomeStruct() {
+        this.fieldAny = new Object();
     }
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
+++ b/testdata/jennies/rawtypes/package-with-dashes/JavaRawTypes/withdashes/SomeStruct.java
@@ -4,6 +4,7 @@ package withdashes;
 public class SomeStruct {
     public Object fieldAny;
     public SomeStruct() {
+        this.fieldAny = new Object();
     }
     public SomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
+++ b/testdata/jennies/rawtypes/refs/JavaRawTypes/refs/RefToSomeStruct.java
@@ -4,6 +4,7 @@ package refs;
 public class RefToSomeStruct {
     public Object fieldAny;
     public RefToSomeStruct() {
+        this.fieldAny = new Object();
     }
     public RefToSomeStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeOtherStruct.java
@@ -4,6 +4,7 @@ package struct_complex_fields;
 public class SomeOtherStruct {
     public Object fieldAny;
     public SomeOtherStruct() {
+        this.fieldAny = new Object();
     }
     public SomeOtherStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/SomeStruct.java
@@ -1,5 +1,7 @@
 package struct_complex_fields;
 
+import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +17,14 @@ public class SomeStruct {
     public StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct;
     public String fieldRefToConstant;
     public SomeStruct() {
+        this.fieldRef = new struct_complex_fields.SomeOtherStruct();
+        this.fieldDisjunctionOfScalars = new struct_complex_fields.StringOrBool();
+        this.fieldMixedDisjunction = new struct_complex_fields.StringOrSomeOtherStruct();
+        this.operator = SomeStructOperator.GREATER_THAN;
+        this.fieldArrayOfStrings = new LinkedList<>();
+        this.fieldMapOfStringToString = new HashMap<>();
+        this.fieldAnonymousStruct = new struct_complex_fields.StructComplexFieldsSomeStructFieldAnonymousStruct();
+        this.fieldRefToConstant = new struct_complex_fields.ConnectionPath();
     }
     public SomeStruct(SomeOtherStruct fieldRef,StringOrBool fieldDisjunctionOfScalars,StringOrSomeOtherStruct fieldMixedDisjunction,String fieldDisjunctionWithNull,SomeStructOperator operator,List<String> fieldArrayOfStrings,Map<String, String> fieldMapOfStringToString,StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct,String fieldRefToConstant) {
         this.fieldRef = fieldRef;

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StructComplexFieldsSomeStructFieldAnonymousStruct.java
@@ -4,6 +4,7 @@ package struct_complex_fields;
 public class StructComplexFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
     public StructComplexFieldsSomeStructFieldAnonymousStruct() {
+        this.fieldAny = new Object();
     }
     public StructComplexFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_defaults/JavaRawTypes/defaults/SomeStruct.java
@@ -10,6 +10,7 @@ public class SomeStruct {
     public SomeStruct() {
         this.fieldBool = true;
         this.fieldString = "foo";
+        this.fieldStringWithConstantValue = "";
         this.fieldFloat32 = 42.4f;
         this.fieldInt32 = 42;
     }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/SomeOtherStruct.java
@@ -4,6 +4,7 @@ package struct_optional_fields;
 public class SomeOtherStruct {
     public Object fieldAny;
     public SomeOtherStruct() {
+        this.fieldAny = new Object();
     }
     public SomeOtherStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JavaRawTypes/struct_optional_fields/StructOptionalFieldsSomeStructFieldAnonymousStruct.java
@@ -4,6 +4,7 @@ package struct_optional_fields;
 public class StructOptionalFieldsSomeStructFieldAnonymousStruct {
     public Object fieldAny;
     public StructOptionalFieldsSomeStructFieldAnonymousStruct() {
+        this.fieldAny = new Object();
     }
     public StructOptionalFieldsSomeStructFieldAnonymousStruct(Object fieldAny) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/JavaRawTypes/basic/SomeStruct.java
@@ -24,6 +24,21 @@ public class SomeStruct {
     public Integer fieldInt32;
     public Long fieldInt64;
     public SomeStruct() {
+        this.fieldAny = new Object();
+        this.fieldBool = false;
+        this.fieldBytes = (byte) 0;
+        this.fieldString = "";
+        this.fieldStringWithConstantValue = "";
+        this.fieldFloat32 = 0.0f;
+        this.fieldFloat64 = 0.0;
+        this.fieldUint8 = 0;
+        this.fieldUint16 = 0;
+        this.fieldUint32 = 0;
+        this.fieldUint64 = 0L;
+        this.fieldInt8 = 0;
+        this.fieldInt16 = 0;
+        this.fieldInt32 = 0;
+        this.fieldInt64 = 0L;
     }
     public SomeStruct(Object fieldAny,Boolean fieldBool,Byte fieldBytes,String fieldString,String fieldStringWithConstantValue,Float fieldFloat32,Double fieldFloat64,Integer fieldUint8,Short fieldUint16,Integer fieldUint32,Long fieldUint64,Integer fieldInt8,Short fieldInt16,Integer fieldInt32,Long fieldInt64) {
         this.fieldAny = fieldAny;

--- a/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
+++ b/testdata/jennies/rawtypes/time_hint/JavaRawTypes/time_hint/ObjWithTimeField.java
@@ -4,6 +4,7 @@ package time_hint;
 public class ObjWithTimeField {
     public String registeredAt;
     public ObjWithTimeField() {
+        this.registeredAt = "";
     }
     public ObjWithTimeField(String registeredAt) {
         this.registeredAt = registeredAt;

--- a/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
+++ b/testdata/jennies/rawtypes/variant_dataquery/JavaRawTypes/variant_dataquery/Query.java
@@ -5,6 +5,7 @@ public class Query implements cog.variants.Dataquery {
     public String expr;
     public Boolean instant;
     public Query() {
+        this.expr = "";
     }
     public Query(String expr,Boolean instant) {
         this.expr = expr;

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/FieldConfig.java
@@ -4,6 +4,7 @@ package variant_panelcfg_full;
 public class FieldConfig {
     public String timeseriesFieldConfigOption;
     public FieldConfig() {
+        this.timeseriesFieldConfigOption = "";
     }
     public FieldConfig(String timeseriesFieldConfigOption) {
         this.timeseriesFieldConfigOption = timeseriesFieldConfigOption;

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/JavaRawTypes/variant_panelcfg_full/Options.java
@@ -4,6 +4,7 @@ package variant_panelcfg_full;
 public class Options {
     public String timeseriesOption;
     public Options() {
+        this.timeseriesOption = "";
     }
     public Options(String timeseriesOption) {
         this.timeseriesOption = timeseriesOption;

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/JavaRawTypes/variant_panelcfg_only_options/Options.java
@@ -4,6 +4,7 @@ package variant_panelcfg_only_options;
 public class Options {
     public String content;
     public Options() {
+        this.content = "";
     }
     public Options(String content) {
         this.content = content;


### PR DESCRIPTION
Without these empty values, we end up producing JSON that isn't valid with the original schemas.

Other languages do something similar too.