### PR TITLE
JsonSchema/Openapi: Return the type of the allOf if there is only one result

### DIFF
--- a/internal/jsonschema/generator.go
+++ b/internal/jsonschema/generator.go
@@ -147,7 +147,7 @@ func (g *generator) walkDefinition(schema *schemaparser.Schema) (ast.Type, error
 		return ast.Any(), nil
 	}
 
-	//nolint: gocritic
+	// nolint: gocritic
 	if len(schema.Types) > 1 {
 		def, err = g.walkScalarDisjunction(schema.Types)
 	} else if schema.Enum != nil {
@@ -270,6 +270,10 @@ func (g *generator) walkAllOf(schema *schemaparser.Schema) (ast.Type, error) {
 		}
 
 		branches[i] = def
+	}
+
+	if len(branches) == 1 {
+		return branches[0], nil
 	}
 
 	return ast.NewIntersection(branches), nil

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -245,6 +245,10 @@ func (g *generator) walkAllOf(schema *openapi3.Schema) (ast.Type, error) {
 		branches[i] = def
 	}
 
+	if len(branches) == 1 {
+		return branches[0], nil
+	}
+
 	return ast.NewIntersection(branches), nil
 }
 


### PR DESCRIPTION
New specs uses allOf to set only one value instead to set directly the reference. 
When it happens the result in the generation isn't desirable and its better to return the first value only when it happens.