### PR TITLE
[CUE->OpenAPI] Add Manual Open Attribute for CUE -> OpenAPI Generation

### DIFF
--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -202,6 +202,11 @@ func (jenny Schema) formatStruct(typeDef ast.Type) Definition {
 
 	definition.Set("type", "object")
 	definition.Set("additionalProperties", false)
+	if typeDef.HasHint("open") {
+		if val, _ := typeDef.Hints["open"].(string); strings.ToLower(val)[0] == 't' {
+			definition.Set("additionalProperties", map[string]any{})
+		}
+	}
 
 	properties := orderedmap.New[string, any]()
 	var required []string

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -404,6 +404,8 @@ func (g *generator) declareNode(v cue.Value) (ast.Type, error) {
 		}
 
 		def := ast.NewStruct(fields...)
+		// Add the hints since we can't supply them in the constructor
+		def.Hints = hints
 		def.Default = defVal
 
 		return def, nil


### PR DESCRIPTION
Add hints to AST struct type, and use the 'open' hint to add `additionalProperties` in openAPI generation.

This allows an author of a CUE schema to specify if a type should be treated as open in scenarios where it is not simply
```cue
foo: {
    [string]: any
}
```
so now something like
```
foo: {
    bar: string
    [string]: any
} @cog(open=true)
```
will generate openAPI which has the `bar` required property, and `additionalProperties: {}` to allow for additional fields.