### PR TITLE
Cue: Add missing `namingFunc` when we parse definitions in structs

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -310,6 +310,7 @@ func (g *generator) structFields(v cue.Value) ([]ast.StructField, error) {
 
 		// inline object definition
 		if i.Selector().IsDefinition() {
+			fieldLabel = g.namingFunc(g.rootVal, i.Value().Path())
 			if err := g.declareObject(fieldLabel, i.Value()); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
We are applying `namingFunc` in all definitions but it seems that we skipped this one...

Contributing with https://github.com/grafana/cog/issues/818