### PR TITLE
[OpenAPI Generation] Fix Handling of Exclusive Constraints in OpenAPI

### DIFF
--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -5,10 +5,9 @@ import (
 	"strings"
 
 	"github.com/grafana/codejen"
-	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
-
 	"github.com/grafana/cog/internal/ast/compiler"
 	"github.com/grafana/cog/internal/languages"
+	schemaparser "github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 const LanguageRef = "jsonschema"

--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/grafana/codejen"
-
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/orderedmap"

--- a/internal/jennies/openapi/schema.go
+++ b/internal/jennies/openapi/schema.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/codejen"
-
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
 	"github.com/grafana/cog/internal/languages"


### PR DESCRIPTION
OpenAPI 3.0 and JSON Schema differ in how they handle the `exclusiveMinimum` and `exclusiveMaximum` fields, with [OpenAPI 3.0 using it s a boolean to declare the existing minimum or maximum field to be exclusive](https://swagger.io/docs/specification/v3_0/data-models/data-types/#numbers) and [JSON Schema using it as a replacement for the minimum or maximum field as an exclusive variant](https://json-schema.org/understanding-json-schema/reference/numeric). This means that both the logic and types mismatch, which causes cog to produce invalid OpenAPI 3.0 if the input data uses exclusive constraints. This PR corrects the handling of exclusive constrains for OpenAPI 3.0 outputs by adding a flag to the JSON Schema Jenny, as it is used to produce both OpenAPI and JSON Schema outputs.