### PR TITLE
Pipeline: Create output options with replace extensions map

### DIFF
--- a/internal/codegen/output.go
+++ b/internal/codegen/output.go
@@ -41,6 +41,9 @@ type Output struct {
 	// TemplatesData holds data that will be injected into package and
 	// repository templates when rendering them.
 	TemplatesData map[string]string `yaml:"templates_data"`
+
+	// OutputOptions configures the output of the file
+	OutputOptions OutputOptions `yaml:"output_options"`
 }
 
 func (output *Output) interpolateParameters(interpolator ParametersInterpolator) {
@@ -87,4 +90,9 @@ func (outputLanguage *OutputLanguage) interpolateParameters(output *Output, inte
 		outputLanguage.Typescript.InterpolateParameters(interpolator)
 		outputLanguage.Typescript.ExtraFilesTemplatesData = output.TemplatesData
 	}
+}
+
+type OutputOptions struct {
+	// ReplaceExtension updates file extensions to the new one
+	ReplaceExtension map[string]string `yaml:"replace_extension"`
 }

--- a/internal/codegen/tools.go
+++ b/internal/codegen/tools.go
@@ -66,8 +66,9 @@ func repositoryTemplatesJenny(pipeline *Pipeline) (*codejen.JennyList[common.Bui
 		return "RepositoryTemplates"
 	})
 	repoTemplatesJenny.AppendOneToMany(&common.RepositoryTemplate{
-		TemplateDir: pipeline.Output.RepositoryTemplates,
-		ExtraData:   pipeline.Output.TemplatesData,
+		TemplateDir:       pipeline.Output.RepositoryTemplates,
+		ExtraData:         pipeline.Output.TemplatesData,
+		ReplaceExtensions: pipeline.Output.OutputOptions.ReplaceExtension,
 	})
 	repoTemplatesJenny.AddPostprocessors(
 		common.GeneratedCommentHeader(pipeline.jenniesConfig()),

--- a/internal/jennies/common/repotemplate.go
+++ b/internal/jennies/common/repotemplate.go
@@ -16,8 +16,9 @@ type BuildOptions struct {
 }
 
 type RepositoryTemplate struct {
-	TemplateDir string
-	ExtraData   map[string]string
+	TemplateDir       string
+	ExtraData         map[string]string
+	ReplaceExtensions map[string]string
 }
 
 func (jenny RepositoryTemplate) JennyName() string {
@@ -72,6 +73,11 @@ func (jenny RepositoryTemplate) renderDirectory(directory string) (codejen.Files
 		rendered, err := tmpl.ExecuteAsBytes(jenny.templateData())
 		if err != nil {
 			return err
+		}
+
+		ext := strings.TrimPrefix(filepath.Ext(path), ".")
+		if newExt, ok := jenny.ReplaceExtensions[ext]; ok {
+			path = strings.TrimSuffix(path, ext) + newExt
 		}
 
 		if len(rendered) != 0 {

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -227,6 +227,10 @@
           },
           "type": "object",
           "description": "TemplatesData holds data that will be injected into package and\nrepository templates when rendering them."
+        },
+        "output_options": {
+          "$ref": "#/$defs/CodegenOutputOptions",
+          "description": "OutputOptions configures the output of the file"
         }
       },
       "additionalProperties": false,
@@ -254,6 +258,19 @@
         },
         "typescript": {
           "$ref": "#/$defs/TypescriptConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CodegenOutputOptions": {
+      "properties": {
+        "replace_extension": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "ReplaceExtension updates file extensions to the new one"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Its a dummy change that allows to update the extension of the parsed files for CI configuration. This configuration is specific per language that adds information for testing and publishing.

For that we are using templates where we replace some information to set the proper version of Grafana since we are working in branches and each branch, should have its version. The problem is that we are using `yaml` files as templates and these templates have escape values to be able to set this information and its detected as "invalid" with `zizmor`.

So with this change we can "skip" this check using a different format against the templates. When we create a new release, the template will generate the final yaml file for CI and `zizmor` will be executed.