### PR TITLE
CI: Remove cache from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,20 +28,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Restore go vendors
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-deps-${{ runner.os }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-deps-${{ runner.os }}
-
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
+        uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 #v0.13.0
         with:
-          enable-cache: "true"
+          enable-cache: "false"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run GoReleaser


### PR DESCRIPTION
Zizmor is being a bit noisy notifying a low priority issue with the cache. After reading about it, it seems that caching is not recommended in release workflows.