### PR TITLE
Java type constructors shouldn't use builders

### DIFF
--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -78,8 +78,10 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 	})
 
 	return jenny.tmpl.Funcs(map[string]any{
-		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
-		"emptyValueForType":        jenny.typeFormatter.emptyValueForType,
+		"formatBuilderFieldType": jenny.typeFormatter.formatBuilderFieldType,
+		"emptyValueForType": func(def ast.Type) string {
+			return jenny.typeFormatter.emptyValueForType(def, true)
+		},
 		"typeHasBuilder":           jenny.typeFormatter.typeHasBuilder,
 		"resolvesToComposableSlot": jenny.typeFormatter.resolvesToComposableSlot,
 		"formatAssignmentPath":     jenny.typeFormatter.formatAssignmentPath,

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -261,7 +261,7 @@ func (jenny RawTypes) constructors(object ast.Object) []ConstructorTemplate {
 			defaultConstructorAssignments = append(defaultConstructorAssignments, ConstructorAssignmentTemplate{
 				Name:  name,
 				Type:  field.Type,
-				Value: jenny.typeFormatter.emptyValueForType(field.Type),
+				Value: jenny.typeFormatter.emptyValueForType(field.Type, false),
 			})
 		}
 	}
@@ -320,7 +320,7 @@ func (jenny RawTypes) formatReferenceDefaults(ref ast.Type, value any) string {
 		if v, ok := defaultValues[f.Name]; ok {
 			args[i] = jenny.genDefaultForType(f.Type, v)
 		} else {
-			args[i] = jenny.typeFormatter.emptyValueForType(f.Type)
+			args[i] = jenny.typeFormatter.emptyValueForType(f.Type, false)
 		}
 	}
 

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -166,7 +166,7 @@ func formatScalarType(def ast.ScalarType) string {
 	return scalarType
 }
 
-func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
+func (tf *typeFormatter) emptyValueForType(def ast.Type, useBuilders bool) string {
 	switch def.Kind {
 	case ast.KindArray:
 		tf.packageMapper("java.util", "LinkedList")
@@ -176,7 +176,7 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 		return "new HashMap<>()"
 	case ast.KindRef:
 		refDef := fmt.Sprintf("%s.%s", formatPackageName(def.AsRef().ReferredPkg), formatObjectName(def.AsRef().ReferredType))
-		if tf.typeHasBuilder(def) {
+		if useBuilders && tf.typeHasBuilder(def) {
 			return fmt.Sprintf("new %sBuilder().build()", tf.config.formatPackage(refDef))
 		}
 


### PR DESCRIPTION
In some cases, java constructors would rely on builders to get the empty value for a field: this is a bug :|