### PR TITLE
Fix generated options reference in java

### DIFF
--- a/internal/jennies/java/apiref.go
+++ b/internal/jennies/java/apiref.go
@@ -80,7 +80,7 @@ func (apiRef *APIRef) apiReferenceFormatter() common.APIReferenceFormatter {
 		OptionSignature: func(context languages.Context, builder ast.Builder, option ast.Option) string {
 			typesFormatter := createFormatter(context, apiRef.config).withPackageMapper(pkgMapper)
 			args := tools.Map(option.Args, func(arg ast.Argument) string {
-				argType := typesFormatter.formatFieldType(arg.Type)
+				argType := typesFormatter.formatBuilderFieldType(arg.Type)
 				if argType != "" {
 					argType += " "
 				}


### PR DESCRIPTION
The reference for options in Java currently show incorrect signature: even when options accept builders, the documentation tells otherwise.