### PR TITLE
CUE: Allow to load cue file from URL

### DIFF
--- a/internal/codegen/cue.go
+++ b/internal/codegen/cue.go
@@ -312,7 +312,12 @@ func readCueURL(entrypoint string, cuePackage string) (map[string]load.Source, e
 		return nil, fmt.Errorf("entrypoint %q must be a cue url", entrypoint)
 	}
 
-	res, err := http.Get(u.String())
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It allows to load a cue file from a URL instead of a path. Its helpful if we need to get a cue file directly from an URL instead to do a local copy to have access to it.

The overlay still uses local path, that its something that we can improve later in other PR.

Why this? Talked with Igor, CUE is more tested than OpenAPI and its going to be easier to parse Dashboard v2 schema until be have something more stable in OpenAPI.