### PR TITLE
Java: Avoid to generate duplicate classes with the same name

### DIFF
--- a/examples/java/src/main/java/test/Common.java
+++ b/examples/java/src/main/java/test/Common.java
@@ -13,10 +13,10 @@ import com.grafana.foundation.common.VisibilityMode;
 import com.grafana.foundation.common.VizLegendOptionsBuilder;
 import com.grafana.foundation.common.VizOrientation;
 import com.grafana.foundation.dashboard.DataSourceRef;
-import com.grafana.foundation.gauge.GaugeBuilder;
-import com.grafana.foundation.logs.LogsBuilder;
+import com.grafana.foundation.gauge.GaugePanelBuilder;
+import com.grafana.foundation.logs.LogsPanelBuilder;
 import com.grafana.foundation.prometheus.PromQueryFormat;
-import com.grafana.foundation.timeseries.TimeseriesBuilder;
+import com.grafana.foundation.timeseries.TimeseriesPanelBuilder;
 
 public class Common {
 
@@ -35,20 +35,20 @@ public class Common {
                 .legendFormat(PromQueryFormat.TABLE.Value()).refId(ref);
     }
 
-    public static TimeseriesBuilder defaultTimeSeries() {
-        return new TimeseriesBuilder().lineWidth(1.0).fillOpacity(10.0).drawStyle(GraphDrawStyle.LINE)
+    public static TimeseriesPanelBuilder defaultTimeSeries() {
+        return new TimeseriesPanelBuilder().lineWidth(1.0).fillOpacity(10.0).drawStyle(GraphDrawStyle.LINE)
                 .showPoints(VisibilityMode.NEVER).legend(new VizLegendOptionsBuilder().showLegend(true)
                         .placement(LegendPlacement.BOTTOM).displayMode(LegendDisplayMode.LIST));
     }
 
-    public static LogsBuilder defaultLogs() {
-        return new LogsBuilder().span(24)
+    public static LogsPanelBuilder defaultLogs() {
+        return new LogsPanelBuilder().span(24)
                 .datasource(new DataSourceRef("loki", "grafana-cloud-logs")).showTime(true).enableLogDetails(true)
                 .sortOrder(LogsSortOrder.DESCENDING).wrapLogMessage(true);
     }
 
-    public static GaugeBuilder defaultGauge() {
-        return new GaugeBuilder().orientation(VizOrientation.AUTO)
+    public static GaugePanelBuilder defaultGauge() {
+        return new GaugePanelBuilder().orientation(VizOrientation.AUTO)
                 .reduceOptions(new ReduceDataOptionsBuilder().calcs(List.of("lastNotNull")).values(false));
     }
 }

--- a/examples/java/src/main/java/test/Disk.java
+++ b/examples/java/src/main/java/test/Disk.java
@@ -12,11 +12,11 @@ import com.grafana.foundation.dashboard.DashboardFieldConfigSourceOverridesBuild
 import com.grafana.foundation.dashboard.DataTransformerConfig;
 import com.grafana.foundation.dashboard.DynamicConfigValue;
 import com.grafana.foundation.dashboard.MatcherConfig;
-import com.grafana.foundation.table.TableBuilder;
-import com.grafana.foundation.timeseries.TimeseriesBuilder;
+import com.grafana.foundation.table.TablePanelBuilder;
+import com.grafana.foundation.timeseries.TimeseriesPanelBuilder;
 
 public class Disk {
-        public static TimeseriesBuilder diskIOTimeseries() {
+        public static TimeseriesPanelBuilder diskIOTimeseries() {
                 return Common.defaultTimeSeries().title("Disk I/O").fillOpacity(0.0).unit("Bps")
                                 .withTarget(Common.basicPrometheusQuery(
                                                 "rate(node_disk_read_bytes_total{job=\"integrations/raspberrypi-node\", instance=\"$instance\", device!=\"\"}[$__rate_interval])",
@@ -32,8 +32,8 @@ public class Disk {
                                 ));
         }
 
-        public static TableBuilder diskSpaceUsageTable() {
-                return new TableBuilder().title("Disk Space Usage")
+        public static TablePanelBuilder diskSpaceUsageTable() {
+                return new TablePanelBuilder().title("Disk Space Usage")
                                 .align(FieldTextAlignment.AUTO).unit("decbytes").cellHeight(TableCellHeight.SM)
                                 .footer(new TableFooterOptionsBuilder().countRows(false).reducer(List.of("sum")))
                                 .withTarget(Common.tablePrometheusQuery(

--- a/examples/java/src/main/java/test/Logs.java
+++ b/examples/java/src/main/java/test/Logs.java
@@ -1,27 +1,27 @@
 package test;
 
-import com.grafana.foundation.logs.LogsBuilder;
+import com.grafana.foundation.logs.LogsPanelBuilder;
 
 public class Logs {
-    public static LogsBuilder errorsInSystemLogs() {
+    public static LogsPanelBuilder errorsInSystemLogs() {
         return Common.defaultLogs().
                 title("Errors in system logs").
                 withTarget(Common.basicLokiQuery("{level=~\"err|crit|alert|emerg\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}")).
                 withTarget(Common.basicLokiQuery("{filename=~\"/var/log/syslog*|/var/log/messages*\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"} |~\".+(?i)error(?-i).+\""));
     }
-    public static LogsBuilder authLogs() {
+    public static LogsPanelBuilder authLogs() {
         return Common.defaultLogs().
                 title("Auth logs").
                 withTarget(Common.basicLokiQuery("{unit=\"ssh.service\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}")).
                 withTarget(Common.basicLokiQuery("{filename=~\"/var/log/auth.log|/var/log/secure\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}"));
     }
-    public static LogsBuilder kernelLogs() {
+    public static LogsPanelBuilder kernelLogs() {
         return Common.defaultLogs().
                 title("Kernel logs").
                 withTarget(Common.basicLokiQuery("{transport=\"kernel\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}")).
                 withTarget(Common.basicLokiQuery("{filename=\"/var/log/kern.log\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}"));
     }
-    public static LogsBuilder allSystemLogs() {
+    public static LogsPanelBuilder allSystemLogs() {
         return Common.defaultLogs().
                 title("All system logs").
                 withTarget(Common.basicLokiQuery("{transport!=\"\", job=\"integrations/raspberrypi-node\", instance=\"$instance\"}")).

--- a/examples/java/src/main/java/test/Memory.java
+++ b/examples/java/src/main/java/test/Memory.java
@@ -7,12 +7,12 @@ import com.grafana.foundation.common.StackingMode;
 import com.grafana.foundation.dashboard.Threshold;
 import com.grafana.foundation.dashboard.ThresholdsConfigBuilder;
 import com.grafana.foundation.dashboard.ThresholdsMode;
-import com.grafana.foundation.gauge.GaugeBuilder;
-import com.grafana.foundation.timeseries.TimeseriesBuilder;
+import com.grafana.foundation.gauge.GaugePanelBuilder;
+import com.grafana.foundation.timeseries.TimeseriesPanelBuilder;
 
 public class Memory {
 
-        public static TimeseriesBuilder memoryUsageTimeseries() {
+        public static TimeseriesPanelBuilder memoryUsageTimeseries() {
                 String memUsedQuery = "(" +
                                 "  node_memory_MemTotal_bytes{job=\"integrations/raspberrypi-node\", instance=\"$instance\"}"
                                 +
@@ -49,7 +49,7 @@ public class Memory {
                                                                 "Free"));
         }
 
-        public static GaugeBuilder memoryUsageGauge() {
+        public static GaugePanelBuilder memoryUsageGauge() {
                 String query = "100 - (" +
                                 "  avg(node_memory_MemAvailable_bytes{job=\"integrations/raspberrypi-node\", instance=\"$instance\"}) /"
                                 +

--- a/examples/java/src/main/java/test/Network.java
+++ b/examples/java/src/main/java/test/Network.java
@@ -1,10 +1,10 @@
 package test;
 
-import com.grafana.foundation.timeseries.TimeseriesBuilder;
+import com.grafana.foundation.timeseries.TimeseriesPanelBuilder;
 
 public class Network {
 
-        public static TimeseriesBuilder networkReceivedTimeseries() {
+        public static TimeseriesPanelBuilder networkReceivedTimeseries() {
                 return Common.defaultTimeSeries().title("Network Received").description("Network received (bits/s)")
                                 .min(0.0).unit("bps").fillOpacity(0.0).withTarget(
                                                 Common.basicPrometheusQuery(
@@ -12,7 +12,7 @@ public class Network {
                                                                 "{{ device }}"));
         }
 
-        public static TimeseriesBuilder networkTransmittedTimeseries() {
+        public static TimeseriesPanelBuilder networkTransmittedTimeseries() {
                 return Common.defaultTimeSeries().title("Network Transmitted")
                                 .description("Network transmitted (bits/s)").min(0.0).unit("bps").fillOpacity(0.0)
                                 .withTarget(

--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -94,7 +94,7 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 
 func (jenny Builder) getBuilderName(builder ast.Builder) string {
 	if builder.For.SelfRef.ReferredPkg != builder.Package {
-		return tools.UpperCamelCase(builder.Package)
+		return fmt.Sprintf("%s%s", tools.UpperCamelCase(builder.Package), tools.UpperCamelCase(builder.For.SelfRef.ReferredType))
 	}
 
 	return tools.UpperCamelCase(builder.Name)

--- a/testdata/jennies/builders/foreign_builder/JavaBuilder/builder_pkg/BuilderPkgSomeStructBuilder.java
+++ b/testdata/jennies/builders/foreign_builder/JavaBuilder/builder_pkg/BuilderPkgSomeStructBuilder.java
@@ -2,13 +2,13 @@ package builder_pkg;
 
 import some_pkg.SomeStruct;
 
-public class BuilderPkgBuilder implements cog.Builder<SomeStruct> {
+public class BuilderPkgSomeStructBuilder implements cog.Builder<SomeStruct> {
     protected final SomeStruct internal;
     
-    public BuilderPkgBuilder() {
+    public BuilderPkgSomeStructBuilder() {
         this.internal = new SomeStruct();
     }
-    public BuilderPkgBuilder title(String title) {
+    public BuilderPkgSomeStructBuilder title(String title) {
         this.internal.title = title;
         return this;
     }

--- a/testdata/jennies/builders/package-with-dashes/JavaBuilder/builderpkg/BuilderPkgSomeStructBuilder.java
+++ b/testdata/jennies/builders/package-with-dashes/JavaBuilder/builderpkg/BuilderPkgSomeStructBuilder.java
@@ -2,13 +2,13 @@ package builder-pkg;
 
 import with-dashes.SomeStruct;
 
-public class BuilderPkgBuilder implements cog.Builder<SomeStruct> {
+public class BuilderPkgSomeStructBuilder implements cog.Builder<SomeStruct> {
     protected final SomeStruct internal;
     
-    public BuilderPkgBuilder() {
+    public BuilderPkgSomeStructBuilder() {
         this.internal = new SomeStruct();
     }
-    public BuilderPkgBuilder title(String title) {
+    public BuilderPkgSomeStructBuilder title(String title) {
         this.internal.title = title;
         return this;
     }


### PR DESCRIPTION
When we are working with composables, we could have conflicts using the same names in their generation.

When we detect that `builder.For.SelfRef.ReferredPkg != builder.Package` is different, it means that it's a composable. `ReferredPkg` indicates the composed package name, and `builder.Package` the one of the class generated. `builder.For.SelfRef.ReferredType` and `builder.Name` could be the same (it happens for panels)

When we have multiple composables for one schema, returning the package only, could be the same. Instead, it composes this package with the composed class name to generating unique names.