### PR TITLE
Go: Add missing Marshal functions for disjunctions with mixed scalars and references

### DIFF
--- a/internal/ast/compiler/disjunctions.go
+++ b/internal/ast/compiler/disjunctions.go
@@ -117,10 +117,10 @@ func (pass *DisjunctionToType) processDisjunction(visitor *Visitor, schema *ast.
 	for hint, value := range def.Hints {
 		structType.Hints[hint] = value
 	}
-	if disjunction.Branches.HasOnlyScalarOrArrayOrMap() {
+	switch {
+	case disjunction.Branches.HasOnlyScalarOrArrayOrMap():
 		structType.Hints[ast.HintDisjunctionOfScalars] = disjunction
-	}
-	if disjunction.Branches.HasOnlyRefs() {
+	case disjunction.Branches.HasOnlyRefs():
 		if len(disjunction.Discriminator) == 0 {
 			return ast.Type{}, fmt.Errorf("discriminator not set")
 		}
@@ -128,6 +128,8 @@ func (pass *DisjunctionToType) processDisjunction(visitor *Visitor, schema *ast.
 			return ast.Type{}, fmt.Errorf("discriminator mapping not set")
 		}
 		structType.Hints[ast.HintDiscriminatedDisjunctionOfRefs] = disjunction
+	default:
+		structType.Hints[ast.HintDisjunctionOfScalarsAndRefs] = disjunction
 	}
 
 	newObject := ast.NewObject(schema.Package, newTypeName, structType)

--- a/internal/ast/hints.go
+++ b/internal/ast/hints.go
@@ -12,6 +12,10 @@ const (
 	// to this hint.
 	HintDiscriminatedDisjunctionOfRefs = "disjunction_of_refs"
 
+	// HintDisjunctionOfScalarsAndRefs indicates that the struct was
+	// previously in the IR by a disjunction of scalars and references
+	HintDisjunctionOfScalarsAndRefs = "disjunction_of_scalars_and_refs"
+
 	// HintImplementsVariant indicates that a type implements a variant.
 	// ie: dataquery, panelcfg, ...
 	HintImplementsVariant = "implements_variant"

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -262,7 +262,6 @@ func (t Type) IsDisjunctionOfAnyKind() bool {
 	return t.Hints[HintDisjunctionOfScalars] != nil ||
 		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil ||
 		t.Hints[HintDisjunctionOfScalarsAndRefs] != nil
-
 }
 
 func (t Type) DeepCopy() Type {

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -235,8 +235,7 @@ func (t Type) IsStructGeneratedFromDisjunction() bool {
 	}
 
 	return t.Hints[HintDisjunctionOfScalars] != nil ||
-		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil ||
-		t.Hints[HintDisjunctionOfScalarsAndRefs] != nil
+		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil
 }
 
 func (t Type) IsDisjunctionOfScalars() bool {
@@ -253,6 +252,17 @@ func (t Type) IsDisjunctionOfRefs() bool {
 	}
 
 	return t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil
+}
+
+func (t Type) IsDisjunctionOfAnyKind() bool {
+	if t.Kind != KindStruct {
+		return false
+	}
+
+	return t.Hints[HintDisjunctionOfScalars] != nil ||
+		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil ||
+		t.Hints[HintDisjunctionOfScalarsAndRefs] != nil
+
 }
 
 func (t Type) DeepCopy() Type {

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -235,7 +235,8 @@ func (t Type) IsStructGeneratedFromDisjunction() bool {
 	}
 
 	return t.Hints[HintDisjunctionOfScalars] != nil ||
-		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil
+		t.Hints[HintDiscriminatedDisjunctionOfRefs] != nil ||
+		t.Hints[HintDisjunctionOfScalarsAndRefs] != nil
 }
 
 func (t Type) IsDisjunctionOfScalars() bool {

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -93,6 +93,12 @@ func (jenny JSONMarshalling) renderCustomMarshal(obj ast.Object) (string, error)
 		})
 	}
 
+	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDisjunctionOfScalarsAndRefs) {
+		return jenny.tmpl.Render("types/disjunction_of_scalars_and_refs.json_marshal.tmpl", map[string]any{
+			"def": obj,
+		})
+	}
+
 	return "", fmt.Errorf("could not determine how to render custom marshal")
 }
 

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -65,7 +65,7 @@ func (jenny JSONMarshalling) objectNeedsCustomMarshal(obj ast.Object) bool {
 	// the only case for which we need a custom marshaller is for structs
 	// that are generated from a disjunction by the `DisjunctionToType` compiler pass.
 
-	return obj.Type.IsStructGeneratedFromDisjunction()
+	return obj.Type.IsDisjunctionOfAnyKind()
 }
 
 func (jenny JSONMarshalling) renderCustomMarshal(obj ast.Object) (string, error) {
@@ -117,7 +117,7 @@ func (jenny JSONMarshalling) objectNeedsCustomUnmarshal(context languages.Contex
 	}
 
 	// is it a struct generated from a disjunction?
-	if obj.Type.IsStructGeneratedFromDisjunction() {
+	if obj.Type.IsDisjunctionOfAnyKind() {
 		return true
 	}
 

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars_and_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars_and_refs.json_marshal.tmpl
@@ -1,0 +1,14 @@
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $fmt := importStdPkg "fmt" -}}
+// MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
+func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
+{{- $json := importStdPkg "encoding/json" -}}
+{{- $fmt := importStdPkg "fmt" -}}
+{{- range .def.Type.Struct.Fields }}
+	if resource.{{ .Name|formatFieldName }} != nil {
+		return json.Marshal(resource.{{ .Name|formatFieldName }})
+	}
+{{- end }}
+
+	return []byte("null"), nil
+}

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -20,7 +20,7 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectMapper")
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectWriter")
 	if t.IsStructGeneratedFromDisjunction() {
-		if t.IsStruct() && (t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) || t.HasHint(ast.HintDisjunctionOfScalars)) {
+		if t.IsStruct() && t.IsStructGeneratedFromDisjunction()  {
 			rendered, _ := j.tmpl.Render("marshalling/disjunctions.json_marshall.tmpl", map[string]any{
 				"Fields": t.AsStruct().Fields,
 			})

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -20,12 +20,10 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectMapper")
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectWriter")
 	if t.IsDisjunctionOfAnyKind() {
-		if t.IsStruct() && t.IsStructGeneratedFromDisjunction() {
-			rendered, _ := j.tmpl.Render("marshalling/disjunctions.json_marshall.tmpl", map[string]any{
-				"Fields": t.AsStruct().Fields,
-			})
-			return rendered
-		}
+		rendered, _ := j.tmpl.Render("marshalling/disjunctions.json_marshall.tmpl", map[string]any{
+			"Fields": t.AsStruct().Fields,
+		})
+		return rendered
 	}
 
 	rendered, _ := j.tmpl.Render("marshalling/marshalling.tmpl", map[string]any{})

--- a/internal/jennies/java/jsonmarshalling.go
+++ b/internal/jennies/java/jsonmarshalling.go
@@ -19,8 +19,8 @@ func (j JSONMarshaller) genToJSONFunction(t ast.Type) string {
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "core.JsonProcessingException")
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectMapper")
 	j.typeFormatter.packageMapper(fasterXMLPackageName, "databind.ObjectWriter")
-	if t.IsStructGeneratedFromDisjunction() {
-		if t.IsStruct() && t.IsStructGeneratedFromDisjunction()  {
+	if t.IsDisjunctionOfAnyKind() {
+		if t.IsStruct() && t.IsStructGeneratedFromDisjunction() {
 			rendered, _ := j.tmpl.Render("marshalling/disjunctions.json_marshall.tmpl", map[string]any{
 				"Fields": t.AsStruct().Fields,
 			})

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -140,7 +140,7 @@ func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Obj
 		ToJSONFunction:          jenny.jsonMarshaller.genToJSONFunction(object.Type),
 		ShouldAddSerializer:     jenny.typeFormatter.objectNeedsCustomSerializer(object),
 		ShouldAddDeserializer:   jenny.typeFormatter.objectNeedsCustomDeserializer(object),
-		ShouldAddFactoryMethods: object.Type.IsStructGeneratedFromDisjunction(),
+		ShouldAddFactoryMethods: object.Type.IsDisjunctionOfAnyKind(),
 		Constructors:            jenny.constructors(object),
 	})
 }
@@ -218,7 +218,7 @@ func (jenny RawTypes) getVariant(t ast.Type) string {
 }
 
 func (jenny RawTypes) constructors(object ast.Object) []ConstructorTemplate {
-	if object.Type.IsStructGeneratedFromDisjunction() {
+	if object.Type.IsDisjunctionOfAnyKind() {
 		return nil
 	}
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -140,7 +140,7 @@ func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Obj
 		ToJSONFunction:          jenny.jsonMarshaller.genToJSONFunction(object.Type),
 		ShouldAddSerializer:     jenny.typeFormatter.objectNeedsCustomSerializer(object),
 		ShouldAddDeserializer:   jenny.typeFormatter.objectNeedsCustomDeserializer(object),
-		ShouldAddFactoryMethods: object.Type.HasHint(ast.HintDisjunctionOfScalars) || object.Type.HasHint(ast.HintDiscriminatedDisjunctionOfRefs),
+		ShouldAddFactoryMethods: object.Type.IsStructGeneratedFromDisjunction(),
 		Constructors:            jenny.constructors(object),
 	})
 }

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -405,6 +405,43 @@ func NewBoolOrSomeStruct() *BoolOrSomeStruct {
 	return &BoolOrSomeStruct{
 }
 }
+// MarshalJSON implements a custom JSON marshalling logic to encode `BoolOrSomeStruct` as JSON.
+func (resource BoolOrSomeStruct) MarshalJSON() ([]byte, error) {
+	if resource.Bool != nil {
+		return json.Marshal(resource.Bool)
+	}
+	if resource.SomeStruct != nil {
+		return json.Marshal(resource.SomeStruct)
+	}
+
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode BoolOrSomeStruct from JSON.
+func (resource *BoolOrSomeStruct) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	
+	if fields["Bool"] != nil {
+		if err := json.Unmarshal(fields["Bool"], &resource.Bool); err != nil {
+			return fmt.Errorf("error decoding field 'Bool': %w", err)
+		}
+	}
+
+	if fields["SomeStruct"] != nil {
+		if err := json.Unmarshal(fields["SomeStruct"], &resource.SomeStruct); err != nil {
+			return fmt.Errorf("error decoding field 'SomeStruct': %w", err)
+		}
+	}
+
+	return nil
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `BoolOrSomeStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *BoolOrSomeStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
+++ b/testdata/jennies/rawtypes/disjunctions/JavaRawTypes/disjunctions/BoolOrRef.java
@@ -2,12 +2,17 @@ package disjunctions;
 
 
 public class BoolOrRef {
-    public Boolean bool;
-    public SomeStruct someStruct;
-    public BoolOrRef() {
+    protected Boolean bool;
+    protected SomeStruct someStruct;
+    protected BoolOrRef() {}
+    public static BoolOrRef createBool(Boolean bool) {
+        BoolOrRef boolOrRef = new BoolOrRef();
+        boolOrRef.bool = bool;
+        return boolOrRef;
     }
-    public BoolOrRef(Boolean bool,SomeStruct someStruct) {
-        this.bool = bool;
-        this.someStruct = someStruct;
+    public static BoolOrRef createSomeStruct(SomeStruct someStruct) {
+        BoolOrRef boolOrRef = new BoolOrRef();
+        boolOrRef.someStruct = someStruct;
+        return boolOrRef;
     }
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/GoRawTypes/struct_complex_fields/types_gen.go
@@ -525,6 +525,43 @@ func NewStringOrSomeOtherStruct() *StringOrSomeOtherStruct {
 	return &StringOrSomeOtherStruct{
 }
 }
+// MarshalJSON implements a custom JSON marshalling logic to encode `StringOrSomeOtherStruct` as JSON.
+func (resource StringOrSomeOtherStruct) MarshalJSON() ([]byte, error) {
+	if resource.String != nil {
+		return json.Marshal(resource.String)
+	}
+	if resource.SomeOtherStruct != nil {
+		return json.Marshal(resource.SomeOtherStruct)
+	}
+
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON implements a custom JSON unmarshalling logic to decode StringOrSomeOtherStruct from JSON.
+func (resource *StringOrSomeOtherStruct) UnmarshalJSON(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	
+	if fields["String"] != nil {
+		if err := json.Unmarshal(fields["String"], &resource.String); err != nil {
+			return fmt.Errorf("error decoding field 'String': %w", err)
+		}
+	}
+
+	if fields["SomeOtherStruct"] != nil {
+		if err := json.Unmarshal(fields["SomeOtherStruct"], &resource.SomeOtherStruct); err != nil {
+			return fmt.Errorf("error decoding field 'SomeOtherStruct': %w", err)
+		}
+	}
+
+	return nil
+}
+
 // UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `StringOrSomeOtherStruct` from JSON.
 // Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
 func (resource *StringOrSomeOtherStruct) UnmarshalJSONStrict(raw []byte) error {

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JavaRawTypes/struct_complex_fields/StringOrSomeOtherStruct.java
@@ -2,12 +2,17 @@ package struct_complex_fields;
 
 
 public class StringOrSomeOtherStruct {
-    public String string;
-    public SomeOtherStruct someOtherStruct;
-    public StringOrSomeOtherStruct() {
+    protected String string;
+    protected SomeOtherStruct someOtherStruct;
+    protected StringOrSomeOtherStruct() {}
+    public static StringOrSomeOtherStruct createString(String string) {
+        StringOrSomeOtherStruct stringOrSomeOtherStruct = new StringOrSomeOtherStruct();
+        stringOrSomeOtherStruct.string = string;
+        return stringOrSomeOtherStruct;
     }
-    public StringOrSomeOtherStruct(String string,SomeOtherStruct someOtherStruct) {
-        this.string = string;
-        this.someOtherStruct = someOtherStruct;
+    public static StringOrSomeOtherStruct createSomeOtherStruct(SomeOtherStruct someOtherStruct) {
+        StringOrSomeOtherStruct stringOrSomeOtherStruct = new StringOrSomeOtherStruct();
+        stringOrSomeOtherStruct.someOtherStruct = someOtherStruct;
+        return stringOrSomeOtherStruct;
     }
 }


### PR DESCRIPTION
Closes https://github.com/grafana/cog/issues/813

We were skipping the Marshal functions when we generate disjunctions with mixed refs and scalars. So disjunctions that have more than one type, are marked as `HintDisjunctionOfScalarsAndRefs` to be used where we need it.

Edit: Looks like that the bug was also in Java 😄