### PR TITLE
Set proper name to use constant reference in yaml configuration

### DIFF
--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -96,7 +96,7 @@ type Type struct {
 	Map               *MapType               `json:",omitempty"`
 	Struct            *StructType            `json:",omitempty"`
 	Ref               *RefType               `json:",omitempty"`
-	ConstantReference *ConstantReferenceType `json:",omitempty"`
+	ConstantReference *ConstantReferenceType `json:",omitempty" yaml:"constant_ref"`
 	Scalar            *ScalarType            `json:",omitempty"`
 	Intersection      *IntersectionType      `json:",omitempty"`
 	ComposableSlot    *ComposableSlotType    `json:",omitempty" yaml:"composable_slot"`


### PR DESCRIPTION
ConstantReference is detected as `constantreferencetype` in the configuration, and it should match the same value as its [kind](https://github.com/grafana/cog/blob/main/internal/ast/types.go#L15).