### PR TITLE
Add constant reference into objects if the parser skipped for any reason

### DIFF
--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -514,15 +514,9 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 			constantRef := ast.NewConstantReferenceType(refPkg, refType, referenceValue)
 			// Sometimes the object isn't added because the scope
 			if !g.schema.Objects.Has(refType) {
-				g.schema.AddObject(ast.Object{
-					Name:     refType,
-					Comments: commentsFromCueValue(referenceRootValue.LookupPath(path)),
-					Type:     constantRef,
-					SelfRef: ast.RefType{
-						ReferredPkg:  g.schema.Package,
-						ReferredType: refType,
-					},
-				})
+				if err := g.declareObject(refType, referenceRootValue.LookupPath(path)); err != nil {
+					return ast.Type{}, err
+				}
 			}
 
 			return constantRef, nil

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -511,7 +511,6 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 				}
 			}
 
-			constantRef := ast.NewConstantReferenceType(refPkg, refType, referenceValue)
 			// Sometimes the object isn't added because the scope
 			if !g.schema.Objects.Has(refType) {
 				if err := g.declareObject(refType, referenceRootValue.LookupPath(path)); err != nil {
@@ -519,7 +518,7 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 				}
 			}
 
-			return constantRef, nil
+			return ast.NewConstantReferenceType(refPkg, refType, referenceValue), nil
 		}
 
 		// Reference to another package

--- a/internal/simplecue/generator.go
+++ b/internal/simplecue/generator.go
@@ -510,7 +510,22 @@ func (g *generator) declareReference(v cue.Value, defV cue.Value) (ast.Type, err
 					return ast.Type{}, errorWithCueRef(v, err.Error())
 				}
 			}
-			return ast.NewConstantReferenceType(refPkg, refType, referenceValue), nil
+
+			constantRef := ast.NewConstantReferenceType(refPkg, refType, referenceValue)
+			// Sometimes the object isn't added because the scope
+			if !g.schema.Objects.Has(refType) {
+				g.schema.AddObject(ast.Object{
+					Name:     refType,
+					Comments: commentsFromCueValue(referenceRootValue.LookupPath(path)),
+					Type:     constantRef,
+					SelfRef: ast.RefType{
+						ReferredPkg:  g.schema.Package,
+						ReferredType: refType,
+					},
+				})
+			}
+
+			return constantRef, nil
 		}
 
 		// Reference to another package


### PR DESCRIPTION
Generating manifest fails in app-sdk because constant reference objects are missing. For any reason, when the scope of the cue value changes (e.g. unifying values), sometimes the parser skips the constant references.

I saw that we have similar behaviour when we detect that a field is a reference and we "skip" some objects, we force to add them 🤷🏼‍♀️.

This change fixes manifest generation.