### PR TITLE
fix: handle case where Type.Slice() could be null

### DIFF
--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -266,7 +266,11 @@ func (g *generator) walkEnum(schema *openapi3.Schema) (ast.Type, error) {
 		format = "%s"
 	}
 
-	enumType, err := getEnumType(schema.Type.Slice()[0])
+	schemaSlice := schema.Type.Slice()
+	if schemaSlice == nil {
+		schemaSlice = []string{openapi3.TypeString}
+	}
+	enumType, err := getEnumType(schemaSlice[0])
 	if err != nil {
 		return ast.Type{}, err
 	}


### PR DESCRIPTION
`cog generate` was failing with my openapi schema because of an enum without a type:
```yaml
    NullEnum:
      enum:
        - null
```
Changing that to this fixed the issue and types were generated:
```yaml
    NullEnum:
      enum:
        - null
      type: string
```
There is a comment in `internal/openapi/generator.go` that alludes to this edge case

![image](https://github.com/user-attachments/assets/4dbcb7bc-0917-4cab-aa5a-8f9dd95b1bc3)

This PR adds code to handle the situation although I'm not sure if it's the correct way to handle it or not?