### PR TITLE
Go: Fix error propagation

### DIFF
--- a/examples/_go_alerting/main.go
+++ b/examples/_go_alerting/main.go
@@ -21,6 +21,7 @@ func main() {
 		Interval(alerting.Duration(interval.Seconds())). // type is confusing
 		WithRule(alerting.NewRuleBuilder("cog alert rule name").
 			For("5m").
+			RuleGroup("group").
 			Annotations(map[string]string{
 				"summary":     "summary",
 				"description": "desc",

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -75,7 +75,7 @@
             {{- else }}
                 {{ .OriginalInputVar }}Depth{{ .Depth }}, err := r{{ .Depth }}.Build()
                 if err != nil {
-                    builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 {{ .ResultVar }} = append({{ .ResultVar}}, {{ .OriginalInputVar }}Depth{{ .Depth }})
@@ -91,7 +91,7 @@
             {{- else }}
                 {{ .OriginalInputVar }}Depth{{ .Depth }}, err := val{{ .Depth }}.Build()
                 if err != nil {
-                    builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 {{ .ResultVar }}[key{{ .Depth }}] = {{ .OriginalInputVar }}Depth{{ .Depth }}
@@ -100,7 +100,7 @@
     {{- else }}
     {{ .ResultVar }}, err := {{ .InputVar}}.Build()
     if err != nil {
-        builder.errors["{{ .AssignmentPath }}"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     {{- end }}

--- a/internal/jennies/golang/templates/builders/builder.tmpl
+++ b/internal/jennies/golang/templates/builders/builder.tmpl
@@ -8,7 +8,7 @@ var _ cog.Builder[{{ .BuilderSignatureType }}] = (*{{ .Builder.Name|formatObject
 {{- end }}
 type {{ .Builder.Name|formatObjectName }}Builder struct {
     internal *{{ .ObjectName }}
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 
     {{- range .Builder.Properties }}
     {{ .Name }} {{ .Type | formatType }}
@@ -19,7 +19,7 @@ func New{{ .Builder.Name|formatObjectName }}Builder({{- template "args" .Builder
 	resource := {{ .ConstructorName }}()
 	builder := &{{ .Builder.Name|formatObjectName }}Builder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
     {{- range .Builder.Constructor.Assignments }}
@@ -38,7 +38,7 @@ func (builder *{{ .Builder.Name|formatObjectName }}Builder) Build() ({{ .Builder
 		return {{ .ObjectName }}{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("{{ .Builder.Package | formatPackageName }}.{{ .Builder.Name | lowerCamelCase }}", builder.errors)
 }
 
 {{- $customMethodsTmpl := print "builder_" .Builder.Package "_" (.Builder.Name|formatObjectName) "_custom_methods" }}

--- a/internal/jennies/golang/templates/builders/builder.tmpl
+++ b/internal/jennies/golang/templates/builders/builder.tmpl
@@ -37,8 +37,12 @@ func (builder *{{ .Builder.Name|formatObjectName }}Builder) Build() ({{ .Builder
 	if err := builder.internal.Validate(); err != nil {
 		return {{ .ObjectName }}{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return {{ .ObjectName }}{}, cog.MakeBuildErrors("{{ .Builder.Package | formatPackageName }}.{{ .Builder.Name | lowerCamelCase }}", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("{{ .Builder.Package | formatPackageName }}.{{ .Builder.Name | lowerCamelCase }}", builder.errors)
+	return *builder.internal, nil
 }
 
 {{- $customMethodsTmpl := print "builder_" .Builder.Package "_" (.Builder.Name|formatObjectName) "_custom_methods" }}

--- a/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("anonymous_struct.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Time(time struct {

--- a/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/anonymous_struct/GoBuilder/anonymous_struct/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("anonymous_struct.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("anonymous_struct.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Time(time struct {

--- a/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Tags(tags string) *SomeStructBuilder {

--- a/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/array_append/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Tags(tags string) *SomeStructBuilder {

--- a/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 // SomeStruct, to hold data.
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("basic_struct.someStruct", builder.errors)
 }
 
 // id identifies something. Weird, right?

--- a/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct/GoBuilder/basic_struct/somestruct_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("basic_struct.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("basic_struct.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 // id identifies something. Weird, right?

--- a/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("basic_struct_defaults.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Id(id int64) *SomeStructBuilder {

--- a/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/basic_struct_defaults/GoBuilder/basic_struct_defaults/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("basic_struct_defaults.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("basic_struct_defaults.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Id(id int64) *SomeStructBuilder {

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
 
 type DashboardBuilder struct {
     internal *Dashboard
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewDashboardBuilder() *DashboardBuilder {
 	resource := NewDashboard()
 	builder := &DashboardBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 		return Dashboard{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("builder_delegation.dashboard", builder.errors)
 }
 
 func (builder *DashboardBuilder) Id(id int64) *DashboardBuilder {
@@ -49,7 +49,7 @@ func (builder *DashboardBuilder) Links(links []cog.Builder[DashboardLink]) *Dash
         for _, r1 := range links {
                 linksDepth1, err := r1.Build()
                 if err != nil {
-                    builder.errors["links"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 linksResources = append(linksResources, linksDepth1)
@@ -67,7 +67,7 @@ func (builder *DashboardBuilder) LinksOfLinks(linksOfLinks [][]cog.Builder[Dashb
         for _, r2 := range r1 {
                 linksOfLinksDepth2, err := r2.Build()
                 if err != nil {
-                    builder.errors["linksOfLinks"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 linksOfLinksDepth1 = append(linksOfLinksDepth1, linksOfLinksDepth2)
@@ -84,7 +84,7 @@ func (builder *DashboardBuilder) LinksOfLinks(linksOfLinks [][]cog.Builder[Dashb
 func (builder *DashboardBuilder) SingleLink(singleLink cog.Builder[DashboardLink]) *DashboardBuilder {
     singleLinkResource, err := singleLink.Build()
     if err != nil {
-        builder.errors["singleLink"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.SingleLink = singleLinkResource

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboard_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Dashboard{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Dashboard{}, cog.MakeBuildErrors("builder_delegation.dashboard", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("builder_delegation.dashboard", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *DashboardBuilder) Id(id int64) *DashboardBuilder {

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *DashboardLinkBuilder) Build() (DashboardLink, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return DashboardLink{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return DashboardLink{}, cog.MakeBuildErrors("builder_delegation.dashboardLink", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("builder_delegation.dashboardLink", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *DashboardLinkBuilder) Title(title string) *DashboardLinkBuilder {

--- a/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
+++ b/testdata/jennies/builders/builder_delegation/GoBuilder/builder_delegation/dashboardlink_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[DashboardLink] = (*DashboardLinkBuilder)(nil)
 
 type DashboardLinkBuilder struct {
     internal *DashboardLink
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewDashboardLinkBuilder() *DashboardLinkBuilder {
 	resource := NewDashboardLink()
 	builder := &DashboardLinkBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *DashboardLinkBuilder) Build() (DashboardLink, error) {
 		return DashboardLink{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("builder_delegation.dashboardLink", builder.errors)
 }
 
 func (builder *DashboardLinkBuilder) Title(title string) *DashboardLinkBuilder {

--- a/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[Dashboard] = (*LokiBuilderBuilder)(nil)
 
 type LokiBuilderBuilder struct {
     internal *Dashboard
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewLokiBuilderBuilder() *LokiBuilderBuilder {
 	resource := NewDashboard()
 	builder := &LokiBuilderBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,13 +29,13 @@ func (builder *LokiBuilderBuilder) Build() (Dashboard, error) {
 		return Dashboard{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("composable_slot.lokiBuilder", builder.errors)
 }
 
 func (builder *LokiBuilderBuilder) Target(target cog.Builder[variants.Dataquery]) *LokiBuilderBuilder {
     targetResource, err := target.Build()
     if err != nil {
-        builder.errors["target"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.Target = targetResource
@@ -48,7 +48,7 @@ func (builder *LokiBuilderBuilder) Targets(targets []cog.Builder[variants.Dataqu
         for _, r1 := range targets {
                 targetsDepth1, err := r1.Build()
                 if err != nil {
-                    builder.errors["targets"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 targetsResources = append(targetsResources, targetsDepth1)

--- a/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/composable_slot/GoBuilder/composable_slot/lokibuilder_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *LokiBuilderBuilder) Build() (Dashboard, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Dashboard{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Dashboard{}, cog.MakeBuildErrors("composable_slot.lokiBuilder", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("composable_slot.lokiBuilder", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *LokiBuilderBuilder) Target(target cog.Builder[variants.Dataquery]) *LokiBuilderBuilder {

--- a/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Editable() *SomeStructBuilder {

--- a/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constant_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Editable() *SomeStructBuilder {

--- a/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("constraints.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("constraints.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Id(id uint64) *SomeStructBuilder {

--- a/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constraints/GoBuilder/constraints/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("constraints.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Id(id uint64) *SomeStructBuilder {

--- a/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder(title string) *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
     builder.internal.Title = title
 
@@ -29,7 +29,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {

--- a/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/constructor_argument/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {

--- a/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomePanel] = (*SomePanelBuilder)(nil)
 
 type SomePanelBuilder struct {
     internal *SomePanel
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomePanelBuilder() *SomePanelBuilder {
 	resource := NewSomePanel()
 	builder := &SomePanelBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
     builder.internal.Type = "panel_type"
     builder.internal.Cursor = "tooltip"
@@ -30,7 +30,7 @@ func (builder *SomePanelBuilder) Build() (SomePanel, error) {
 		return SomePanel{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("constructor_initializations.somePanel", builder.errors)
 }
 
 func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {

--- a/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/constructor_initializations/GoBuilder/constructor_initializations/somepanel_builder_gen.go
@@ -29,8 +29,12 @@ func (builder *SomePanelBuilder) Build() (SomePanel, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomePanel{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomePanel{}, cog.MakeBuildErrors("constructor_initializations.somePanel", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("constructor_initializations.somePanel", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {

--- a/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *LokiBuilderBuilder) Build() (variants.Dataquery, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Loki{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Loki{}, cog.MakeBuildErrors("dataquery_variant_builder.lokiBuilder", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("dataquery_variant_builder.lokiBuilder", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *LokiBuilderBuilder) Expr(expr string) *LokiBuilderBuilder {

--- a/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
+++ b/testdata/jennies/builders/dataquery_variant_builder/GoBuilder/dataquery_variant_builder/lokibuilder_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[variants.Dataquery] = (*LokiBuilderBuilder)(nil)
 
 type LokiBuilderBuilder struct {
     internal *Loki
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewLokiBuilderBuilder() *LokiBuilderBuilder {
 	resource := NewLoki()
 	builder := &LokiBuilderBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *LokiBuilderBuilder) Build() (variants.Dataquery, error) {
 		return Loki{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("dataquery_variant_builder.lokiBuilder", builder.errors)
 }
 
 func (builder *LokiBuilderBuilder) Expr(expr string) *LokiBuilderBuilder {

--- a/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
 
 type DashboardBuilder struct {
     internal *Dashboard
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewDashboardBuilder() *DashboardBuilder {
 	resource := NewDashboard()
 	builder := &DashboardBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 		return Dashboard{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.dashboard", builder.errors)
 }
 
 func (builder *DashboardBuilder) WithVariable(name string,value string) *DashboardBuilder {

--- a/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/envelope_assignment/GoBuilder/sandbox/dashboard_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Dashboard{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Dashboard{}, cog.MakeBuildErrors("sandbox.dashboard", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.dashboard", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *DashboardBuilder) WithVariable(name string,value string) *DashboardBuilder {

--- a/testdata/jennies/builders/factories/GoBuilder/promql/funccallexpr_builder_gen.go
+++ b/testdata/jennies/builders/factories/GoBuilder/promql/funccallexpr_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[FuncCallExpr] = (*FuncCallExprBuilder)(nil)
 
 type FuncCallExprBuilder struct {
     internal *FuncCallExpr
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewFuncCallExprBuilder() *FuncCallExprBuilder {
 	resource := NewFuncCallExpr()
 	builder := &FuncCallExprBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
     builder.internal.Type = "funcCallExpr"
 
@@ -70,7 +70,7 @@ func (builder *FuncCallExprBuilder) Build() (FuncCallExpr, error) {
 		return FuncCallExpr{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("promql.funcCallExpr", builder.errors)
 }
 
 func (builder *FuncCallExprBuilder) Function(function string) *FuncCallExprBuilder {
@@ -84,7 +84,7 @@ func (builder *FuncCallExprBuilder) Args(args []cog.Builder[Expr]) *FuncCallExpr
         for _, r1 := range args {
                 argsDepth1, err := r1.Build()
                 if err != nil {
-                    builder.errors["args"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 argsResources = append(argsResources, argsDepth1)
@@ -99,7 +99,7 @@ func (builder *FuncCallExprBuilder) Args(args []cog.Builder[Expr]) *FuncCallExpr
 func (builder *FuncCallExprBuilder) Arg(arg cog.Builder[Expr]) *FuncCallExprBuilder {
     argResource, err := arg.Build()
     if err != nil {
-        builder.errors["args"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.Args = append(builder.internal.Args, argResource)

--- a/testdata/jennies/builders/factories/GoBuilder/promql/funccallexpr_builder_gen.go
+++ b/testdata/jennies/builders/factories/GoBuilder/promql/funccallexpr_builder_gen.go
@@ -69,8 +69,12 @@ func (builder *FuncCallExprBuilder) Build() (FuncCallExpr, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return FuncCallExpr{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return FuncCallExpr{}, cog.MakeBuildErrors("promql.funcCallExpr", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("promql.funcCallExpr", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *FuncCallExprBuilder) Function(function string) *FuncCallExprBuilder {

--- a/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[some_pkg.SomeStruct] = (*SomeNiceBuilderBuilder)(nil)
 
 type SomeNiceBuilderBuilder struct {
     internal *some_pkg.SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeNiceBuilderBuilder() *SomeNiceBuilderBuilder {
 	resource := some_pkg.NewSomeStruct()
 	builder := &SomeNiceBuilderBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *SomeNiceBuilderBuilder) Build() (some_pkg.SomeStruct, error) {
 		return some_pkg.SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("builder_pkg.someNiceBuilder", builder.errors)
 }
 
 func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuilder {

--- a/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/foreign_builder/GoBuilder/builder_pkg/somenicebuilder_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *SomeNiceBuilderBuilder) Build() (some_pkg.SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return some_pkg.SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return some_pkg.SomeStruct{}, cog.MakeBuildErrors("builder_pkg.someNiceBuilder", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("builder_pkg.someNiceBuilder", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuilder {

--- a/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomePanel] = (*SomePanelBuilder)(nil)
 
 type SomePanelBuilder struct {
     internal *SomePanel
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomePanelBuilder() *SomePanelBuilder {
 	resource := NewSomePanel()
 	builder := &SomePanelBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomePanelBuilder) Build() (SomePanel, error) {
 		return SomePanel{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("initialization_safeguards.somePanel", builder.errors)
 }
 
 func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {

--- a/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
+++ b/testdata/jennies/builders/initialization_safeguards/GoBuilder/initialization_safeguards/somepanel_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomePanelBuilder) Build() (SomePanel, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomePanel{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomePanel{}, cog.MakeBuildErrors("initialization_safeguards.somePanel", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("initialization_safeguards.somePanel", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomePanelBuilder) Title(title string) *SomePanelBuilder {

--- a/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("known_any.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("known_any.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {

--- a/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/known_any/GoBuilder/known_any/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("known_any.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {

--- a/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Annotations(key string,value string) *SomeStructBuilder {

--- a/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/map_index_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Annotations(key string,value string) *SomeStructBuilder {

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Dashboard{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Dashboard{}, cog.MakeBuildErrors("map_of_builders.dashboard", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("map_of_builders.dashboard", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Panel]) *DashboardBuilder {

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/dashboard_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
 
 type DashboardBuilder struct {
     internal *Dashboard
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewDashboardBuilder() *DashboardBuilder {
 	resource := NewDashboard()
 	builder := &DashboardBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *DashboardBuilder) Build() (Dashboard, error) {
 		return Dashboard{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("map_of_builders.dashboard", builder.errors)
 }
 
 func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Panel]) *DashboardBuilder {
@@ -36,7 +36,7 @@ func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Panel]) *D
         for key1, val1 := range panels {
                 panelsDepth1, err := val1.Build()
                 if err != nil {
-                    builder.errors["panels"] = err.(cog.BuildErrors)
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
                     return builder
                 }
                 panelsResource[key1] = panelsDepth1

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *PanelBuilder) Build() (Panel, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Panel{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Panel{}, cog.MakeBuildErrors("map_of_builders.panel", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("map_of_builders.panel", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *PanelBuilder) Title(title string) *PanelBuilder {

--- a/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_builders/GoBuilder/map_of_builders/panel_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Panel] = (*PanelBuilder)(nil)
 
 type PanelBuilder struct {
     internal *Panel
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewPanelBuilder() *PanelBuilder {
 	resource := NewPanel()
 	builder := &PanelBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *PanelBuilder) Build() (Panel, error) {
 		return Panel{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("map_of_builders.panel", builder.errors)
 }
 
 func (builder *PanelBuilder) Title(title string) *PanelBuilder {

--- a/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("nullable_map_assignment.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("nullable_map_assignment.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Config(config map[string]string) *SomeStructBuilder {

--- a/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/nullable_map_assignment/GoBuilder/nullable_map_assignment/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("nullable_map_assignment.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Config(config map[string]string) *SomeStructBuilder {

--- a/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[withdashes.SomeStruct] = (*SomeNiceBuilderBuilder)(nil)
 
 type SomeNiceBuilderBuilder struct {
     internal *withdashes.SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeNiceBuilderBuilder() *SomeNiceBuilderBuilder {
 	resource := withdashes.NewSomeStruct()
 	builder := &SomeNiceBuilderBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *SomeNiceBuilderBuilder) Build() (withdashes.SomeStruct, error) {
 		return withdashes.SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("builderpkg.someNiceBuilder", builder.errors)
 }
 
 func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuilder {

--- a/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
+++ b/testdata/jennies/builders/package-with-dashes/GoBuilder/builderpkg/somenicebuilder_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *SomeNiceBuilderBuilder) Build() (withdashes.SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return withdashes.SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return withdashes.SomeStruct{}, cog.MakeBuildErrors("builderpkg.someNiceBuilder", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("builderpkg.someNiceBuilder", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeNiceBuilderBuilder) Title(title string) *SomeNiceBuilderBuilder {

--- a/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Panel] = (*PanelBuilder)(nil)
 
 type PanelBuilder struct {
     internal *Panel
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewPanelBuilder() *PanelBuilder {
 	resource := NewPanel()
 	builder := &PanelBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *PanelBuilder) Build() (Panel, error) {
 		return Panel{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("panelbuilder.panel", builder.errors)
 }
 
 func (builder *PanelBuilder) OnlyFromThisDashboard(onlyFromThisDashboard bool) *PanelBuilder {

--- a/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
+++ b/testdata/jennies/builders/panel_builders/GoBuilder/panelbuilder/panel_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *PanelBuilder) Build() (Panel, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Panel{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Panel{}, cog.MakeBuildErrors("panelbuilder.panel", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("panelbuilder.panel", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *PanelBuilder) OnlyFromThisDashboard(onlyFromThisDashboard bool) *PanelBuilder {

--- a/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("properties.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("properties.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Id(id int64) *SomeStructBuilder {

--- a/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/properties/GoBuilder/properties/somestruct_builder_gen.go
@@ -8,7 +8,7 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
     someBuilderProperty string
 }
 
@@ -16,7 +16,7 @@ func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("properties.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Id(id int64) *SomeStructBuilder {

--- a/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
+++ b/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
@@ -9,14 +9,14 @@ var _ cog.Builder[Person] = (*PersonBuilder)(nil)
 
 type PersonBuilder struct {
     internal *Person
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewPersonBuilder() *PersonBuilder {
 	resource := NewPerson()
 	builder := &PersonBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -29,7 +29,7 @@ func (builder *PersonBuilder) Build() (Person, error) {
 		return Person{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("some_pkg.person", builder.errors)
 }
 
 func (builder *PersonBuilder) Name(name other_pkg.Name) *PersonBuilder {

--- a/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
+++ b/testdata/jennies/builders/references/GoBuilder/some_pkg/person_builder_gen.go
@@ -28,8 +28,12 @@ func (builder *PersonBuilder) Build() (Person, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Person{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Person{}, cog.MakeBuildErrors("some_pkg.person", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("some_pkg.person", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *PersonBuilder) Name(name other_pkg.Name) *PersonBuilder {

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return SomeStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *SomeStructBuilder) Time(from string,to string) *SomeStructBuilder {

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
 
 type SomeStructBuilder struct {
     internal *SomeStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewSomeStructBuilder() *SomeStructBuilder {
 	resource := NewSomeStruct()
 	builder := &SomeStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
 		return SomeStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
 }
 
 func (builder *SomeStructBuilder) Time(from string,to string) *SomeStructBuilder {

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[NestedStruct] = (*NestedStructBuilder)(nil)
 
 type NestedStructBuilder struct {
     internal *NestedStruct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewNestedStructBuilder() *NestedStructBuilder {
 	resource := NewNestedStruct()
 	builder := &NestedStructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,7 +28,7 @@ func (builder *NestedStructBuilder) Build() (NestedStruct, error) {
 		return NestedStruct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("struct_with_defaults.nestedStruct", builder.errors)
 }
 
 func (builder *NestedStructBuilder) StringVal(stringVal string) *NestedStructBuilder {

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/nestedstruct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *NestedStructBuilder) Build() (NestedStruct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return NestedStruct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return NestedStruct{}, cog.MakeBuildErrors("struct_with_defaults.nestedStruct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("struct_with_defaults.nestedStruct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *NestedStructBuilder) StringVal(stringVal string) *NestedStructBuilder {

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
@@ -8,14 +8,14 @@ var _ cog.Builder[Struct] = (*StructBuilder)(nil)
 
 type StructBuilder struct {
     internal *Struct
-    errors map[string]cog.BuildErrors
+    errors cog.BuildErrors
 }
 
 func NewStructBuilder() *StructBuilder {
 	resource := NewStruct()
 	builder := &StructBuilder{
 		internal: resource,
-		errors: make(map[string]cog.BuildErrors),
+		errors: make(cog.BuildErrors, 0),
 	}
 
 	return builder
@@ -28,13 +28,13 @@ func (builder *StructBuilder) Build() (Struct, error) {
 		return Struct{}, err
 	}
 
-	return *builder.internal, nil
+	return *builder.internal, cog.MakeBuildErrors("struct_with_defaults.struct", builder.errors)
 }
 
 func (builder *StructBuilder) AllFields(allFields cog.Builder[NestedStruct]) *StructBuilder {
     allFieldsResource, err := allFields.Build()
     if err != nil {
-        builder.errors["allFields"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.AllFields = allFieldsResource
@@ -45,7 +45,7 @@ func (builder *StructBuilder) AllFields(allFields cog.Builder[NestedStruct]) *St
 func (builder *StructBuilder) PartialFields(partialFields cog.Builder[NestedStruct]) *StructBuilder {
     partialFieldsResource, err := partialFields.Build()
     if err != nil {
-        builder.errors["partialFields"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.PartialFields = partialFieldsResource
@@ -56,7 +56,7 @@ func (builder *StructBuilder) PartialFields(partialFields cog.Builder[NestedStru
 func (builder *StructBuilder) EmptyFields(emptyFields cog.Builder[NestedStruct]) *StructBuilder {
     emptyFieldsResource, err := emptyFields.Build()
     if err != nil {
-        builder.errors["emptyFields"] = err.(cog.BuildErrors)
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
         return builder
     }
     builder.internal.EmptyFields = emptyFieldsResource

--- a/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
+++ b/testdata/jennies/builders/struct_with_defaults/GoBuilder/struct_with_defaults/struct_builder_gen.go
@@ -27,8 +27,12 @@ func (builder *StructBuilder) Build() (Struct, error) {
 	if err := builder.internal.Validate(); err != nil {
 		return Struct{}, err
 	}
+	
+	if len(builder.errors) > 0 {
+	    return Struct{}, cog.MakeBuildErrors("struct_with_defaults.struct", builder.errors)
+	}
 
-	return *builder.internal, cog.MakeBuildErrors("struct_with_defaults.struct", builder.errors)
+	return *builder.internal, nil
 }
 
 func (builder *StructBuilder) AllFields(allFields cog.Builder[NestedStruct]) *StructBuilder {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-foundation-sdk/issues/748

It returns builder.errors instead of nil when validation is ok. The error happens in panels because they extend from the Panel and this validator doesn't check internal values.

The error map was changed into an array since the index value is never used.