### PR TITLE
Java: Custom deserializer fixes

### DIFF
--- a/internal/jennies/java/deserializers.go
+++ b/internal/jennies/java/deserializers.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
 
 type Deserializers struct {
-	config  Config
-	tmpl    *template.Template
-	imports []string
+	config        Config
+	tmpl          *template.Template
+	imports       *common.DirectImportMap
+	typeFormatter *typeFormatter
+	packageMapper func(pkg string, class string) string
 }
 
 func (jenny *Deserializers) JennyName() string {
@@ -22,11 +25,29 @@ func (jenny *Deserializers) JennyName() string {
 }
 
 func (jenny *Deserializers) Generate(context languages.Context) (codejen.Files, error) {
+	jenny.imports = NewImportMap(jenny.config.PackagePath)
+	jenny.typeFormatter = createFormatter(context, jenny.config)
+	jenny.tmpl = jenny.tmpl.
+		Funcs(common.TypeResolvingTemplateHelpers(context)).
+		Funcs(template.FuncMap{
+			"importPkg":  jenny.config.formatPackage,
+			"formatType": jenny.typeFormatter.formatFieldType,
+		})
+
 	deserialisers := make(codejen.Files, 0)
 	for _, schema := range context.Schemas {
 		var hasErr error
 		schema.Objects.Iterate(func(key string, obj ast.Object) {
-			if objectNeedsCustomDeserialiser(context, obj) {
+			jenny.packageMapper = func(pkg string, class string) string {
+				if jenny.imports.IsIdentical(pkg, schema.Package) {
+					return ""
+				}
+
+				return jenny.imports.Add(class, pkg)
+			}
+			jenny.typeFormatter.withPackageMapper(jenny.packageMapper)
+
+			if objectNeedsCustomDeserializer(context, obj, jenny.tmpl) {
 				f, err := jenny.genCustomDeserialiser(context, obj)
 				if err != nil {
 					hasErr = err
@@ -44,12 +65,26 @@ func (jenny *Deserializers) Generate(context languages.Context) (codejen.Files, 
 }
 
 func (jenny *Deserializers) genCustomDeserialiser(context languages.Context, obj ast.Object) (*codejen.File, error) {
+	customUnmarshalTmpl := template.CustomObjectUnmarshalBlock(obj)
+	if jenny.tmpl.Exists(customUnmarshalTmpl) {
+		rendered, err := jenny.tmpl.RenderAsBytes(customUnmarshalTmpl, map[string]any{
+			"Object": obj,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		path := filepath.Join(jenny.config.ProjectPath, obj.SelfRef.ReferredPkg, fmt.Sprintf("%sDeserializer.java", tools.UpperCamelCase(obj.SelfRef.ReferredType)))
+		return codejen.NewFile(path, rendered, jenny), nil
+	}
+
 	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDisjunctionOfScalars) {
-		return jenny.genDisjunctionsDeserialiser(obj, "disjunctions_of_scalars")
+		return jenny.genDisjunctionsDeserializer(obj, "disjunctions_of_scalars")
 	}
 
 	if obj.Type.IsStruct() && obj.Type.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) {
-		return jenny.genDisjunctionsDeserialiser(obj, "disjunctions_of_refs")
+		return jenny.genDisjunctionsDeserializer(obj, "disjunctions_of_refs")
 	}
 
 	// TODO(kgz): this shouldn't be done by cog
@@ -58,7 +93,12 @@ func (jenny *Deserializers) genCustomDeserialiser(context languages.Context, obj
 
 // TODO(kgz): this shouldn't be done by cog
 func (jenny *Deserializers) genDataqueryDeserialiser(context languages.Context, obj ast.Object) (*codejen.File, error) {
-	jenny.imports = jenny.genImports(obj)
+	jenny.packageMapper("cog.variants", "Dataquery")
+	jenny.packageMapper("cog.variants", "Registry")
+
+	if obj.SelfRef.ReferredPkg == "dashboard" && obj.Name == "Panel" {
+		jenny.packageMapper("cog.variants", "PanelConfig")
+	}
 
 	rendered, err := jenny.tmpl.Render("marshalling/unmarshalling.tmpl", Unmarshalling{
 		Package:                   jenny.config.formatPackage(obj.SelfRef.ReferredPkg),
@@ -107,7 +147,7 @@ func (jenny *Deserializers) renderUnmarshalDataqueryField(obj ast.Object, field 
 
 		hintField = &obj.Type.AsStruct().Fields[i]
 		if obj.SelfRef.ReferredPkg != f.Type.AsRef().ReferredPkg {
-			jenny.imports = append(jenny.imports, jenny.config.formatPackage(fmt.Sprintf("%s.%s", f.Type.AsRef().ReferredPkg, "DataSourceRef")))
+			jenny.packageMapper(f.Type.AsRef().ReferredPkg, "DataSourceRef")
 		}
 	}
 
@@ -126,21 +166,7 @@ func (jenny *Deserializers) renderUnmarshalDataqueryField(obj ast.Object, field 
 	}
 }
 
-// TODO(kgz): this shouldn't be done by cog
-func (jenny *Deserializers) genImports(obj ast.Object) []string {
-	imports := []string{
-		jenny.config.formatPackage("cog.variants.Dataquery"),
-		jenny.config.formatPackage("cog.variants.Registry"),
-	}
-
-	if obj.SelfRef.ReferredPkg == "dashboard" && obj.Name == "Panel" {
-		imports = append(imports, jenny.config.formatPackage("cog.variants.PanelConfig"))
-	}
-
-	return imports
-}
-
-func (jenny *Deserializers) genDisjunctionsDeserialiser(obj ast.Object, tmpl string) (*codejen.File, error) {
+func (jenny *Deserializers) genDisjunctionsDeserializer(obj ast.Object, tmpl string) (*codejen.File, error) {
 	rendered, err := jenny.tmpl.Render(fmt.Sprintf("marshalling/%s.json_unmarshall.tmpl", tmpl), Unmarshalling{
 		Package: jenny.config.formatPackage(obj.SelfRef.ReferredPkg),
 		Name:    tools.UpperCamelCase(obj.Name),

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -139,7 +139,7 @@ func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Obj
 		Annotation:              jenny.jsonMarshaller.annotation(object.Type),
 		ToJSONFunction:          jenny.jsonMarshaller.genToJSONFunction(object.Type),
 		ShouldAddSerializer:     jenny.typeFormatter.objectNeedsCustomSerializer(object),
-		ShouldAddDeserializer:   jenny.typeFormatter.objectNeedsCustomDeserializer(object),
+		ShouldAddDeserializer:   jenny.typeFormatter.objectNeedsCustomDeserializer(object, jenny.tmpl),
 		ShouldAddFactoryMethods: object.Type.IsDisjunctionOfAnyKind(),
 		Constructors:            jenny.constructors(object),
 	})

--- a/internal/jennies/java/templates/marshalling/unmarshalling.tmpl
+++ b/internal/jennies/java/templates/marshalling/unmarshalling.tmpl
@@ -10,9 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.grafana.foundation.cog.variants.UnknownDataquery;
 import com.grafana.foundation.cog.variants.Registry;
 
-{{- range .Imports }}
-import {{ . }};
-{{- end }}
+{{ .Imports }}
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -22,9 +22,9 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
     {{- if .ShouldAddFactoryMethods }}
     protected {{ .Name }}() {}
     {{- range .Fields }}
-    public static {{ $.Name }} create{{ .Name }}({{ .Type | formatBuilderFieldType }} {{ .Name | lowerCamelCase | escapeVar }}) {
+    public static {{ $.Name }} create{{ .Name }}({{ .Type | formatType }} {{ .Name | lowerCamelCase | escapeVar }}) {
         {{ $.Name }} {{ $.Name | lowerCamelCase }} = new {{ $.Name }}();
-        {{ $.Name | lowerCamelCase }}.{{ .Name | lowerCamelCase | escapeVar }} = {{ .Name | lowerCamelCase | escapeVar }}{{ if .Type | typeHasBuilder }}.build(){{ end }};
+        {{ $.Name | lowerCamelCase }}.{{ .Name | lowerCamelCase | escapeVar }} = {{ .Name | lowerCamelCase | escapeVar }};
         return {{ $.Name | lowerCamelCase }};
     }
     {{- end }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -62,6 +62,9 @@ func functions() template.FuncMap {
 		"importStdPkg": func(_ ast.Type) string {
 			panic("importStdPkg() needs to be overridden by a jenny")
 		},
+		"importPkg": func(_ string) string {
+			panic("importPkg() needs to be overridden by a jenny")
+		},
 		"formatPackageName": func(_ ast.Type) string {
 			panic("formatPackageName() needs to be overridden by a jenny")
 		},
@@ -209,7 +212,7 @@ type Unmarshalling struct {
 	Package                   string
 	Name                      string
 	ShouldUnmarshallingPanels bool
-	Imports                   []string
+	Imports                   fmt.Stringer
 	DataqueryUnmarshalling    []DataqueryUnmarshalling
 	Fields                    []ast.StructField
 	Hint                      any

--- a/internal/jennies/java/tools.go
+++ b/internal/jennies/java/tools.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -166,7 +167,7 @@ func getJavaFieldTypeCheck(t ast.Type) string {
 	}
 }
 
-func objectNeedsCustomDeserialiser(context languages.Context, obj ast.Object) bool {
+func objectNeedsCustomDeserializer(context languages.Context, obj ast.Object, tmpl *template.Template) bool {
 	// an object needs a custom unmarshal if:
 	// - it is a struct that was generated from a disjunction by the `DisjunctionToType` compiler pass.
 	// - it is a struct and one or more of its fields is a KindComposableSlot, or an array of KindComposableSlot
@@ -175,8 +176,13 @@ func objectNeedsCustomDeserialiser(context languages.Context, obj ast.Object) bo
 		return false
 	}
 
+	// is there a custom unmarshal template block?
+	if tmpl.Exists(template.CustomObjectUnmarshalBlock(obj)) {
+		return true
+	}
+
 	// is it a struct generated from a disjunction?
-	if obj.Type.IsStructGeneratedFromDisjunction() {
+	if obj.Type.IsDisjunctionOfAnyKind() {
 		return true
 	}
 

--- a/internal/jennies/java/types.go
+++ b/internal/jennies/java/types.go
@@ -330,11 +330,11 @@ func (tf *typeFormatter) objectNeedsCustomSerializer(obj ast.Object) bool {
 	return false
 }
 
-func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object) bool {
+func (tf *typeFormatter) objectNeedsCustomDeserializer(obj ast.Object, tmpl *template.Template) bool {
 	if !tf.config.GenerateBuilders || tf.config.SkipRuntime {
 		return false
 	}
-	if objectNeedsCustomDeserialiser(tf.context, obj) {
+	if objectNeedsCustomDeserializer(tf.context, obj, tmpl) {
 		tf.packageMapper(fasterXMLPackageName, "databind.annotation.JsonDeserialize")
 		return true
 	}


### PR DESCRIPTION
Java didn't support custom Deserializers (ones added by config). This is necessary to make it works with V2 schemas since we have to add custom schemas for some models.

Also it removes the builder check in factory constructors. It doesn't have sense because types shouldn't know about builders.

Note: There are some code that still living in cog that should be move into `foundation-sdk` since is specific to schemas.