### PR TITLE
Go: Add YAML struct tags to generated code

### DIFF
--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -99,7 +99,7 @@ func TestBuilder_emptyValueForGuard(t *testing.T) {
 			context: languages.Context{},
 			input:   ast.NewStruct(ast.NewStructField("field", ast.String())),
 			expected: `&struct {
-    Field string ` + "`" + `json:"field,omitempty"` + "`" + `
+		Field string ` + "`" + `json:"field,omitempty" yaml:"field,omitempty"` + "`" + `
 }{}`,
 		},
 	}

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -227,7 +227,7 @@ func (formatter *typeFormatter) formatField(def ast.StructField) string {
 	}
 
 	buffer.WriteString(fmt.Sprintf(
-		"%s %s `json:\"%s%s\"`",
+		"%s %s `json:\"%[3]s%[4]s\" yaml:\"%[3]s%[4]s\"`",
 		formatFieldName(def.Name),
 		formatter.doFormatType(fieldType, false),
 		def.Name,

--- a/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
+++ b/testdata/jennies/rawtypes/arrays/GoRawTypes/arrays/types_gen.go
@@ -12,7 +12,7 @@ import (
 type ArrayOfStrings []string
 
 type SomeStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/GoRawTypes/constant_reference_discriminator/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/GoRawTypes/constant_reference_discriminator/types_gen.go
@@ -14,8 +14,8 @@ func NewLayoutWithValue() *LayoutWithValue {
 	return NewGridLayoutUsingValueOrRowsLayoutUsingValue()
 }
 type GridLayoutUsingValue struct {
-    Kind string `json:"kind"`
-    GridLayoutProperty string `json:"gridLayoutProperty"`
+    Kind string `json:"kind" yaml:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty" yaml:"gridLayoutProperty"`
 }
 
 // NewGridLayoutUsingValue creates a new GridLayoutUsingValue object.
@@ -93,8 +93,8 @@ func (resource GridLayoutUsingValue) Validate() error {
 
 
 type RowsLayoutUsingValue struct {
-    Kind string `json:"kind"`
-    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+    Kind string `json:"kind" yaml:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty" yaml:"rowsLayoutProperty"`
 }
 
 // NewRowsLayoutUsingValue creates a new RowsLayoutUsingValue object.
@@ -178,8 +178,8 @@ func NewLayoutWithoutValue() *LayoutWithoutValue {
 	return NewGridLayoutWithoutValueOrRowsLayoutWithoutValue()
 }
 type GridLayoutWithoutValue struct {
-    Kind string `json:"kind"`
-    GridLayoutProperty string `json:"gridLayoutProperty"`
+    Kind string `json:"kind" yaml:"kind"`
+    GridLayoutProperty string `json:"gridLayoutProperty" yaml:"gridLayoutProperty"`
 }
 
 // NewGridLayoutWithoutValue creates a new GridLayoutWithoutValue object.
@@ -257,8 +257,8 @@ func (resource GridLayoutWithoutValue) Validate() error {
 
 
 type RowsLayoutWithoutValue struct {
-    Kind string `json:"kind"`
-    RowsLayoutProperty string `json:"rowsLayoutProperty"`
+    Kind string `json:"kind" yaml:"kind"`
+    RowsLayoutProperty string `json:"rowsLayoutProperty" yaml:"rowsLayoutProperty"`
 }
 
 // NewRowsLayoutWithoutValue creates a new RowsLayoutWithoutValue object.
@@ -340,8 +340,8 @@ const GridLayoutKindType = "GridLayout"
 const RowsLayoutKindType = "RowsLayout"
 
 type GridLayoutUsingValueOrRowsLayoutUsingValue struct {
-    GridLayoutUsingValue *GridLayoutUsingValue `json:"GridLayoutUsingValue,omitempty"`
-    RowsLayoutUsingValue *RowsLayoutUsingValue `json:"RowsLayoutUsingValue,omitempty"`
+    GridLayoutUsingValue *GridLayoutUsingValue `json:"GridLayoutUsingValue,omitempty" yaml:"GridLayoutUsingValue,omitempty"`
+    RowsLayoutUsingValue *RowsLayoutUsingValue `json:"RowsLayoutUsingValue,omitempty" yaml:"RowsLayoutUsingValue,omitempty"`
 }
 
 // NewGridLayoutUsingValueOrRowsLayoutUsingValue creates a new GridLayoutUsingValueOrRowsLayoutUsingValue object.
@@ -488,8 +488,8 @@ func (resource GridLayoutUsingValueOrRowsLayoutUsingValue) Validate() error {
 
 
 type GridLayoutWithoutValueOrRowsLayoutWithoutValue struct {
-    GridLayoutWithoutValue *GridLayoutWithoutValue `json:"GridLayoutWithoutValue,omitempty"`
-    RowsLayoutWithoutValue *RowsLayoutWithoutValue `json:"RowsLayoutWithoutValue,omitempty"`
+    GridLayoutWithoutValue *GridLayoutWithoutValue `json:"GridLayoutWithoutValue,omitempty" yaml:"GridLayoutWithoutValue,omitempty"`
+    RowsLayoutWithoutValue *RowsLayoutWithoutValue `json:"RowsLayoutWithoutValue,omitempty" yaml:"RowsLayoutWithoutValue,omitempty"`
 }
 
 // NewGridLayoutWithoutValueOrRowsLayoutWithoutValue creates a new GridLayoutWithoutValueOrRowsLayoutWithoutValue object.

--- a/testdata/jennies/rawtypes/constant_references/GoRawTypes/constant_references/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_references/GoRawTypes/constant_references/types_gen.go
@@ -16,7 +16,7 @@ const (
 
 
 type ParentStruct struct {
-    MyEnum Enum `json:"myEnum"`
+    MyEnum Enum `json:"myEnum" yaml:"myEnum"`
 }
 
 // NewParentStruct creates a new ParentStruct object.
@@ -78,8 +78,8 @@ func (resource ParentStruct) Validate() error {
 
 
 type Struct struct {
-    MyValue string `json:"myValue"`
-    MyEnum Enum `json:"myEnum"`
+    MyValue string `json:"myValue" yaml:"myValue"`
+    MyEnum Enum `json:"myEnum" yaml:"myEnum"`
 }
 
 // NewStruct creates a new Struct object.
@@ -156,7 +156,7 @@ func (resource Struct) Validate() error {
 
 
 type StructA struct {
-    MyEnum Enum `json:"myEnum"`
+    MyEnum Enum `json:"myEnum" yaml:"myEnum"`
 }
 
 // NewStructA creates a new StructA object.
@@ -228,8 +228,8 @@ func (resource StructA) Validate() error {
 
 
 type StructB struct {
-    MyEnum Enum `json:"myEnum"`
-    MyValue string `json:"myValue"`
+    MyEnum Enum `json:"myEnum" yaml:"myEnum"`
+    MyValue string `json:"myValue" yaml:"myValue"`
 }
 
 // NewStructB creates a new StructB object.

--- a/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
+++ b/testdata/jennies/rawtypes/constraints/GoRawTypes/constraints/types_gen.go
@@ -9,10 +9,10 @@ import (
 )
 
 type SomeStruct struct {
-    Id uint64 `json:"id"`
-    MaybeId *uint64 `json:"maybeId,omitempty"`
-    Title string `json:"title"`
-    RefStruct *RefStruct `json:"refStruct,omitempty"`
+    Id uint64 `json:"id" yaml:"id"`
+    MaybeId *uint64 `json:"maybeId,omitempty" yaml:"maybeId,omitempty"`
+    Title string `json:"title" yaml:"title"`
+    RefStruct *RefStruct `json:"refStruct,omitempty" yaml:"refStruct,omitempty"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.
@@ -174,8 +174,8 @@ func (resource SomeStruct) Validate() error {
 
 
 type RefStruct struct {
-    Labels map[string]string `json:"labels"`
-    Tags []string `json:"tags"`
+    Labels map[string]string `json:"labels" yaml:"labels"`
+    Tags []string `json:"tags" yaml:"tags"`
 }
 
 // NewRefStruct creates a new RefStruct object.

--- a/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/GoRawTypes/dashboard/types_gen.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Dashboard struct {
-    Title string `json:"title"`
-    Panels []Panel `json:"panels,omitempty"`
+    Title string `json:"title" yaml:"title"`
+    Panels []Panel `json:"panels,omitempty" yaml:"panels,omitempty"`
 }
 
 // NewDashboard creates a new Dashboard object.
@@ -119,8 +119,8 @@ func (resource Dashboard) Validate() error {
 
 
 type DataSourceRef struct {
-    Type *string `json:"type,omitempty"`
-    Uid *string `json:"uid,omitempty"`
+    Type *string `json:"type,omitempty" yaml:"type,omitempty"`
+    Uid *string `json:"uid,omitempty" yaml:"uid,omitempty"`
 }
 
 // NewDataSourceRef creates a new DataSourceRef object.
@@ -207,7 +207,7 @@ func (resource DataSourceRef) Validate() error {
 
 
 type FieldConfigSource struct {
-    Defaults *FieldConfig `json:"defaults,omitempty"`
+    Defaults *FieldConfig `json:"defaults,omitempty" yaml:"defaults,omitempty"`
 }
 
 // NewFieldConfigSource creates a new FieldConfigSource object.
@@ -287,8 +287,8 @@ func (resource FieldConfigSource) Validate() error {
 
 
 type FieldConfig struct {
-    Unit *string `json:"unit,omitempty"`
-    Custom any `json:"custom,omitempty"`
+    Unit *string `json:"unit,omitempty" yaml:"unit,omitempty"`
+    Custom any `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 // NewFieldConfig creates a new FieldConfig object.
@@ -370,12 +370,12 @@ func (resource FieldConfig) Validate() error {
 
 
 type Panel struct {
-    Title string `json:"title"`
-    Type string `json:"type"`
-    Datasource *DataSourceRef `json:"datasource,omitempty"`
-    Options any `json:"options,omitempty"`
-    Targets []variants.Dataquery `json:"targets,omitempty"`
-    FieldConfig *FieldConfigSource `json:"fieldConfig,omitempty"`
+    Title string `json:"title" yaml:"title"`
+    Type string `json:"type" yaml:"type"`
+    Datasource *DataSourceRef `json:"datasource,omitempty" yaml:"datasource,omitempty"`
+    Options any `json:"options,omitempty" yaml:"options,omitempty"`
+    Targets []variants.Dataquery `json:"targets,omitempty" yaml:"targets,omitempty"`
+    FieldConfig *FieldConfigSource `json:"fieldConfig,omitempty" yaml:"fieldConfig,omitempty"`
 }
 
 // NewPanel creates a new Panel object.

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -18,8 +18,8 @@ func NewRefreshRate() *RefreshRate {
 type StringOrNull *string
 
 type SomeStruct struct {
-    Type string `json:"Type"`
-    FieldAny any `json:"FieldAny"`
+    Type string `json:"Type" yaml:"Type"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.
@@ -104,8 +104,8 @@ func NewBoolOrRef() *BoolOrRef {
 	return NewBoolOrSomeStruct()
 }
 type SomeOtherStruct struct {
-    Type string `json:"Type"`
-    Foo []byte `json:"Foo"`
+    Type string `json:"Type" yaml:"Type"`
+    Foo []byte `json:"Foo" yaml:"Foo"`
 }
 
 // NewSomeOtherStruct creates a new SomeOtherStruct object.
@@ -183,8 +183,8 @@ func (resource SomeOtherStruct) Validate() error {
 
 
 type YetAnotherStruct struct {
-    Type string `json:"Type"`
-    Bar uint8 `json:"Bar"`
+    Type string `json:"Type" yaml:"Type"`
+    Bar uint8 `json:"Bar" yaml:"Bar"`
 }
 
 // NewYetAnotherStruct creates a new YetAnotherStruct object.
@@ -268,8 +268,8 @@ func NewSeveralRefs() *SeveralRefs {
 	return NewSomeStructOrSomeOtherStructOrYetAnotherStruct()
 }
 type StringOrBool struct {
-    String *string `json:"String,omitempty"`
-    Bool *bool `json:"Bool,omitempty"`
+    String *string `json:"String,omitempty" yaml:"String,omitempty"`
+    Bool *bool `json:"Bool,omitempty" yaml:"Bool,omitempty"`
 }
 
 // NewStringOrBool creates a new StringOrBool object.
@@ -396,8 +396,8 @@ func (resource StringOrBool) Validate() error {
 
 
 type BoolOrSomeStruct struct {
-    Bool *bool `json:"Bool,omitempty"`
-    SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
+    Bool *bool `json:"Bool,omitempty" yaml:"Bool,omitempty"`
+    SomeStruct *SomeStruct `json:"SomeStruct,omitempty" yaml:"SomeStruct,omitempty"`
 }
 
 // NewBoolOrSomeStruct creates a new BoolOrSomeStruct object.
@@ -497,9 +497,9 @@ func (resource BoolOrSomeStruct) Validate() error {
 
 
 type SomeStructOrSomeOtherStructOrYetAnotherStruct struct {
-    SomeStruct *SomeStruct `json:"SomeStruct,omitempty"`
-    SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
-    YetAnotherStruct *YetAnotherStruct `json:"YetAnotherStruct,omitempty"`
+    SomeStruct *SomeStruct `json:"SomeStruct,omitempty" yaml:"SomeStruct,omitempty"`
+    SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty" yaml:"SomeOtherStruct,omitempty"`
+    YetAnotherStruct *YetAnotherStruct `json:"YetAnotherStruct,omitempty" yaml:"YetAnotherStruct,omitempty"`
 }
 
 // NewSomeStructOrSomeOtherStructOrYetAnotherStruct creates a new SomeStructOrSomeOtherStructOrYetAnotherStruct object.

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -8,8 +8,8 @@ import (
 )
 
 type NestedStruct struct {
-    StringVal string `json:"stringVal"`
-    IntVal int64 `json:"intVal"`
+    StringVal string `json:"stringVal" yaml:"stringVal"`
+    IntVal int64 `json:"intVal" yaml:"intVal"`
 }
 
 // NewNestedStruct creates a new NestedStruct object.
@@ -86,11 +86,11 @@ func (resource NestedStruct) Validate() error {
 
 
 type Struct struct {
-    AllFields NestedStruct `json:"allFields"`
-    PartialFields NestedStruct `json:"partialFields"`
-    EmptyFields NestedStruct `json:"emptyFields"`
-    ComplexField DefaultsStructComplexField `json:"complexField"`
-    PartialComplexField DefaultsStructPartialComplexField `json:"partialComplexField"`
+    AllFields NestedStruct `json:"allFields" yaml:"allFields"`
+    PartialFields NestedStruct `json:"partialFields" yaml:"partialFields"`
+    EmptyFields NestedStruct `json:"emptyFields" yaml:"emptyFields"`
+    ComplexField DefaultsStructComplexField `json:"complexField" yaml:"complexField"`
+    PartialComplexField DefaultsStructPartialComplexField `json:"partialComplexField" yaml:"partialComplexField"`
 }
 
 // NewStruct creates a new Struct object.
@@ -258,7 +258,7 @@ func (resource Struct) Validate() error {
 
 
 type DefaultsStructComplexFieldNested struct {
-    NestedVal string `json:"nestedVal"`
+    NestedVal string `json:"nestedVal" yaml:"nestedVal"`
 }
 
 // NewDefaultsStructComplexFieldNested creates a new DefaultsStructComplexFieldNested object.
@@ -320,9 +320,9 @@ func (resource DefaultsStructComplexFieldNested) Validate() error {
 
 
 type DefaultsStructComplexField struct {
-    Uid string `json:"uid"`
-    Nested DefaultsStructComplexFieldNested `json:"nested"`
-    Array []string `json:"array"`
+    Uid string `json:"uid" yaml:"uid"`
+    Nested DefaultsStructComplexFieldNested `json:"nested" yaml:"nested"`
+    Array []string `json:"array" yaml:"array"`
 }
 
 // NewDefaultsStructComplexField creates a new DefaultsStructComplexField object.
@@ -435,8 +435,8 @@ func (resource DefaultsStructComplexField) Validate() error {
 
 
 type DefaultsStructPartialComplexField struct {
-    Uid string `json:"uid"`
-    IntVal int64 `json:"intVal"`
+    Uid string `json:"uid" yaml:"uid"`
+    IntVal int64 `json:"intVal" yaml:"intVal"`
 }
 
 // NewDefaultsStructPartialComplexField creates a new DefaultsStructPartialComplexField object.

--- a/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
+++ b/testdata/jennies/rawtypes/intersections/GoRawTypes/intersections/types_gen.go
@@ -12,12 +12,12 @@ type Intersections struct {
 	SomeStruct
 	externalpkg.AnotherStruct
 
-	FieldString string `json:"fieldString"`
-	FieldInteger int32 `json:"fieldInteger"`
+	FieldString string `json:"fieldString" yaml:"fieldString"`
+	FieldInteger int32 `json:"fieldInteger" yaml:"fieldInteger"`
 }
 
 type SomeStruct struct {
-    FieldBool bool `json:"fieldBool"`
+    FieldBool bool `json:"fieldBool" yaml:"fieldBool"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
+++ b/testdata/jennies/rawtypes/maps/GoRawTypes/maps/types_gen.go
@@ -14,7 +14,7 @@ type MapOfStringToAny map[string]any
 type MapOfStringToString map[string]string
 
 type SomeStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/GoRawTypes/withdashes/types_gen.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SomeStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.
@@ -79,8 +79,8 @@ func NewRefreshRate() *RefreshRate {
 	return NewStringOrBool()
 }
 type StringOrBool struct {
-    String *string `json:"String,omitempty"`
-    Bool *bool `json:"Bool,omitempty"`
+    String *string `json:"String,omitempty" yaml:"String,omitempty"`
+    Bool *bool `json:"Bool,omitempty" yaml:"Bool,omitempty"`
 }
 
 // NewStringOrBool creates a new StringOrBool object.

--- a/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/GoRawTypes/refs/types_gen.go
@@ -10,7 +10,7 @@ import (
 )
 
 type SomeStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -10,15 +10,15 @@ import (
 
 // This struct does things.
 type SomeStruct struct {
-    FieldRef SomeOtherStruct `json:"FieldRef"`
-    FieldDisjunctionOfScalars StringOrBool `json:"FieldDisjunctionOfScalars"`
-    FieldMixedDisjunction StringOrSomeOtherStruct `json:"FieldMixedDisjunction"`
-    FieldDisjunctionWithNull *string `json:"FieldDisjunctionWithNull"`
-    Operator SomeStructOperator `json:"Operator"`
-    FieldArrayOfStrings []string `json:"FieldArrayOfStrings"`
-    FieldMapOfStringToString map[string]string `json:"FieldMapOfStringToString"`
-    FieldAnonymousStruct StructComplexFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct"`
-    FieldRefToConstant string `json:"fieldRefToConstant"`
+    FieldRef SomeOtherStruct `json:"FieldRef" yaml:"FieldRef"`
+    FieldDisjunctionOfScalars StringOrBool `json:"FieldDisjunctionOfScalars" yaml:"FieldDisjunctionOfScalars"`
+    FieldMixedDisjunction StringOrSomeOtherStruct `json:"FieldMixedDisjunction" yaml:"FieldMixedDisjunction"`
+    FieldDisjunctionWithNull *string `json:"FieldDisjunctionWithNull" yaml:"FieldDisjunctionWithNull"`
+    Operator SomeStructOperator `json:"Operator" yaml:"Operator"`
+    FieldArrayOfStrings []string `json:"FieldArrayOfStrings" yaml:"FieldArrayOfStrings"`
+    FieldMapOfStringToString map[string]string `json:"FieldMapOfStringToString" yaml:"FieldMapOfStringToString"`
+    FieldAnonymousStruct StructComplexFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct" yaml:"FieldAnonymousStruct"`
+    FieldRefToConstant string `json:"fieldRefToConstant" yaml:"fieldRefToConstant"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.
@@ -255,7 +255,7 @@ func (resource SomeStruct) Validate() error {
 const ConnectionPath = "straight"
 
 type SomeOtherStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeOtherStruct creates a new SomeOtherStruct object.
@@ -318,7 +318,7 @@ func (resource SomeOtherStruct) Validate() error {
 
 
 type StructComplexFieldsSomeStructFieldAnonymousStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewStructComplexFieldsSomeStructFieldAnonymousStruct creates a new StructComplexFieldsSomeStructFieldAnonymousStruct object.
@@ -388,8 +388,8 @@ const (
 
 
 type StringOrBool struct {
-    String *string `json:"String,omitempty"`
-    Bool *bool `json:"Bool,omitempty"`
+    String *string `json:"String,omitempty" yaml:"String,omitempty"`
+    Bool *bool `json:"Bool,omitempty" yaml:"Bool,omitempty"`
 }
 
 // NewStringOrBool creates a new StringOrBool object.
@@ -516,8 +516,8 @@ func (resource StringOrBool) Validate() error {
 
 
 type StringOrSomeOtherStruct struct {
-    String *string `json:"String,omitempty"`
-    SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty"`
+    String *string `json:"String,omitempty" yaml:"String,omitempty"`
+    SomeOtherStruct *SomeOtherStruct `json:"SomeOtherStruct,omitempty" yaml:"SomeOtherStruct,omitempty"`
 }
 
 // NewStringOrSomeOtherStruct creates a new StringOrSomeOtherStruct object.

--- a/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_defaults/GoRawTypes/defaults/types_gen.go
@@ -8,11 +8,11 @@ import (
 )
 
 type SomeStruct struct {
-    FieldBool bool `json:"fieldBool"`
-    FieldString string `json:"fieldString"`
-    FieldStringWithConstantValue string `json:"FieldStringWithConstantValue"`
-    FieldFloat32 float32 `json:"FieldFloat32"`
-    FieldInt32 int32 `json:"FieldInt32"`
+    FieldBool bool `json:"fieldBool" yaml:"fieldBool"`
+    FieldString string `json:"fieldString" yaml:"fieldString"`
+    FieldStringWithConstantValue string `json:"FieldStringWithConstantValue" yaml:"FieldStringWithConstantValue"`
+    FieldFloat32 float32 `json:"FieldFloat32" yaml:"FieldFloat32"`
+    FieldInt32 int32 `json:"FieldInt32" yaml:"FieldInt32"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/GoRawTypes/struct_optional_fields/types_gen.go
@@ -9,11 +9,11 @@ import (
 )
 
 type SomeStruct struct {
-    FieldRef *SomeOtherStruct `json:"FieldRef,omitempty"`
-    FieldString *string `json:"FieldString,omitempty"`
-    Operator *SomeStructOperator `json:"Operator,omitempty"`
-    FieldArrayOfStrings []string `json:"FieldArrayOfStrings,omitempty"`
-    FieldAnonymousStruct *StructOptionalFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct,omitempty"`
+    FieldRef *SomeOtherStruct `json:"FieldRef,omitempty" yaml:"FieldRef,omitempty"`
+    FieldString *string `json:"FieldString,omitempty" yaml:"FieldString,omitempty"`
+    Operator *SomeStructOperator `json:"Operator,omitempty" yaml:"Operator,omitempty"`
+    FieldArrayOfStrings []string `json:"FieldArrayOfStrings,omitempty" yaml:"FieldArrayOfStrings,omitempty"`
+    FieldAnonymousStruct *StructOptionalFieldsSomeStructFieldAnonymousStruct `json:"FieldAnonymousStruct,omitempty" yaml:"FieldAnonymousStruct,omitempty"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.
@@ -182,7 +182,7 @@ func (resource SomeStruct) Validate() error {
 
 
 type SomeOtherStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewSomeOtherStruct creates a new SomeOtherStruct object.
@@ -245,7 +245,7 @@ func (resource SomeOtherStruct) Validate() error {
 
 
 type StructOptionalFieldsSomeStructFieldAnonymousStruct struct {
-    FieldAny any `json:"FieldAny"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
 }
 
 // NewStructOptionalFieldsSomeStructFieldAnonymousStruct creates a new StructOptionalFieldsSomeStructFieldAnonymousStruct object.

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
@@ -15,21 +15,21 @@ import (
 type SomeStruct struct {
     // Anything can go in there.
     // Really, anything.
-    FieldAny any `json:"FieldAny"`
-    FieldBool bool `json:"FieldBool"`
-    FieldBytes []byte `json:"FieldBytes"`
-    FieldString string `json:"FieldString"`
-    FieldStringWithConstantValue string `json:"FieldStringWithConstantValue"`
-    FieldFloat32 float32 `json:"FieldFloat32"`
-    FieldFloat64 float64 `json:"FieldFloat64"`
-    FieldUint8 uint8 `json:"FieldUint8"`
-    FieldUint16 uint16 `json:"FieldUint16"`
-    FieldUint32 uint32 `json:"FieldUint32"`
-    FieldUint64 uint64 `json:"FieldUint64"`
-    FieldInt8 int8 `json:"FieldInt8"`
-    FieldInt16 int16 `json:"FieldInt16"`
-    FieldInt32 int32 `json:"FieldInt32"`
-    FieldInt64 int64 `json:"FieldInt64"`
+    FieldAny any `json:"FieldAny" yaml:"FieldAny"`
+    FieldBool bool `json:"FieldBool" yaml:"FieldBool"`
+    FieldBytes []byte `json:"FieldBytes" yaml:"FieldBytes"`
+    FieldString string `json:"FieldString" yaml:"FieldString"`
+    FieldStringWithConstantValue string `json:"FieldStringWithConstantValue" yaml:"FieldStringWithConstantValue"`
+    FieldFloat32 float32 `json:"FieldFloat32" yaml:"FieldFloat32"`
+    FieldFloat64 float64 `json:"FieldFloat64" yaml:"FieldFloat64"`
+    FieldUint8 uint8 `json:"FieldUint8" yaml:"FieldUint8"`
+    FieldUint16 uint16 `json:"FieldUint16" yaml:"FieldUint16"`
+    FieldUint32 uint32 `json:"FieldUint32" yaml:"FieldUint32"`
+    FieldUint64 uint64 `json:"FieldUint64" yaml:"FieldUint64"`
+    FieldInt8 int8 `json:"FieldInt8" yaml:"FieldInt8"`
+    FieldInt16 int16 `json:"FieldInt16" yaml:"FieldInt16"`
+    FieldInt32 int32 `json:"FieldInt32" yaml:"FieldInt32"`
+    FieldInt64 int64 `json:"FieldInt64" yaml:"FieldInt64"`
 }
 
 // NewSomeStruct creates a new SomeStruct object.

--- a/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/GoRawTypes/time_hint/types_gen.go
@@ -11,7 +11,7 @@ import (
 type ObjTime time.Time
 
 type ObjWithTimeField struct {
-    RegisteredAt time.Time `json:"registeredAt"`
+    RegisteredAt time.Time `json:"registeredAt" yaml:"registeredAt"`
 }
 
 // NewObjWithTimeField creates a new ObjWithTimeField object.

--- a/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/GoRawTypes/variant_dataquery/types_gen.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Query struct {
-    Expr string `json:"expr"`
-    Instant *bool `json:"instant,omitempty"`
+    Expr string `json:"expr" yaml:"expr"`
+    Instant *bool `json:"instant,omitempty" yaml:"instant,omitempty"`
 }
 func (resource Query) ImplementsDataqueryVariant() {}
 

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/GoRawTypes/variant_panelcfg_full/types_gen.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Options struct {
-    TimeseriesOption string `json:"timeseries_option"`
+    TimeseriesOption string `json:"timeseries_option" yaml:"timeseries_option"`
 }
 
 // NewOptions creates a new Options object.
@@ -70,7 +70,7 @@ func (resource Options) Validate() error {
 
 
 type FieldConfig struct {
-    TimeseriesFieldConfigOption string `json:"timeseries_field_config_option"`
+    TimeseriesFieldConfigOption string `json:"timeseries_field_config_option" yaml:"timeseries_field_config_option"`
 }
 
 // NewFieldConfig creates a new FieldConfig object.

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/GoRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Options struct {
-    Content string `json:"content"`
+    Content string `json:"content" yaml:"content"`
 }
 
 // NewOptions creates a new Options object.


### PR DESCRIPTION
This supports users who want to deserialize to Go using common YAML libraries like gopkg.in/yaml.v3

Fixes #812