### PR TITLE
Converters: Add function for templates to check if an object exists

### DIFF
--- a/internal/jennies/common/templatehelpers.go
+++ b/internal/jennies/common/templatehelpers.go
@@ -36,10 +36,14 @@ func TypeResolvingTemplateHelpers(context languages.Context) template.FuncMap {
 	}
 }
 
-func TypesTemplateHelpers() template.FuncMap {
+func TypesTemplateHelpers(context languages.Context) template.FuncMap {
 	return template.FuncMap{
 		"schemaHasObject": func(schema *ast.Schema, name string) bool {
 			return schema.HasObject(name)
+		},
+		"objectExists": func(pkg string, name string) bool {
+			_, ok := context.Schemas.LocateObject(pkg, name)
+			return ok
 		},
 	}
 }

--- a/internal/jennies/golang/rawtypes.go
+++ b/internal/jennies/golang/rawtypes.go
@@ -29,7 +29,9 @@ func (jenny RawTypes) JennyName() string {
 func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0, len(context.Schemas))
 
-	jenny.tmpl = jenny.tmpl.Funcs(common.TypeResolvingTemplateHelpers(context))
+	jenny.tmpl = jenny.tmpl.
+		Funcs(common.TypeResolvingTemplateHelpers(context)).
+		Funcs(common.TypesTemplateHelpers(context))
 
 	for _, schema := range context.Schemas {
 		output, err := jenny.generateSchema(context, schema)

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -20,7 +20,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 
 		// placeholder functions, will be overridden by jennies
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
-		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
 		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		template.Funcs(formattingTemplateFuncs(config)),
 		template.Funcs(template.FuncMap{

--- a/internal/jennies/java/tmpl.go
+++ b/internal/jennies/java/tmpl.go
@@ -18,7 +18,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 	tmpl, err := template.New(
 		"java",
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
-		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
 		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		template.Funcs(functions()),
 		template.Funcs(formattingTemplateFuncs()),

--- a/internal/jennies/php/tmpl.go
+++ b/internal/jennies/php/tmpl.go
@@ -21,7 +21,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		// "dummy"/unimplemented helpers, to be able to parse the templates before jennies are initialized.
 		// Jennies will override these with proper dependencies.
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
-		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
 		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		template.Funcs(common.DynamicFilesTemplateHelpers()),
 

--- a/internal/jennies/python/tmpl.go
+++ b/internal/jennies/python/tmpl.go
@@ -19,7 +19,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 		"python",
 
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
-		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
 		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		template.Funcs(formattingTemplateFuncs()),
 		// placeholder functions, will be overridden by jennies

--- a/internal/jennies/typescript/tmpl.go
+++ b/internal/jennies/typescript/tmpl.go
@@ -18,7 +18,7 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 	tmpl, err := template.New(
 		"typescript",
 		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
-		template.Funcs(common.TypesTemplateHelpers()),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
 		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
 		// placeholder functions, will be overridden by jennies
 		template.Funcs(template.FuncMap{


### PR DESCRIPTION
For converters, in Go at least, each panel has a configuration function that returns the proper converter for that panel. For example, [this one](https://github.com/grafana/grafana-foundation-sdk/blob/v11.6.x%2Bcog-v0.0.x/go/bargauge/types_gen.go#L327-L333). The code is generated using a [template](https://github.com/grafana/grafana-foundation-sdk/blob/main/.cog/templates/go/overrides/schema_variant_panelcfg.tmpl#L61-L65). 

For V2 schemas, we have to cast the input received into `dashboardv2beta1.VizConfigKind`, but adding this code isn't enough since the template is used in all versions of Grafana and it will only work with Grafana 12+. Something like that:

```go
if panel, ok := inputPanel.(*dashboardv2beta1.VizConfigKind); ok {
    return VisualizationConverter(*panel)
}
```

So this PR adds a function to check if an object exist in order to add this new piece of code to make it works to all versions of Grafana.