### PR TITLE
Java: Fix template parsing

### DIFF
--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -87,7 +87,6 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
-		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -87,6 +87,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
+		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/java/builder_test.go
+++ b/internal/jennies/java/builder_test.go
@@ -23,7 +23,7 @@ func TestBuilder_Generate(t *testing.T) {
 	})
 	jenny := Builder{
 		config:          language.config,
-		tmpl:            initTemplates([]string{}),
+		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -102,7 +102,7 @@ func (language *Language) Name() string {
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
 
-	tmpl := initTemplates(language.config.OverridesTemplatesDirectories)
+	tmpl := initTemplates(config, language.apiRefCollector)
 
 	apiRef := APIRef{config: config, tmpl: tmpl}
 

--- a/internal/jennies/java/rawtypes.go
+++ b/internal/jennies/java/rawtypes.go
@@ -83,7 +83,7 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 		}
 
 		pkg := formatPackageName(schema.Package)
-		output, innerErr := jenny.generateSchema(pkg, schema.Metadata.Identifier, object)
+		output, innerErr := jenny.generateSchema(pkg, schema, object)
 		if innerErr != nil {
 			err = innerErr
 			return
@@ -111,22 +111,27 @@ func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, erro
 	return files, nil
 }
 
-func (jenny RawTypes) generateSchema(pkg string, identifier string, object ast.Object) ([]byte, error) {
+func (jenny RawTypes) generateSchema(pkg string, schema *ast.Schema, object ast.Object) ([]byte, error) {
+	functionsBlock, err := jenny.extraFunctionsBlock(schema, object)
+	if err != nil {
+		return nil, err
+	}
+
 	switch object.Type.Kind {
 	case ast.KindStruct:
-		return jenny.formatStruct(pkg, identifier, object)
+		return jenny.formatStruct(pkg, schema.Metadata.Identifier, object, functionsBlock)
 	case ast.KindEnum:
 		return formatEnum(jenny.config.formatPackage(pkg), object, jenny.getTemplate())
 	case ast.KindRef:
-		return jenny.formatReference(pkg, identifier, object)
+		return jenny.formatReference(pkg, schema.Metadata.Identifier, object, functionsBlock)
 	case ast.KindIntersection:
-		return jenny.formatIntersection(pkg, identifier, object)
+		return jenny.formatIntersection(pkg, schema.Metadata.Identifier, object, functionsBlock)
 	}
 
 	return nil, nil
 }
 
-func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Object) ([]byte, error) {
+func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Object, functionsBlock string) ([]byte, error) {
 	return jenny.getTemplate().RenderAsBytes("types/class.tmpl", ClassTemplate{
 		Package:                 jenny.config.formatPackage(pkg),
 		RawPackage:              pkg,
@@ -142,6 +147,7 @@ func (jenny RawTypes) formatStruct(pkg string, identifier string, object ast.Obj
 		ShouldAddDeserializer:   jenny.typeFormatter.objectNeedsCustomDeserializer(object, jenny.tmpl),
 		ShouldAddFactoryMethods: object.Type.IsDisjunctionOfAnyKind(),
 		Constructors:            jenny.constructors(object),
+		ExtraFunctionsBlock:     functionsBlock,
 	})
 }
 
@@ -167,22 +173,23 @@ func (jenny RawTypes) formatScalars(pkg string, scalars map[string]ast.ScalarTyp
 	})
 }
 
-func (jenny RawTypes) formatReference(pkg string, identifier string, object ast.Object) ([]byte, error) {
+func (jenny RawTypes) formatReference(pkg string, identifier string, object ast.Object, extraFunctionsBlock string) ([]byte, error) {
 	ref := object.Type.AsRef()
 	reference := fmt.Sprintf("%s.%s", jenny.config.formatPackage(formatPackageName(ref.ReferredPkg)), formatObjectName(ref.ReferredType))
 
 	return jenny.getTemplate().RenderAsBytes("types/class.tmpl", ClassTemplate{
-		Package:    jenny.config.formatPackage(pkg),
-		Imports:    jenny.imports,
-		Name:       formatObjectName(object.Name),
-		Extends:    []string{reference},
-		Comments:   object.Comments,
-		Variant:    jenny.getVariant(object.Type),
-		Identifier: identifier,
+		Package:             jenny.config.formatPackage(pkg),
+		Imports:             jenny.imports,
+		Name:                formatObjectName(object.Name),
+		Extends:             []string{reference},
+		Comments:            object.Comments,
+		Variant:             jenny.getVariant(object.Type),
+		Identifier:          identifier,
+		ExtraFunctionsBlock: extraFunctionsBlock,
 	})
 }
 
-func (jenny RawTypes) formatIntersection(pkg string, identifier string, object ast.Object) ([]byte, error) {
+func (jenny RawTypes) formatIntersection(pkg string, identifier string, object ast.Object, extraFunctionsBlock string) ([]byte, error) {
 	intersection := object.Type.AsIntersection()
 	extensions := make([]string, 0)
 	fields := make([]ast.StructField, 0)
@@ -197,14 +204,15 @@ func (jenny RawTypes) formatIntersection(pkg string, identifier string, object a
 	}
 
 	return jenny.getTemplate().RenderAsBytes("types/class.tmpl", ClassTemplate{
-		Package:    jenny.config.formatPackage(pkg),
-		Imports:    jenny.imports,
-		Name:       object.Name,
-		Extends:    extensions,
-		Comments:   object.Comments,
-		Fields:     fields,
-		Variant:    jenny.getVariant(object.Type),
-		Identifier: identifier,
+		Package:             jenny.config.formatPackage(pkg),
+		Imports:             jenny.imports,
+		Name:                object.Name,
+		Extends:             extensions,
+		Comments:            object.Comments,
+		Fields:              fields,
+		Variant:             jenny.getVariant(object.Type),
+		Identifier:          identifier,
+		ExtraFunctionsBlock: extraFunctionsBlock,
 	})
 }
 
@@ -331,4 +339,33 @@ func (jenny RawTypes) formatReferenceDefaults(ref ast.Type, value any) string {
 
 	jenny.typeFormatter.packageMapper(ref.AsRef().ReferredPkg, ref.AsRef().ReferredType)
 	return fmt.Sprintf("new %s(%s)", class, strings.Join(args, ", "))
+}
+
+func (jenny RawTypes) extraFunctionsBlock(schema *ast.Schema, object ast.Object) (string, error) {
+	buffer := strings.Builder{}
+
+	customMethodsBlock := template.CustomObjectMethodsBlock(object)
+	if jenny.tmpl.Exists(customMethodsBlock) {
+		buffer.WriteString("\n\n")
+		if err := jenny.tmpl.RenderInBuffer(&buffer, customMethodsBlock, map[string]any{
+			"Object": object,
+		}); err != nil {
+			return "", err
+		}
+
+		buffer.WriteString("\n")
+	}
+
+	customVariantTmpl := template.CustomObjectVariantBlock(object)
+	if object.Type.ImplementsVariant() && jenny.tmpl.Exists(customVariantTmpl) {
+		buffer.WriteString("\n\n\n")
+		if err := jenny.tmpl.RenderInBuffer(&buffer, customVariantTmpl, map[string]any{
+			"Object": object,
+			"Schema": schema,
+		}); err != nil {
+			return "", err
+		}
+	}
+
+	return buffer.String(), nil
 }

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		GenerateJSONMarshaller: true,
 	}
 
-	jenny := RawTypes{config: cfg, tmpl: initTemplates([]string{})}
+	jenny := RawTypes{config: cfg, tmpl: initTemplates(cfg, common.NewAPIReferenceCollector())}
 	compilerPasses := New(cfg).CompilerPasses()
 
 	test.Run(t, func(tc *testutils.Test[ast.Schema]) {

--- a/internal/jennies/java/templates/types/class.tmpl
+++ b/internal/jennies/java/templates/types/class.tmpl
@@ -47,6 +47,8 @@ public class {{ .Name }}{{ if .Extends }} extends {{ range $i, $e := .Extends }}
         return "{{ .Identifier | lower }}";
     }
     {{- end }}
+    
+    {{- .ExtraFunctionsBlock }}
 
     {{- if and (ne .ToJSONFunction "") (not .Extends) }}
     {{ .ToJSONFunction }}

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -26,7 +26,6 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
-		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))
@@ -154,6 +153,7 @@ type ClassTemplate struct {
 	ShouldAddDeserializer   bool
 	ShouldAddFactoryMethods bool
 	Constructors            []ConstructorTemplate
+	ExtraFunctionsBlock     string
 }
 
 type ConstructorTemplate struct {

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -14,14 +14,19 @@ import (
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
-func initTemplates(extraTemplatesDirectories []string) *template.Template {
+func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector) *template.Template {
 	tmpl, err := template.New(
 		"java",
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
+		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		template.Funcs(functions()),
 		template.Funcs(formattingTemplateFuncs()),
+
+		// parse templates
 		template.ParseFS(templatesFS, "templates"),
-		template.ParseDirectories(extraTemplatesDirectories...),
+		template.ParseDirectories(config.OverridesTemplatesDirectories...),
+		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/php/builder_test.go
+++ b/internal/jennies/php/builder_test.go
@@ -24,7 +24,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(config)
 	jenny := Builder{
 		config:          config,
-		tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/php/converter_test.go
+++ b/internal/jennies/php/converter_test.go
@@ -27,7 +27,7 @@ func TestConverter_Generate(t *testing.T) {
 	jenny := Converter{
 		config:         config,
 		nullableConfig: language.NullableKinds(),
-		tmpl:           initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		tmpl:           initTemplates(language.config, common.NewAPIReferenceCollector()),
 	}
 
 	test.Run(t, func(tc *testutils.Test[languages.Context]) {

--- a/internal/jennies/php/jennies.go
+++ b/internal/jennies/php/jennies.go
@@ -93,7 +93,7 @@ func (language *Language) Name() string {
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	config := language.config.MergeWithGlobal(globalConfig)
 
-	tmpl := initTemplates(language.apiRefCollector, language.config.OverridesTemplatesDirectories)
+	tmpl := initTemplates(config, language.apiRefCollector)
 	rawTypesJenny := RawTypes{config: config, tmpl: tmpl, apiRefCollector: language.apiRefCollector}
 
 	jenny := codejen.JennyListWithNamer(func(_ languages.Context) string {

--- a/internal/jennies/php/rawtypes_test.go
+++ b/internal/jennies/php/rawtypes_test.go
@@ -25,7 +25,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 	jenny := RawTypes{
 		config:          config,
-		tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 	compilerPasses := New(config).CompilerPasses()

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -31,7 +31,6 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
-		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -14,7 +14,7 @@ import (
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
-func initTemplates(apiRefCollector *common.APIReferenceCollector, extraTemplatesDirectories []string) *template.Template {
+func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector) *template.Template {
 	tmpl, err := template.New(
 		"php",
 
@@ -30,7 +30,8 @@ func initTemplates(apiRefCollector *common.APIReferenceCollector, extraTemplates
 
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
-		template.ParseDirectories(extraTemplatesDirectories...),
+		template.ParseDirectories(config.OverridesTemplatesDirectories...),
+		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/python/builder_test.go
+++ b/internal/jennies/python/builder_test.go
@@ -21,7 +21,7 @@ func TestBuilder_Generate(t *testing.T) {
 
 	language := New(Config{})
 	jenny := Builder{
-		tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -59,7 +59,7 @@ func (language *Language) Name() string {
 }
 
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
-	tmpl := initTemplates(language.apiRefCollector, language.config.OverridesTemplatesDirectories)
+	tmpl := initTemplates(language.config, language.apiRefCollector)
 
 	extraTemplatesJenny := common.CustomTemplates{
 		TemplateDirectories: language.config.ExtraFilesTemplatesDirectories,

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -25,7 +25,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 	jenny := RawTypes{
 		config:          config,
-		tmpl:            initTemplates(common.NewAPIReferenceCollector(), []string{}),
+		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 	compilerPasses := New(config).CompilerPasses()

--- a/internal/jennies/python/tmpl.go
+++ b/internal/jennies/python/tmpl.go
@@ -14,7 +14,7 @@ import (
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
-func initTemplates(apiRefCollector *common.APIReferenceCollector, extraTemplatesDirectories []string) *template.Template {
+func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector) *template.Template {
 	tmpl, err := template.New(
 		"python",
 
@@ -61,7 +61,8 @@ func initTemplates(apiRefCollector *common.APIReferenceCollector, extraTemplates
 
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
-		template.ParseDirectories(extraTemplatesDirectories...),
+		template.ParseDirectories(config.OverridesTemplatesDirectories...),
+		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/python/tmpl.go
+++ b/internal/jennies/python/tmpl.go
@@ -62,7 +62,6 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
-		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -23,7 +23,7 @@ func TestBuilder_Generate(t *testing.T) {
 	language := New(config)
 	jenny := Builder{
 		config:          config,
-		tmpl:            initTemplates([]string{}),
+		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
 

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -107,7 +107,7 @@ func (language *Language) Name() string {
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
 	language.config.applyDefaults()
 
-	tmpl := initTemplates(language.config.OverridesTemplatesDirectories)
+	tmpl := initTemplates(language.config, language.apiRefCollector)
 
 	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
 		return LanguageRef

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	config := Config{}
 	config.applyDefaults()
 	jenny := RawTypes{
-		tmpl:   initTemplates([]string{}),
+		tmpl:   initTemplates(config, common.NewAPIReferenceCollector()),
 		config: config,
 	}
 	compilerPasses := New(config).CompilerPasses()

--- a/internal/jennies/typescript/tmpl.go
+++ b/internal/jennies/typescript/tmpl.go
@@ -55,7 +55,6 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// parse templates
 		template.ParseFS(templatesFS, "templates"),
 		template.ParseDirectories(config.OverridesTemplatesDirectories...),
-		template.ParseDirectories(config.ExtraFilesTemplatesDirectories...),
 	)
 	if err != nil {
 		panic(fmt.Errorf("could not initialize templates: %w", err))


### PR DESCRIPTION
Java missing the way to identify if exist custom templates to add more functions to rawtypes.

And it also has a small refactor so all languages follow the same structure.