### PR TITLE
Converters: Modify runtime output by configuration.

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -149,7 +149,7 @@ func inspectConvertersIR(codegenCtx languages.Context, language languages.Langua
 		return fmt.Errorf("language '%s' does not appear to support converters", language.Name())
 	}
 
-	converter := languages.NewConverterGenerator(nullableConfig.NullableKinds()).FromBuilder(codegenCtx, builders[0])
+	converter := languages.NewConverterGenerator(nullableConfig.NullableKinds(), codegenCtx.ConverterConfig).FromBuilder(codegenCtx, builders[0])
 
 	return prettyPrintJSON(converter)
 }

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -102,5 +102,12 @@ func (pipeline *Pipeline) ContextForLanguage(language languages.Language, schema
 		return languages.Context{}, err
 	}
 
+	converterConfig, err := pipeline.readConverterConfig()
+	if err != nil {
+		return languages.Context{}, err
+	}
+
+	jenniesInput.ConverterConfig = *converterConfig
+
 	return jenniesInput, nil
 }

--- a/internal/codegen/transforms.go
+++ b/internal/codegen/transforms.go
@@ -10,22 +10,26 @@ type Transforms struct {
 	// passes to apply to all the schemas.
 	// Note: these compiler passes are applied *before* language-specific passes.
 	CommonPassesFiles []string `yaml:"schemas"`
-
+	
 	// CommonPasses holds a list of compiler passes to apply to all the schemas.
 	// If this field is set, CommonPassesFiles is ignored.
 	// Note: these compiler passes are applied *before* language-specific passes.
 	CommonPasses compiler.Passes `yaml:"-"`
-
+	
 	// FinalPasses holds a list of compiler passes to apply to all the schemas.
 	// Note: these compiler passes are applied *after* language-specific passes.
 	FinalPasses compiler.Passes `yaml:"-"`
-
+	
 	// VeneersDirectories holds a list of paths to directories containing
 	// veneers to apply to all the builders.
 	VeneersDirectories []string `yaml:"builders"`
+	
+	// ConverterConfig is the configuration to set up custom runtime configuration for specific ones.
+	ConverterConfig string `yaml:"converters"`
 }
 
 func (transforms *Transforms) interpolateParameters(interpolator ParametersInterpolator) {
 	transforms.CommonPassesFiles = tools.Map(transforms.CommonPassesFiles, interpolator)
 	transforms.VeneersDirectories = tools.Map(transforms.VeneersDirectories, interpolator)
+	transforms.ConverterConfig = interpolator(transforms.ConverterConfig)
 }

--- a/internal/codegen/transforms.go
+++ b/internal/codegen/transforms.go
@@ -10,21 +10,21 @@ type Transforms struct {
 	// passes to apply to all the schemas.
 	// Note: these compiler passes are applied *before* language-specific passes.
 	CommonPassesFiles []string `yaml:"schemas"`
-	
+
 	// CommonPasses holds a list of compiler passes to apply to all the schemas.
 	// If this field is set, CommonPassesFiles is ignored.
 	// Note: these compiler passes are applied *before* language-specific passes.
 	CommonPasses compiler.Passes `yaml:"-"`
-	
+
 	// FinalPasses holds a list of compiler passes to apply to all the schemas.
 	// Note: these compiler passes are applied *after* language-specific passes.
 	FinalPasses compiler.Passes `yaml:"-"`
-	
+
 	// VeneersDirectories holds a list of paths to directories containing
 	// veneers to apply to all the builders.
 	VeneersDirectories []string `yaml:"builders"`
-	
-	// ConverterConfig is the configuration to set up custom runtime configuration for specific ones.
+
+	// ConverterConfig is the configuration modify the converters output.
 	ConverterConfig string `yaml:"converters"`
 }
 

--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -43,7 +43,7 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 }
 
 func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
-	converter := languages.NewConverterGenerator(jenny.NullableConfig).FromBuilder(context, builder)
+	converter := languages.NewConverterGenerator(jenny.NullableConfig, context.ConverterConfig).FromBuilder(context, builder)
 
 	imports := NewImportMap(jenny.Config.PackageRoot)
 	typeImportMapper := func(pkg string) string {

--- a/internal/jennies/java/converter.go
+++ b/internal/jennies/java/converter.go
@@ -77,7 +77,7 @@ func filterDataqueryObjects(schema *ast.Schema) *orderedmap.Map[string, ast.Obje
 }
 
 func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
-	converter := languages.NewConverterGenerator(jenny.nullableConfig).FromBuilder(context, builder)
+	converter := languages.NewConverterGenerator(jenny.nullableConfig, context.ConverterConfig).FromBuilder(context, builder)
 
 	schema, schemaFound := context.Schemas.Locate(builder.Package)
 	isPanel := schemaFound && schema.Metadata.Variant == ast.SchemaVariantPanel && builder.Name == "Panel"

--- a/internal/jennies/php/converter.go
+++ b/internal/jennies/php/converter.go
@@ -42,7 +42,7 @@ func (jenny *Converter) Generate(context languages.Context) (codejen.Files, erro
 }
 
 func (jenny *Converter) generateConverter(context languages.Context, builder ast.Builder) ([]byte, error) {
-	converter := languages.NewConverterGenerator(jenny.nullableConfig).FromBuilder(context, builder)
+	converter := languages.NewConverterGenerator(jenny.nullableConfig, context.ConverterConfig).FromBuilder(context, builder)
 	schema, schemaFound := context.Schemas.Locate(builder.Package)
 
 	inputIsDataquery := schemaFound && schema.Metadata.Variant == ast.SchemaVariantDataQuery && schema.EntryPoint == builder.For.Name

--- a/internal/languages/context.go
+++ b/internal/languages/context.go
@@ -9,8 +9,9 @@ import (
 
 //nolint:musttag
 type Context struct {
-	Schemas  ast.Schemas
-	Builders ast.Builders
+	Schemas         ast.Schemas
+	Builders        ast.Builders
+	ConverterConfig ConverterConfig
 }
 
 func (context *Context) LocateObject(pkg string, name string) (ast.Object, bool) {

--- a/internal/yaml/converter_config.go
+++ b/internal/yaml/converter_config.go
@@ -1,0 +1,47 @@
+package yaml
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ConverterConfig struct {
+	Runtime []Runtime `yaml:"runtime"`
+}
+
+type Runtime struct {
+	Package            string `yaml:"package"`
+	Name               string `yaml:"name"`
+	NameFunc           string `yaml:"name_func"`
+	DiscriminatorField string `yaml:"discriminator_field"`
+}
+
+type ConverterConfigReader struct{}
+
+func NewConverterConfigReader() *ConverterConfigReader {
+	return &ConverterConfigReader{}
+}
+
+func (c ConverterConfigReader) ReadConverterConfig(filename string) (ConverterConfig, error) {
+	if filename == "" {
+		return ConverterConfig{}, nil
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return ConverterConfig{}, err
+	}
+
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	decoder.KnownFields(true)
+
+	var config ConverterConfig
+	if err = decoder.Decode(&config); err != nil {
+		return config, err
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
The Runtime configuration to detect that the panels needs to use runtime code ([extra code added in Foundation-SDK by configuration](https://github.com/grafana/grafana-foundation-sdk/blob/main/.cog/templates/go/extra/cog/runtime.go)) is hardcoded.

For V2 we need the same for `VizConfigKind` to be able to set the proper panel if exists.

You can see the current behaviour [here](https://github.com/grafana/grafana-foundation-sdk/blob/v11.6.x%2Bcog-v0.0.x/go/dashboard/dashboard_converter_gen.go#L344) if you need to check how its the result.

If we want to release a new version of Foundation-SDK with this version, it needs to adds the converters configuration to have the previous result.