### PR TITLE
Go: Fix []byte in equal function

### DIFF
--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -378,6 +378,10 @@ func (jenny RawTypes) maybeValueAsPointer(value string, nullable bool, typeDef a
 		return value
 	}
 
+	if typeDef.IsScalar() && typeDef.AsScalar().ScalarKind == ast.KindBytes {
+		return value
+	}
+
 	nonNullableField := typeDef.DeepCopy()
 	nonNullableField.Nullable = false
 	typeHint := jenny.typeFormatter.formatType(nonNullableField)

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -83,11 +83,21 @@ func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|forma
 		if !{{ .SelfName }}.Equals({{ $dereference }}{{ .OtherName }}) {
 			return false
 		}
-	{{- else if or (resolvesToScalar .Type) (resolvesToEnum .Type) }}
+	{{- else if (resolvesToEnum .Type) }}
 		{{- $dereference := ternary "*" "" .Dereference }}
 		if {{ $dereference }}{{ .SelfName }} != {{ $dereference }}{{ .OtherName }} {
 			return false
 		}
+    {{- else if (resolvesToScalar .Type) }}
+        {{- if eq .Type.AsScalar.ScalarKind "bytes" }}
+        {{- $bytes := importStdPkg "bytes" }}
+        if !bytes.Equal({{ .SelfName }}, {{ .OtherName }}) {
+        {{- else }} 
+        {{- $dereference := ternary "*" "" .Dereference }}
+        if {{ $dereference }}{{ .SelfName }} != {{ $dereference }}{{ .OtherName }} {
+        {{- end }}
+            return false
+        }
     {{- else if .Type.IsConstantRef }}
         if {{ .SelfName }} != {{ .OtherName}} {
             return false

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -83,21 +83,16 @@ func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|forma
 		if !{{ .SelfName }}.Equals({{ $dereference }}{{ .OtherName }}) {
 			return false
 		}
-	{{- else if (resolvesToEnum .Type) }}
+	{{- else if or (resolvesToScalar .Type) (resolvesToEnum .Type) }}
+	    {{- if and (.Type.IsScalar) (eq .Type.Scalar.ScalarKind "bytes")}}
+	    {{- $bytes := importStdPkg "bytes" }}
+	    if !bytes.Equal({{ .SelfName }}, {{ .OtherName }}) {
+	    {{- else }}
 		{{- $dereference := ternary "*" "" .Dereference }}
 		if {{ $dereference }}{{ .SelfName }} != {{ $dereference }}{{ .OtherName }} {
+	    {{- end }}
 			return false
 		}
-    {{- else if (resolvesToScalar .Type) }}
-        {{- if eq .Type.AsScalar.ScalarKind "bytes" }}
-        {{- $bytes := importStdPkg "bytes" }}
-        if !bytes.Equal({{ .SelfName }}, {{ .OtherName }}) {
-        {{- else }} 
-        {{- $dereference := ternary "*" "" .Dereference }}
-        if {{ $dereference }}{{ .SelfName }} != {{ $dereference }}{{ .OtherName }} {
-        {{- end }}
-            return false
-        }
     {{- else if .Type.IsConstantRef }}
         if {{ .SelfName }} != {{ .OtherName}} {
             return false

--- a/internal/simplecue/utils.go
+++ b/internal/simplecue/utils.go
@@ -73,7 +73,7 @@ outer:
 	}
 	args = args[:k]
 
-	//nolint: gocritic
+	// nolint: gocritic
 	if op == cue.NoOp && len(args) == 1 {
 		// TODO: this is to deal with default value removal. This may change
 		// when we completely separate default values from values.
@@ -143,7 +143,7 @@ func getTypeHint(v cue.Value) (string, error) {
 func cueConcreteToScalar(v cue.Value) (interface{}, error) {
 	switch v.Kind() {
 	case cue.NullKind:
-		return nil, nil //nolint: nilnil
+		return nil, nil // nolint: nilnil
 	case cue.StringKind:
 		return v.String()
 	case cue.NumberKind, cue.FloatKind:
@@ -152,6 +152,8 @@ func cueConcreteToScalar(v cue.Value) (interface{}, error) {
 		return v.Int64()
 	case cue.BoolKind:
 		return v.Bool()
+	case cue.BytesKind:
+		return v.Bytes()
 	case cue.ListKind:
 		var values []any
 		it, err := v.List()
@@ -171,7 +173,7 @@ func cueConcreteToScalar(v cue.Value) (interface{}, error) {
 		}
 
 		if len(values) == 0 {
-			//nolint: nilnil
+			// nolint: nilnil
 			return nil, nil
 		}
 
@@ -189,7 +191,7 @@ func cueConcreteToScalar(v cue.Value) (interface{}, error) {
 		}
 
 		if len(newMap) == 0 {
-			//nolint: nilnil
+			// nolint: nilnil
 			return nil, nil
 		}
 
@@ -199,7 +201,7 @@ func cueConcreteToScalar(v cue.Value) (interface{}, error) {
 		if defVal, ok := v.Default(); ok {
 			return cueConcreteToScalar(defVal)
 		}
-		//nolint: nilnil
+		// nolint: nilnil
 		return nil, nil
 	default:
 		return nil, errorWithCueRef(v, "can not convert kind to scalar: %s", v.Kind())

--- a/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/GoRawTypes/disjunctions/types_gen.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"bytes"
 )
 
 // Refresh rate or disabled.
@@ -168,7 +169,7 @@ func (resource SomeOtherStruct) Equals(other SomeOtherStruct) bool {
 		if resource.Type != other.Type {
 			return false
 		}
-		if resource.Foo != other.Foo {
+	    if !bytes.Equal(resource.Foo, other.Foo) {
 			return false
 		}
 

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/GoRawTypes/basic/types_gen.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"bytes"
 )
 
 // This
@@ -252,7 +253,7 @@ func (resource SomeStruct) Equals(other SomeStruct) bool {
 		if resource.FieldBool != other.FieldBool {
 			return false
 		}
-		if resource.FieldBytes != other.FieldBytes {
+	    if !bytes.Equal(resource.FieldBytes, other.FieldBytes) {
 			return false
 		}
 		if resource.FieldString != other.FieldString {

--- a/testdata/schemas/equality/equality.cue
+++ b/testdata/schemas/equality/equality.cue
@@ -17,6 +17,7 @@ optionals: {
 	stringField?: string
 	enumField?: #Direction
 	refField?: #Variable
+	byteField?: bytes
 }
 
 arrays: {


### PR DESCRIPTION
We weren't parsing byte values with cue and we were using `!=` to check the equality of `[]byte` generating invalid code. 

This PR adds the missing value in cue and uses `bytes.Equal` function to compare bytes.