### PR TITLE
Go: Remove unused `fmt` import from marshal/unmarshal templates

### DIFF
--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -175,8 +175,7 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 		if _, ok := context.ResolveToComposableSlot(field.Type); ok {
 			continue
 		}
-
-		jenny.imports.Add("fmt", "fmt")
+		
 		buffer.WriteString(fmt.Sprintf(`
 	if fields["%[1]s"] != nil {
 		if err := json.Unmarshal(fields["%[1]s"], &resource.%[2]s); err != nil {
@@ -199,6 +198,7 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 			return "", fmt.Errorf("can not generate custom unmarshal function for composable slot with variant '%s': template block %s not found", variant, unmarshalVariantBlock)
 		}
 
+		jenny.imports.Add("fmt", "fmt")
 		if err := jenny.tmpl.RenderInBuffer(&buffer, unmarshalVariantBlock, map[string]any{
 			"Object": obj,
 			"Field":  field,

--- a/internal/jennies/golang/jsonmarshalling.go
+++ b/internal/jennies/golang/jsonmarshalling.go
@@ -175,7 +175,8 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 		if _, ok := context.ResolveToComposableSlot(field.Type); ok {
 			continue
 		}
-		
+
+		jenny.imports.Add("fmt", "fmt")
 		buffer.WriteString(fmt.Sprintf(`
 	if fields["%[1]s"] != nil {
 		if err := json.Unmarshal(fields["%[1]s"], &resource.%[2]s); err != nil {
@@ -198,7 +199,6 @@ func (jenny JSONMarshalling) renderCustomComposableSlotUnmarshal(context languag
 			return "", fmt.Errorf("can not generate custom unmarshal function for composable slot with variant '%s': template block %s not found", variant, unmarshalVariantBlock)
 		}
 
-		jenny.imports.Add("fmt", "fmt")
 		if err := jenny.tmpl.RenderInBuffer(&buffer, unmarshalVariantBlock, map[string]any{
 			"Object": obj,
 			"Field":  field,

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_marshal.tmpl
@@ -1,7 +1,6 @@
 // MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
 func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- $json := importStdPkg "encoding/json" -}}
-{{- $fmt := importStdPkg "fmt" -}}
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|formatFieldName }} != nil {
 		return json.Marshal(resource.{{ .Name|formatFieldName }})

--- a/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_refs.json_unmarshal.tmpl
@@ -1,6 +1,5 @@
 {{- $json := importStdPkg "encoding/json" -}}
 {{- $errors := importStdPkg "errors" -}}
-{{- $fmt := importStdPkg "fmt" -}}
 {{- $struct := .def.Type.Struct -}}
 // UnmarshalJSON implements a custom JSON unmarshalling logic to decode `{{ .def.Name|formatObjectName }}` from JSON.
 func (resource *{{ .def.Name|formatObjectName }}) UnmarshalJSON(raw []byte) error {

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars.json_marshal.tmpl
@@ -1,5 +1,4 @@
 {{- $json := importStdPkg "encoding/json" -}}
-{{- $fmt := importStdPkg "fmt" -}}
 // MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
 func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- range .def.Type.Struct.Fields }}

--- a/internal/jennies/golang/templates/types/disjunction_of_scalars_and_refs.json_marshal.tmpl
+++ b/internal/jennies/golang/templates/types/disjunction_of_scalars_and_refs.json_marshal.tmpl
@@ -1,9 +1,6 @@
-{{- $json := importStdPkg "encoding/json" -}}
-{{- $fmt := importStdPkg "fmt" -}}
 // MarshalJSON implements a custom JSON marshalling logic to encode `{{ .def.Name|formatObjectName }}` as JSON.
 func (resource {{ .def.Name|formatObjectName }}) MarshalJSON() ([]byte, error) {
 {{- $json := importStdPkg "encoding/json" -}}
-{{- $fmt := importStdPkg "fmt" -}}
 {{- range .def.Type.Struct.Fields }}
 	if resource.{{ .Name|formatFieldName }} != nil {
 		return json.Marshal(resource.{{ .Name|formatFieldName }})


### PR DESCRIPTION
Some templates were adding `fmt` import when they don't need it.