### PR TITLE
Fix Constant References null checks

### DIFF
--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -561,7 +561,7 @@ func (generator *BuilderGenerator) structObjectToBuilder(schemas Schemas, schema
 			builder.Constructor.Assignments = append(builder.Constructor.Assignments, constantAssignment)
 			continue
 		}
-		if field.Type.IsConstantRef() {
+		if field.Type.IsConstantRef() && !field.Required {
 			continue
 		}
 

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -353,6 +353,9 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 			if referredPkg != "" {
 				defaultValue = referredPkg + "." + defaultValue
 			}
+
+			defaultValue = jenny.maybeValueAsPointer(defaultValue, field.Type.Nullable, field.Type)
+
 		} else if field.Type.IsArray() {
 			defaultValue = "[]" + jenny.typeFormatter.formatType(field.Type.Array.ValueType) + "{}"
 		} else if field.Type.IsMap() {

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -355,7 +355,6 @@ func (jenny RawTypes) defaultsForStruct(context languages.Context, objectRef ast
 			}
 
 			defaultValue = jenny.maybeValueAsPointer(defaultValue, field.Type.Nullable, field.Type)
-
 		} else if field.Type.IsArray() {
 			defaultValue = "[]" + jenny.typeFormatter.formatType(field.Type.Array.ValueType) + "{}"
 		} else if field.Type.IsMap() {

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -58,7 +58,7 @@ func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|forma
 			{{- template "type_equality_check" (dict "Type" (resolveRefs .Type).Map.ValueType "Nullable" (resolveRefs .Type).Map.ValueType.Nullable "Dereference" false "SelfName" $selfKey "OtherName" $otherKey "Depth" (add1 $depth)) }}
 		}
 		{{- if $needsDereference }}}{{ end }}
-	{{- else if .Nullable }}
+	{{- else if and .Nullable (not .Type.IsConstantRef) }}
 		if {{ .SelfName }} == nil && {{ .OtherName }} != nil || {{ .SelfName }} != nil && {{ .OtherName }} == nil {
 			return false
 		}

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -94,7 +94,9 @@ func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|forma
 			return false
 		}
     {{- else if .Type.IsConstantRef }}
-        if {{ .SelfName }} != {{ .OtherName}} {
+        {{- $needsDereference := .Type.Nullable }}
+        {{- $dereference := ternary "*" "" $needsDereference }}
+        if {{ $dereference }}{{ .SelfName }} != {{ $dereference }}{{ .OtherName }} {
             return false
         }
 	{{- else }}

--- a/internal/jennies/golang/templates/types/struct_equality_method.tmpl
+++ b/internal/jennies/golang/templates/types/struct_equality_method.tmpl
@@ -58,7 +58,7 @@ func (resource {{ .def.Name|formatObjectName }}) Equals(other {{ .def.Name|forma
 			{{- template "type_equality_check" (dict "Type" (resolveRefs .Type).Map.ValueType "Nullable" (resolveRefs .Type).Map.ValueType.Nullable "Dereference" false "SelfName" $selfKey "OtherName" $otherKey "Depth" (add1 $depth)) }}
 		}
 		{{- if $needsDereference }}}{{ end }}
-	{{- else if and .Nullable (not .Type.IsConstantRef) }}
+	{{- else if and .Nullable }}
 		if {{ .SelfName }} == nil && {{ .OtherName }} != nil || {{ .SelfName }} != nil && {{ .OtherName }} == nil {
 			return false
 		}

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -279,8 +279,13 @@ func (formatter *typeFormatter) formatConstantRef(def ast.Type) string {
 		return "unknown"
 	}
 
+	nullable := ""
+	if def.Nullable {
+		nullable = "*"
+	}
+
 	if obj.Type.IsScalar() {
-		return string(obj.Type.AsScalar().ScalarKind)
+		return nullable + string(obj.Type.AsScalar().ScalarKind)
 	}
 
 	referredPkg := formatter.packageMapper(constRef.ReferredPkg)
@@ -290,7 +295,7 @@ func (formatter *typeFormatter) formatConstantRef(def ast.Type) string {
 		typeName = referredPkg + "." + typeName
 	}
 
-	return typeName
+	return nullable + typeName
 }
 
 func (formatter *typeFormatter) formatIntersection(def ast.IntersectionType) string {

--- a/internal/jennies/typescript/rawtypes.go
+++ b/internal/jennies/typescript/rawtypes.go
@@ -203,7 +203,7 @@ func (jenny RawTypes) defaultValuesForStructType(structType ast.Type, packageMap
 			}
 		}
 
-		if !field.Required {
+		if !field.Required && !field.Type.IsConstantRef() {
 			continue
 		}
 

--- a/testdata/jennies/rawtypes/constant_reference_as_default/GoRawTypes/constant_reference_as_default/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/GoRawTypes/constant_reference_as_default/types_gen.go
@@ -1,0 +1,94 @@
+package constant_reference_as_default
+
+import (
+	"encoding/json"
+	cog "github.com/grafana/cog/generated/cog"
+	"errors"
+	"fmt"
+)
+
+const ConstantRefString = "AString"
+
+type MyStruct struct {
+    AString string `json:"aString"`
+    OptString *string `json:"optString,omitempty"`
+}
+
+// NewMyStruct creates a new MyStruct object.
+func NewMyStruct() *MyStruct {
+	return &MyStruct{
+		AString: ConstantRefString,
+		OptString: (func (input string) *string { return &input })(ConstantRefString),
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `MyStruct` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *MyStruct) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "aString"
+	if fields["aString"] != nil {
+		if string(fields["aString"]) != "null" {
+			if err := json.Unmarshal(fields["aString"], &resource.AString); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("aString", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("aString", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "aString")
+	} else {errs = append(errs, cog.MakeBuildErrors("aString", errors.New("required field is missing from input"))...)
+	}
+	// Field "optString"
+	if fields["optString"] != nil {
+		if string(fields["optString"]) != "null" {
+			if err := json.Unmarshal(fields["optString"], &resource.OptString); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("optString", err)...)
+			}
+		
+		}
+		delete(fields, "optString")
+	
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("MyStruct", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `MyStruct` objects.
+func (resource MyStruct) Equals(other MyStruct) bool {
+        if resource.AString != other.AString {
+            return false
+        }
+		if resource.OptString == nil && other.OptString != nil || resource.OptString != nil && other.OptString == nil {
+			return false
+		}
+
+		if resource.OptString != nil {
+        if resource.OptString != other.OptString {
+            return false
+        }
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `MyStruct` fields for violations and returns them.
+func (resource MyStruct) Validate() error {
+	return nil
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/GoRawTypes/constant_reference_as_default/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/GoRawTypes/constant_reference_as_default/types_gen.go
@@ -79,7 +79,7 @@ func (resource MyStruct) Equals(other MyStruct) bool {
 		}
 
 		if resource.OptString != nil {
-        if resource.OptString != other.OptString {
+        if *resource.OptString != *other.OptString {
             return false
         }
 		}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/JSONSchema/constant_reference_as_default.jsonschema.json
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/JSONSchema/constant_reference_as_default.jsonschema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "ConstantRefString": {
+      "type": "string",
+      "const": "AString"
+    },
+    "MyStruct": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "aString"
+      ],
+      "properties": {
+        "aString": {
+          "$ref": "#/definitions/ConstantRefString"
+        },
+        "optString": {
+          "$ref": "#/definitions/ConstantRefString"
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/JavaRawTypes/constant_reference_as_default/Constants.java
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/JavaRawTypes/constant_reference_as_default/Constants.java
@@ -1,0 +1,5 @@
+package constant_reference_as_default;
+
+public class Constants {
+    public static final String ConstantRefString = "AString";
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/JavaRawTypes/constant_reference_as_default/MyStruct.java
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/JavaRawTypes/constant_reference_as_default/MyStruct.java
@@ -1,0 +1,11 @@
+package constant_reference_as_default;
+
+
+public class MyStruct {
+    public String aString;
+    public String optString;
+    public MyStruct() {
+        this.aString = ConstantRefString;
+        this.optString = ConstantRefString;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/OpenAPI/constant_reference_as_default.openapi.json
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/OpenAPI/constant_reference_as_default.openapi.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "constant_references",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Enum": {
+        "enum": [
+          "ValueA",
+          "ValueB",
+          "ValueC"
+        ],
+        "type": "string"
+      },
+      "ParentStruct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "myEnum"
+        ],
+        "properties": {
+          "myEnum": {
+            "$ref": "#/components/schemas/Enum"
+          }
+        }
+      },
+      "Struct": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "myValue",
+          "myEnum"
+        ],
+        "properties": {
+          "myValue": {
+            "type": "string"
+          },
+          "myEnum": {
+            "$ref": "#/components/schemas/Enum"
+          }
+        }
+      },
+      "StructA": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "myEnum"
+        ],
+        "properties": {
+          "myEnum": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Enum"
+              }
+            ],
+            "default": "ValueA"
+          }
+        }
+      },
+      "StructB": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "myEnum",
+          "myValue"
+        ],
+        "properties": {
+          "myEnum": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Enum"
+              }
+            ],
+            "default": "ValueB"
+          },
+          "myValue": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/OpenAPI/constant_reference_as_default.openapi.json
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/OpenAPI/constant_reference_as_default.openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "constant_references",
+    "title": "constant_reference_as_default",
     "version": "0.0.0",
     "x-schema-identifier": "",
     "x-schema-kind": ""
@@ -9,77 +9,22 @@
   "paths": {},
   "components": {
     "schemas": {
-      "Enum": {
-        "enum": [
-          "ValueA",
-          "ValueB",
-          "ValueC"
-        ],
-        "type": "string"
+      "ConstantRefString": {
+        "type": "string",
+        "const": "AString"
       },
-      "ParentStruct": {
+      "MyStruct": {
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "myEnum"
+          "aString"
         ],
         "properties": {
-          "myEnum": {
-            "$ref": "#/components/schemas/Enum"
-          }
-        }
-      },
-      "Struct": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "myValue",
-          "myEnum"
-        ],
-        "properties": {
-          "myValue": {
-            "type": "string"
+          "aString": {
+            "$ref": "#/components/schemas/ConstantRefString"
           },
-          "myEnum": {
-            "$ref": "#/components/schemas/Enum"
-          }
-        }
-      },
-      "StructA": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "myEnum"
-        ],
-        "properties": {
-          "myEnum": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Enum"
-              }
-            ],
-            "default": "ValueA"
-          }
-        }
-      },
-      "StructB": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "myEnum",
-          "myValue"
-        ],
-        "properties": {
-          "myEnum": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Enum"
-              }
-            ],
-            "default": "ValueB"
-          },
-          "myValue": {
-            "type": "string"
+          "optString": {
+            "$ref": "#/components/schemas/ConstantRefString"
           }
         }
       }

--- a/testdata/jennies/rawtypes/constant_reference_as_default/PHPRawTypes/src/ConstantReferenceAsDefault/Constants.php
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/PHPRawTypes/src/ConstantReferenceAsDefault/Constants.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceAsDefault;
+
+final class Constants
+{
+    const CONSTANT_REF_STRING = "AString";
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/PHPRawTypes/src/ConstantReferenceAsDefault/MyStruct.php
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/PHPRawTypes/src/ConstantReferenceAsDefault/MyStruct.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Grafana\Foundation\ConstantReferenceAsDefault;
+
+class MyStruct implements \JsonSerializable
+{
+    public string $aString;
+
+    public ?string $optString;
+
+    public function __construct()
+    {
+        $this->aString = \Grafana\Foundation\ConstantReferenceAsDefault\ConstantRefString;
+        $this->optString = \Grafana\Foundation\ConstantReferenceAsDefault\ConstantRefString;
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        return new self(
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function jsonSerialize(): mixed
+    {
+        $data = new \stdClass;
+        $data->aString = $this->aString;
+        if (isset($this->optString)) {
+            $data->optString = $this->optString;
+        }
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/PythonRawTypes/models/constant_reference_as_default.py
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/PythonRawTypes/models/constant_reference_as_default.py
@@ -1,0 +1,26 @@
+import typing
+
+
+ConstantRefString: typing.Literal["AString"] = "AString"
+
+
+class MyStruct:
+    a_string: str
+    opt_string: str
+
+    def __init__(self, ):
+        self.a_string = ConstantRefString
+        self.opt_string = ConstantRefString
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "aString": self.a_string,
+        }
+        if self.opt_string is not None:
+            payload["optString"] = self.opt_string
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        return cls(**args)

--- a/testdata/jennies/rawtypes/constant_reference_as_default/TypescriptRawTypes/src/constantReferenceAsDefault/types.gen.ts
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/TypescriptRawTypes/src/constantReferenceAsDefault/types.gen.ts
@@ -1,0 +1,11 @@
+export const ConstantRefString = "AString";
+
+export interface MyStruct {
+	aString: "AString";
+	optString?: "AString";
+}
+
+export const defaultMyStruct = (): MyStruct => ({
+	aString: ConstantRefString,
+	optString: ConstantRefString,
+});

--- a/testdata/jennies/rawtypes/constant_reference_as_default/ir.json
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/ir.json
@@ -1,0 +1,66 @@
+{
+  "Package": "constant_reference_as_default",
+  "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
+  "Objects": {
+    "ConstantRefString": {
+      "Name": "ConstantRefString",
+      "Type": {
+        "Kind": "scalar",
+        "Nullable": false,
+        "Scalar": {
+          "ScalarKind": "string",
+          "Value": "AString"
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_as_default",
+        "ReferredType": "ConstantRefString"
+      }
+    },
+    "MyStruct": {
+      "Name": "MyStruct",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "aString",
+              "Type": {
+                "Kind": "constant_ref",
+                "Nullable": false,
+                "ConstantReference": {
+                  "ReferredPkg": "constant_reference_as_default",
+                  "ReferredType": "ConstantRefString",
+                  "ReferenceValue": "AString"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "optString",
+              "Type": {
+                "Kind": "constant_ref",
+                "Nullable": false,
+                "ConstantReference": {
+                  "ReferredPkg": "constant_reference_as_default",
+                  "ReferredType": "ConstantRefString",
+                  "ReferenceValue": "AString"
+                }
+              },
+              "Required": false
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "constant_reference_as_default",
+        "ReferredType": "MyStruct"
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/schema.cue
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/schema.cue
@@ -1,0 +1,8 @@
+package constant_reference_as_default
+
+ConstantRefString: "AString"
+
+MyStruct: {
+	aString: ConstantRefString
+	optString?: ConstantRefString
+}


### PR DESCRIPTION
Edited!!!

* **Go**: It fixes the fields declared as ConstantReferences when they are optional. We were missing to set them as nullable, making the equal function to fail.

* **Typescript**: We weren't setting the ConstantReference value in the constructor when it was optional.

* **All builders**: We were skipping the options declared as ConstantReference and they were used as fixed value. The option now is available only if the field is optional.