### PR TITLE
[OpenAPI] Add 'type' field for enum by inferring from first element.

### DIFF
--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -292,6 +292,11 @@ func (jenny Schema) formatEnum(typeDef ast.Type) Definition {
 	})
 
 	definition.Set("enum", values)
+	// Make an educated guess about the enum type by looking at the first element in the values set
+	if len(typeDef.AsEnum().Values) > 0 {
+		def := jenny.formatType(typeDef.AsEnum().Values[0].Type)
+		definition.Set("type", def.Get("type"))
+	}
 
 	return definition
 }

--- a/testdata/jennies/rawtypes/constant_references/JSONSchema/constant_references.jsonschema.json
+++ b/testdata/jennies/rawtypes/constant_references/JSONSchema/constant_references.jsonschema.json
@@ -6,7 +6,8 @@
         "ValueA",
         "ValueB",
         "ValueC"
-      ]
+      ],
+      "type": "string"
     },
     "ParentStruct": {
       "type": "object",

--- a/testdata/jennies/rawtypes/constant_references/OpenAPI/constant_references.openapi.json
+++ b/testdata/jennies/rawtypes/constant_references/OpenAPI/constant_references.openapi.json
@@ -14,7 +14,8 @@
           "ValueA",
           "ValueB",
           "ValueC"
-        ]
+        ],
+        "type": "string"
       },
       "ParentStruct": {
         "type": "object",

--- a/testdata/jennies/rawtypes/enums/JSONSchema/enums.jsonschema.json
+++ b/testdata/jennies/rawtypes/enums/JSONSchema/enums.jsonschema.json
@@ -6,19 +6,22 @@
         "\u003e",
         "\u003c"
       ],
+      "type": "string",
       "description": "This is a very interesting string enum."
     },
     "TableSortOrder": {
       "enum": [
         "asc",
         "desc"
-      ]
+      ],
+      "type": "string"
     },
     "LogsSortOrder": {
       "enum": [
         "time_asc",
         "time_desc"
-      ]
+      ],
+      "type": "string"
     },
     "DashboardCursorSync": {
       "enum": [
@@ -26,6 +29,7 @@
         1,
         2
       ],
+      "type": "integer",
       "description": "0 for no shared crosshair or tooltip (default).\n1 for shared crosshair.\n2 for shared crosshair AND shared tooltip."
     }
   }

--- a/testdata/jennies/rawtypes/enums/OpenAPI/enums.openapi.json
+++ b/testdata/jennies/rawtypes/enums/OpenAPI/enums.openapi.json
@@ -14,19 +14,22 @@
           "\u003e",
           "\u003c"
         ],
+        "type": "string",
         "description": "This is a very interesting string enum."
       },
       "TableSortOrder": {
         "enum": [
           "asc",
           "desc"
-        ]
+        ],
+        "type": "string"
       },
       "LogsSortOrder": {
         "enum": [
           "time_asc",
           "time_desc"
-        ]
+        ],
+        "type": "string"
       },
       "DashboardCursorSync": {
         "enum": [
@@ -34,6 +37,7 @@
           1,
           2
         ],
+        "type": "integer",
         "description": "0 for no shared crosshair or tooltip (default).\n1 for shared crosshair.\n2 for shared crosshair AND shared tooltip."
       }
     }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
@@ -47,7 +47,8 @@
           "enum": [
             "\u003e",
             "\u003c"
-          ]
+          ],
+          "type": "string"
         },
         "FieldArrayOfStrings": {
           "type": "array",

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
@@ -55,7 +55,8 @@
             "enum": [
               "\u003e",
               "\u003c"
-            ]
+            ],
+            "type": "string"
           },
           "FieldArrayOfStrings": {
             "type": "array",

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/JSONSchema/struct_optional_fields.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/JSONSchema/struct_optional_fields.jsonschema.json
@@ -15,7 +15,8 @@
           "enum": [
             "\u003e",
             "\u003c"
-          ]
+          ],
+          "type": "string"
         },
         "FieldArrayOfStrings": {
           "type": "array",

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/OpenAPI/struct_optional_fields.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/OpenAPI/struct_optional_fields.openapi.json
@@ -23,7 +23,8 @@
             "enum": [
               "\u003e",
               "\u003c"
-            ]
+            ],
+            "type": "string"
           },
           "FieldArrayOfStrings": {
             "type": "array",


### PR DESCRIPTION
The cog-generated OpenAPI enums don't always contain a `type` field, use the first value in the enum set to infer the type.