### PR TITLE
Add rename options in compose configuration

### DIFF
--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -172,7 +172,7 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 		refType := composableBuilder.For.SelfRef.AsType()
 		newRoot[len(newRoot)-1].TypeHint = &refType
 
-		newBuilder, err = mergeBuilderInto(composableBuilder, newBuilder, newRoot, nil, nil)
+		newBuilder, err = mergeBuilderInto(composableBuilder, newBuilder, newRoot, nil, config.RenameOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -227,7 +227,6 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 					},
 					VeneerTrail: []string{"ComposeBuilders[created]"},
 				}
-
 				newBuilder.Options = append(newBuilder.Options, branchOpt)
 			}
 		case resolvedEntrypointType.IsStruct():
@@ -238,7 +237,7 @@ func composeBuilderForType(schemas ast.Schemas, builders ast.Builders, config Co
 				refType := entrypointBuilder.For.SelfRef.AsType()
 				newRoot[len(newRoot)-1].TypeHint = &refType
 
-				newBuilder, err = mergeBuilderInto(entrypointBuilder, newBuilder, newRoot, nil, nil)
+				newBuilder, err = mergeBuilderInto(entrypointBuilder, newBuilder, newRoot, nil, config.RenameOptions)
 				if err != nil {
 					return nil, err
 				}
@@ -294,6 +293,10 @@ type CompositionConfig struct {
 	// (ex: dashboard and dashboardv2 packages both use Options & FieldConfig
 	// types from panels for their composition needs)
 	PreserveOriginalBuilders bool
+
+	// RenameOption is used to rename the options from the original schema in order
+	// to avoid conflicts with composed builders.
+	RenameOptions map[string]string
 }
 
 func ComposeBuilders(selector Selector, config CompositionConfig) RewriteRule {

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -117,6 +117,7 @@ type ComposeBuilders struct {
 	CompositionMap           map[string]string `yaml:"composition_map"`
 	ComposedBuilderName      string            `yaml:"composed_builder_name"`
 	PreserveOriginalBuilders bool              `yaml:"preserve_original_builders"`
+	RenameOptions            map[string]string `yaml:"rename_options"`
 }
 
 func (rule ComposeBuilders) AsRewriteRule(pkg string) (builder.RewriteRule, error) {
@@ -134,6 +135,7 @@ func (rule ComposeBuilders) AsRewriteRule(pkg string) (builder.RewriteRule, erro
 			CompositionMap:           rule.CompositionMap,
 			ComposedBuilderName:      rule.ComposedBuilderName,
 			PreserveOriginalBuilders: rule.PreserveOriginalBuilders,
+			RenameOptions:            rule.RenameOptions,
 		},
 	), nil
 }


### PR DESCRIPTION
This change allows to add a map of fields to rename when we generate the compose builder. It updates the options from the original schema to avoid to have conflicts with the names from the composed builder.

I saw that the code was already implemented for `MergeInto` configuration and I re-use it.

Datasources for V2 extends from `DataQueryKind` and it adds `datasource` field, conflicting with the `datasource` field inside each datasource schema.