### PR TITLE
Converters: Fix disjunction refs and maps

### DIFF
--- a/internal/jennies/golang/converter.go
+++ b/internal/jennies/golang/converter.go
@@ -83,10 +83,11 @@ func (jenny *Converter) generateConverter(context languages.Context, builder ast
 			"importStdPkg": func(pkg string) string {
 				return imports.Add(pkg, pkg)
 			},
-			"importPkg":    typeImportMapper,
-			"formatType":   builderTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
-			"formatPath":   makePathFormatter(formatter),
-			"formatRawRef": formatRawRef,
+			"importPkg":          typeImportMapper,
+			"formatType":         builderTypeFormatter(jenny.Config, context, dummyImports, dummyImportMapper).formatType,
+			"formatPath":         makePathFormatter(formatter),
+			"formatPathForRange": formatPathForRange(formatter),
+			"formatRawRef":       formatRawRef,
 		}).
 		RenderAsBytes("converters/converter.tmpl", map[string]any{
 			"Imports":   imports,

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -105,7 +105,7 @@ package {{ .Converter.Package | formatPackageName }}
 {{- define "conversion_mapping" -}}
     {{- $firstOpt := .Options | first }}
     {{- with $firstOpt.Guards -}}if {{ template "guards" . }} { {{- end }}
-    {{- if ne .RepeatFor nil -}}for {{ .RepeatIndex | default "_" }}{{ if or (eq .RepeatIndex "_") (eq .RepeatIndex "") }}, {{ .RepeatAs }}{{ end }} := range {{ .RepeatFor | formatPathForRange }} { {{- end }}
+    {{- if ne .RepeatFor nil -}}for {{ .RepeatIndex | default "_" }}, {{ .RepeatAs }} := range {{ .RepeatFor | formatPathForRange }} { {{- end }}
     {{- range $optMapping := .Options }}
         {{ template "option_mapping" $optMapping }}
     {{- end }}

--- a/internal/jennies/golang/templates/converters/converter.tmpl
+++ b/internal/jennies/golang/templates/converters/converter.tmpl
@@ -105,7 +105,7 @@ package {{ .Converter.Package | formatPackageName }}
 {{- define "conversion_mapping" -}}
     {{- $firstOpt := .Options | first }}
     {{- with $firstOpt.Guards -}}if {{ template "guards" . }} { {{- end }}
-    {{- if ne .RepeatFor nil -}}for {{ .RepeatIndex | default "_" }}, {{ .RepeatAs }} := range {{ .RepeatFor | formatPath }} { {{- end }}
+    {{- if ne .RepeatFor nil -}}for {{ .RepeatIndex | default "_" }}{{ if or (eq .RepeatIndex "_") (eq .RepeatIndex "") }}, {{ .RepeatAs }}{{ end }} := range {{ .RepeatFor | formatPathForRange }} { {{- end }}
     {{- range $optMapping := .Options }}
         {{ template "option_mapping" $optMapping }}
     {{- end }}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -27,6 +27,9 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 			"formatPath": func(_ ast.Path) string {
 				panic("formatPath() needs to be overridden by a jenny")
 			},
+			"formatPathForRange": func(_ ast.Path) string {
+				panic("formatPathForRange() needs to be overridden by a jenny")
+			},
 			"formatType": func(_ ast.Type) string {
 				panic("formatType() needs to be overridden by a jenny")
 			},

--- a/internal/jennies/golang/types.go
+++ b/internal/jennies/golang/types.go
@@ -399,3 +399,36 @@ func makePathFormatter(typeFormatter *typeFormatter) func(path ast.Path) string 
 		return path
 	}
 }
+
+func formatPathForRange(typeFormatter *typeFormatter) func(path ast.Path) string {
+	return func(fieldPath ast.Path) string {
+		path := ""
+
+		for i := range fieldPath {
+			last := i == len(fieldPath)-1
+			output := fieldPath[i].Identifier
+			if !fieldPath[i].Root {
+				output = formatFieldName(output)
+			}
+
+			// don't generate type hints if:
+			// * there isn't one defined
+			// * the type isn't "any"
+			// * as a trailing element in the path
+			if !fieldPath[i].Type.IsAny() || fieldPath[i].TypeHint == nil || i == len(fieldPath)-1 {
+				path += output
+				if !last && fieldPath[i+1].Index == nil {
+					path += "."
+				}
+				continue
+			}
+
+			path += output + fmt.Sprintf(".(*%s)", typeFormatter.doFormatType(*fieldPath[i].TypeHint, false))
+			if !last && fieldPath[i+1].Index == nil {
+				path += "."
+			}
+		}
+
+		return path
+	}
+}

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -404,32 +404,6 @@ func (generator *ConverterGenerator) argumentForType(context Context, converter 
 			},
 		}
 	}
-	if len(possibleBuilders) > 1 && strings.EqualFold(possibleBuilders[0].Package, "dashboardv2beta1") && strings.EqualFold("vizconfigkind", possibleBuilders[0].For.Name) {
-		typeField, _ := possibleBuilders[0].For.Type.Struct.FieldByName("group")
-
-		return ArgumentMapping{
-			Runtime: &RuntimeArgMapping{
-				FuncName: "ConvertPanelToCode",
-				Args: []*DirectArgMapping{
-					{ValuePath: valuePath, ValueType: typeDef},
-					{ValuePath: valuePath.AppendStructField(typeField), ValueType: typeField.Type},
-				},
-			},
-		}
-	}
-	if len(possibleBuilders) > 1 && strings.EqualFold(possibleBuilders[0].Package, "dashboardv2beta1") && strings.EqualFold("dataquerykind", possibleBuilders[0].For.Name) {
-		typeField, _ := possibleBuilders[0].For.Type.Struct.FieldByName("group")
-
-		return ArgumentMapping{
-			Runtime: &RuntimeArgMapping{
-				FuncName: "ConvertDataQueryKindToCode",
-				Args: []*DirectArgMapping{
-					{ValuePath: valuePath, ValueType: typeDef},
-					{ValuePath: valuePath.AppendStructField(typeField), ValueType: typeField.Type},
-				},
-			},
-		}
-	}
 	if len(possibleBuilders) > 1 && possibleBuilders.HaveConstantConstructorAssignment() {
 		choices := make([]BuilderChoiceMapping, 0, len(possibleBuilders))
 		for _, possibleBuilder := range possibleBuilders {

--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -294,12 +294,11 @@ func (generator *ConverterGenerator) mappingForOption(context Context, converter
 			argument := generator.argumentForType(context, converter, mapping.RepeatIndex, indexPath, indexType)
 			optMapping.Args = append(optMapping.Args, argument)
 			// If it isn't a disjunction, we have to put the value in the second argument
+			// value
+			valuePath = ast.Path{
+				{Identifier: mapping.RepeatAs, Type: valueType, Root: true},
+			}
 			if !generator.isAssignmentFromDisjunctionStruct(context, assignment) {
-				// value
-				valuePath = ast.Path{
-					{Identifier: mapping.RepeatAs, Type: valueType, Root: true},
-				}
-
 				argument = generator.argumentForType(context, converter, argName, valuePath, valueType)
 				optMapping.Args = append(optMapping.Args, argument)
 				continue

--- a/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/dashboard_builder_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/dashboard_builder_gen.go
@@ -1,0 +1,51 @@
+package map_of_disjunctions
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Dashboard] = (*DashboardBuilder)(nil)
+
+type DashboardBuilder struct {
+    internal *Dashboard
+    errors cog.BuildErrors
+}
+
+func NewDashboardBuilder() *DashboardBuilder {
+	resource := NewDashboard()
+	builder := &DashboardBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+
+	return builder
+}
+
+
+
+func (builder *DashboardBuilder) Build() (Dashboard, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return Dashboard{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return Dashboard{}, cog.MakeBuildErrors("map_of_disjunctions.dashboard", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *DashboardBuilder) Panels(panels map[string]cog.Builder[Element]) *DashboardBuilder {
+        panelsResource := make(map[string]Element)
+        for key1, val1 := range panels {
+                panelsDepth1, err := val1.Build()
+                if err != nil {
+                    builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
+                    return builder
+                }
+                panelsResource[key1] = panelsDepth1
+        }
+    builder.internal.Panels = panelsResource
+
+    return builder
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/element_builder_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/element_builder_gen.go
@@ -1,0 +1,58 @@
+package map_of_disjunctions
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Element] = (*ElementBuilder)(nil)
+
+type ElementBuilder struct {
+    internal *Element
+    errors cog.BuildErrors
+}
+
+func NewElementBuilder() *ElementBuilder {
+	resource := NewElement()
+	builder := &ElementBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+
+	return builder
+}
+
+
+
+func (builder *ElementBuilder) Build() (Element, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return Element{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return Element{}, cog.MakeBuildErrors("map_of_disjunctions.element", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *ElementBuilder) Panel(panel cog.Builder[Panel]) *ElementBuilder {
+    panelResource, err := panel.Build()
+    if err != nil {
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
+        return builder
+    }
+    builder.internal.Panel = &panelResource
+
+    return builder
+}
+
+func (builder *ElementBuilder) LibraryPanel(libraryPanel cog.Builder[LibraryPanel]) *ElementBuilder {
+    libraryPanelResource, err := libraryPanel.Build()
+    if err != nil {
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
+        return builder
+    }
+    builder.internal.LibraryPanel = &libraryPanelResource
+
+    return builder
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/librarypanel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/librarypanel_builder_gen.go
@@ -1,0 +1,43 @@
+package map_of_disjunctions
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[LibraryPanel] = (*LibraryPanelBuilder)(nil)
+
+type LibraryPanelBuilder struct {
+    internal *LibraryPanel
+    errors cog.BuildErrors
+}
+
+func NewLibraryPanelBuilder() *LibraryPanelBuilder {
+	resource := NewLibraryPanel()
+	builder := &LibraryPanelBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+    builder.internal.Kind = "Library"
+
+	return builder
+}
+
+
+
+func (builder *LibraryPanelBuilder) Build() (LibraryPanel, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return LibraryPanel{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return LibraryPanel{}, cog.MakeBuildErrors("map_of_disjunctions.libraryPanel", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *LibraryPanelBuilder) Text(text string) *LibraryPanelBuilder {
+    builder.internal.Text = text
+
+    return builder
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/panel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/panel_builder_gen.go
@@ -1,0 +1,43 @@
+package map_of_disjunctions
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[Panel] = (*PanelBuilder)(nil)
+
+type PanelBuilder struct {
+    internal *Panel
+    errors cog.BuildErrors
+}
+
+func NewPanelBuilder() *PanelBuilder {
+	resource := NewPanel()
+	builder := &PanelBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+    builder.internal.Kind = "Panel"
+
+	return builder
+}
+
+
+
+func (builder *PanelBuilder) Build() (Panel, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return Panel{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return Panel{}, cog.MakeBuildErrors("map_of_disjunctions.panel", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *PanelBuilder) Title(title string) *PanelBuilder {
+    builder.internal.Title = title
+
+    return builder
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/panelorlibrarypanel_builder_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoBuilder/map_of_disjunctions/panelorlibrarypanel_builder_gen.go
@@ -1,0 +1,58 @@
+package map_of_disjunctions
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[PanelOrLibraryPanel] = (*PanelOrLibraryPanelBuilder)(nil)
+
+type PanelOrLibraryPanelBuilder struct {
+    internal *PanelOrLibraryPanel
+    errors cog.BuildErrors
+}
+
+func NewPanelOrLibraryPanelBuilder() *PanelOrLibraryPanelBuilder {
+	resource := NewPanelOrLibraryPanel()
+	builder := &PanelOrLibraryPanelBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+
+	return builder
+}
+
+
+
+func (builder *PanelOrLibraryPanelBuilder) Build() (PanelOrLibraryPanel, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return PanelOrLibraryPanel{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return PanelOrLibraryPanel{}, cog.MakeBuildErrors("map_of_disjunctions.panelOrLibraryPanel", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *PanelOrLibraryPanelBuilder) Panel(panel cog.Builder[Panel]) *PanelOrLibraryPanelBuilder {
+    panelResource, err := panel.Build()
+    if err != nil {
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
+        return builder
+    }
+    builder.internal.Panel = &panelResource
+
+    return builder
+}
+
+func (builder *PanelOrLibraryPanelBuilder) LibraryPanel(libraryPanel cog.Builder[LibraryPanel]) *PanelOrLibraryPanelBuilder {
+    libraryPanelResource, err := libraryPanel.Build()
+    if err != nil {
+        builder.errors = append(builder.errors, err.(cog.BuildErrors)...)
+        return builder
+    }
+    builder.internal.LibraryPanel = &libraryPanelResource
+
+    return builder
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/dashboard_converter_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/dashboard_converter_gen.go
@@ -1,0 +1,35 @@
+package map_of_disjunctions
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// DashboardConverter accepts a `Dashboard` object and generates the Go code to build this object using builders.
+func DashboardConverter(input Dashboard) string {
+    calls := []string{
+    `map_of_disjunctions.NewDashboardBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Panels != nil {
+        
+    buffer.WriteString(`Panels(`)
+        arg0 := "map[string]cog.Builder[map_of_disjunctions.Element]{"
+        for key, arg1 := range input.Panels {
+            tmppanelsarg1 := ElementConverter(arg1)
+            arg0 += "\t" + fmt.Sprintf("%#v", key) + ": " + tmppanelsarg1 +","
+        }
+        arg0 += "}"
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/element_converter_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/element_converter_gen.go
@@ -1,0 +1,41 @@
+package map_of_disjunctions
+
+
+
+import (
+	"strings"
+)
+
+// ElementConverter accepts a `Element` object and generates the Go code to build this object using builders.
+func ElementConverter(input Element) string {
+    calls := []string{
+    `map_of_disjunctions.NewElementBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Panel != nil {
+        
+    buffer.WriteString(`Panel(`)
+        arg0 := PanelConverter(*input.Panel)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+        if input.LibraryPanel != nil {
+        
+    buffer.WriteString(`LibraryPanel(`)
+        arg0 := LibraryPanelConverter(*input.LibraryPanel)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/librarypanel_converter_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/librarypanel_converter_gen.go
@@ -1,0 +1,30 @@
+package map_of_disjunctions
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// LibraryPanelConverter accepts a `LibraryPanel` object and generates the Go code to build this object using builders.
+func LibraryPanelConverter(input LibraryPanel) string {
+    calls := []string{
+    `map_of_disjunctions.NewLibraryPanelBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Text != "" {
+        
+    buffer.WriteString(`Text(`)
+        arg0 :=fmt.Sprintf("%#v", input.Text)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/panel_converter_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/panel_converter_gen.go
@@ -1,0 +1,30 @@
+package map_of_disjunctions
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// PanelConverter accepts a `Panel` object and generates the Go code to build this object using builders.
+func PanelConverter(input Panel) string {
+    calls := []string{
+    `map_of_disjunctions.NewPanelBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Title != "" {
+        
+    buffer.WriteString(`Title(`)
+        arg0 :=fmt.Sprintf("%#v", input.Title)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/panelorlibrarypanel_converter_gen.go
+++ b/testdata/jennies/builders/map_of_disjunctions/GoConverter/map_of_disjunctions/panelorlibrarypanel_converter_gen.go
@@ -1,0 +1,41 @@
+package map_of_disjunctions
+
+
+
+import (
+	"strings"
+)
+
+// PanelOrLibraryPanelConverter accepts a `PanelOrLibraryPanel` object and generates the Go code to build this object using builders.
+func PanelOrLibraryPanelConverter(input PanelOrLibraryPanel) string {
+    calls := []string{
+    `map_of_disjunctions.NewPanelOrLibraryPanelBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Panel != nil {
+        
+    buffer.WriteString(`Panel(`)
+        arg0 := PanelConverter(*input.Panel)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+        if input.LibraryPanel != nil {
+        
+    buffer.WriteString(`LibraryPanel(`)
+        arg0 := LibraryPanelConverter(*input.LibraryPanel)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+} 

--- a/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/DashboardBuilder.java
+++ b/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/DashboardBuilder.java
@@ -1,0 +1,24 @@
+package map_of_disjunctions;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class DashboardBuilder implements cog.Builder<Dashboard> {
+    protected final Dashboard internal;
+    
+    public DashboardBuilder() {
+        this.internal = new Dashboard();
+    }
+    public DashboardBuilder panels(Map<String, cog.Builder<Element>> panels) {
+        Map<String, Element> panelsResources = new HashMap<>();
+        for (var entry1 : panels.entrySet()) {
+                panelsDepth1 = entry1.getValue().build();
+                panelsResources.put(entry1.getKey(), panelsDepth1);           
+        }
+        this.internal.panels = panelsResources;
+        return this;
+    }
+    public Dashboard build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/ElementBuilder.java
+++ b/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/ElementBuilder.java
@@ -1,0 +1,24 @@
+package map_of_disjunctions;
+
+
+public class ElementBuilder implements cog.Builder<Element> {
+    protected final Element internal;
+    
+    public ElementBuilder() {
+        this.internal = new Element();
+    }
+    public ElementBuilder panel(cog.Builder<Panel> panel) {
+    Panel panelResource = panel.build();
+        this.internal.panel = panelResource;
+        return this;
+    }
+    
+    public ElementBuilder libraryPanel(cog.Builder<LibraryPanel> libraryPanel) {
+    LibraryPanel libraryPanelResource = libraryPanel.build();
+        this.internal.libraryPanel = libraryPanelResource;
+        return this;
+    }
+    public Element build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/LibraryPanelBuilder.java
+++ b/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/LibraryPanelBuilder.java
@@ -1,0 +1,18 @@
+package map_of_disjunctions;
+
+
+public class LibraryPanelBuilder implements cog.Builder<LibraryPanel> {
+    protected final LibraryPanel internal;
+    
+    public LibraryPanelBuilder() {
+        this.internal = new LibraryPanel();
+        this.internal.kind = "Library";
+    }
+    public LibraryPanelBuilder text(String text) {
+        this.internal.text = text;
+        return this;
+    }
+    public LibraryPanel build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/PanelBuilder.java
+++ b/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/PanelBuilder.java
@@ -1,0 +1,18 @@
+package map_of_disjunctions;
+
+
+public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Panel> {
+    protected final Panel internal;
+    
+    public PanelBuilder() {
+        this.internal = new Panel();
+        this.internal.kind = "Panel";
+    }
+    public T title(String title) {
+        this.internal.title = title;
+        return (T) this;
+    }
+    public Panel build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/PanelOrLibraryPanelBuilder.java
+++ b/testdata/jennies/builders/map_of_disjunctions/JavaBuilder/map_of_disjunctions/PanelOrLibraryPanelBuilder.java
@@ -1,0 +1,24 @@
+package map_of_disjunctions;
+
+
+public class PanelOrLibraryPanelBuilder implements cog.Builder<PanelOrLibraryPanel> {
+    protected final PanelOrLibraryPanel internal;
+    
+    public PanelOrLibraryPanelBuilder() {
+        this.internal = new PanelOrLibraryPanel();
+    }
+    public PanelOrLibraryPanelBuilder panel(cog.Builder<Panel> panel) {
+    Panel panelResource = panel.build();
+        this.internal.panel = panelResource;
+        return this;
+    }
+    
+    public PanelOrLibraryPanelBuilder libraryPanel(cog.Builder<LibraryPanel> libraryPanel) {
+    LibraryPanel libraryPanelResource = libraryPanel.build();
+        this.internal.libraryPanel = libraryPanelResource;
+        return this;
+    }
+    public PanelOrLibraryPanel build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/DashboardBuilder.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/DashboardBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Dashboard>
+ */
+class DashboardBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfDisjunctions\Dashboard $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfDisjunctions\Dashboard();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfDisjunctions\Dashboard
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    /**
+     * @param array<string, \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Element>> $panels
+     */
+    public function panels(array $panels): static
+    {
+            $panelsResources = [];
+            foreach ($panels as $key1 => $val1) {
+                    $panelsResources[$key1] = $val1->build();
+            }
+        $this->internal->panels = $panelsResources;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/ElementBuilder.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/ElementBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Element>
+ */
+class ElementBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfDisjunctions\Element $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfDisjunctions\Element();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfDisjunctions\Element
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    /**
+     * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Panel> $panel
+     */
+    public function panel(\Grafana\Foundation\Cog\Builder $panel): static
+    {
+        $panelResource = $panel->build();
+        $this->internal->panel = $panelResource;
+    
+        return $this;
+    }
+
+    /**
+     * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\LibraryPanel> $libraryPanel
+     */
+    public function libraryPanel(\Grafana\Foundation\Cog\Builder $libraryPanel): static
+    {
+        $libraryPanelResource = $libraryPanel->build();
+        $this->internal->libraryPanel = $libraryPanelResource;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/LibraryPanelBuilder.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/LibraryPanelBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\LibraryPanel>
+ */
+class LibraryPanelBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfDisjunctions\LibraryPanel $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfDisjunctions\LibraryPanel();
+    $this->internal->kind = "Library";
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfDisjunctions\LibraryPanel
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    public function text(string $text): static
+    {
+        $this->internal->text = $text;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/PanelBuilder.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/PanelBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Panel>
+ */
+class PanelBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfDisjunctions\Panel $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfDisjunctions\Panel();
+    $this->internal->kind = "Panel";
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfDisjunctions\Panel
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    public function title(string $title): static
+    {
+        $this->internal->title = $title;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/PanelOrLibraryPanelBuilder.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPBuilder/src/MapOfDisjunctions/PanelOrLibraryPanelBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanel>
+ */
+class PanelOrLibraryPanelBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanel $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanel();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanel
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    /**
+     * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\Panel> $panel
+     */
+    public function panel(\Grafana\Foundation\Cog\Builder $panel): static
+    {
+        $panelResource = $panel->build();
+        $this->internal->panel = $panelResource;
+    
+        return $this;
+    }
+
+    /**
+     * @param \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\MapOfDisjunctions\LibraryPanel> $libraryPanel
+     */
+    public function libraryPanel(\Grafana\Foundation\Cog\Builder $libraryPanel): static
+    {
+        $libraryPanelResource = $libraryPanel->build();
+        $this->internal->libraryPanel = $libraryPanelResource;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfBuilders/DashboardConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfBuilders/DashboardConverter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+final class DashboardConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfBuilders\Dashboard $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfBuilders\DashboardBuilder())',
+        ];
+            
+    
+        {
+    $buffer = 'panels(';
+        $arg0 = "[";
+        foreach ($input->panels as $key => $arg1) {
+            $tmppanelsarg1 = \Grafana\Foundation\MapOfBuilders\PanelConverter::convert($arg1);
+            $arg0 .= "\t".var_export($key, true)." => $tmppanelsarg1,";
+        }
+        $arg0 .= "]";
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    }
+    
+    
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfBuilders/PanelConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfBuilders/PanelConverter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Grafana\Foundation\MapOfBuilders;
+
+final class PanelConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfBuilders\Panel $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfBuilders\PanelBuilder())',
+        ];
+            if ($input->title !== "") {
+    
+        
+    $buffer = 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/DashboardConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/DashboardConverter.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Grafana\Foundation\MapOfBuilders;
+namespace Grafana\Foundation\MapOfDisjunctions;
 
 final class DashboardConverter
 {
-    public static function convert(\Grafana\Foundation\MapOfBuilders\Dashboard $input): string
+    public static function convert(\Grafana\Foundation\MapOfDisjunctions\Dashboard $input): string
     {
         
         $calls = [
-            '(new \Grafana\Foundation\MapOfBuilders\DashboardBuilder())',
+            '(new \Grafana\Foundation\MapOfDisjunctions\DashboardBuilder())',
         ];
             
     
@@ -16,7 +16,7 @@ final class DashboardConverter
     $buffer = 'panels(';
         $arg0 = "[";
         foreach ($input->panels as $key => $arg1) {
-            $tmppanelsarg1 = \Grafana\Foundation\MapOfBuilders\PanelConverter::convert($arg1);
+            $tmppanelsarg1 = \Grafana\Foundation\MapOfDisjunctions\ElementConverter::convert($arg1);
             $arg0 .= "\t".var_export($key, true)." => $tmppanelsarg1,";
         }
         $arg0 .= "]";
@@ -32,4 +32,3 @@ final class DashboardConverter
         return \implode("\n\t->", $calls);
     }
 }
-

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/ElementConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/ElementConverter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+final class ElementConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfDisjunctions\Element $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfDisjunctions\ElementBuilder())',
+        ];
+            if ($input->panel !== null) {
+    
+        
+    $buffer = 'panel(';
+        $arg0 = \Grafana\Foundation\MapOfDisjunctions\PanelConverter::convert($input->panel);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+            if ($input->libraryPanel !== null) {
+    
+        
+    $buffer = 'libraryPanel(';
+        $arg0 = \Grafana\Foundation\MapOfDisjunctions\LibraryPanelConverter::convert($input->libraryPanel);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/LibraryPanelConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/LibraryPanelConverter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+final class LibraryPanelConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfDisjunctions\LibraryPanel $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfDisjunctions\LibraryPanelBuilder())',
+        ];
+            if ($input->text !== "") {
+    
+        
+    $buffer = 'text(';
+        $arg0 =\var_export($input->text, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/PanelConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/PanelConverter.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Grafana\Foundation\MapOfBuilders;
+namespace Grafana\Foundation\MapOfDisjunctions;
 
 final class PanelConverter
 {
-    public static function convert(\Grafana\Foundation\MapOfBuilders\Panel $input): string
+    public static function convert(\Grafana\Foundation\MapOfDisjunctions\Panel $input): string
     {
         
         $calls = [
-            '(new \Grafana\Foundation\MapOfBuilders\PanelBuilder())',
+            '(new \Grafana\Foundation\MapOfDisjunctions\PanelBuilder())',
         ];
             if ($input->title !== "") {
     
@@ -27,4 +27,3 @@ final class PanelConverter
         return \implode("\n\t->", $calls);
     }
 }
-

--- a/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/PanelOrLibraryPanelConverter.php
+++ b/testdata/jennies/builders/map_of_disjunctions/PHPConverter/src/MapOfDisjunctions/PanelOrLibraryPanelConverter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Grafana\Foundation\MapOfDisjunctions;
+
+final class PanelOrLibraryPanelConverter
+{
+    public static function convert(\Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanel $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\MapOfDisjunctions\PanelOrLibraryPanelBuilder())',
+        ];
+            if ($input->panel !== null) {
+    
+        
+    $buffer = 'panel(';
+        $arg0 = \Grafana\Foundation\MapOfDisjunctions\PanelConverter::convert($input->panel);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+            if ($input->libraryPanel !== null) {
+    
+        
+    $buffer = 'libraryPanel(';
+        $arg0 = \Grafana\Foundation\MapOfDisjunctions\LibraryPanelConverter::convert($input->libraryPanel);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/PythonBuilder/builders/map_of_disjunctions.py
+++ b/testdata/jennies/builders/map_of_disjunctions/PythonBuilder/builders/map_of_disjunctions.py
@@ -1,0 +1,115 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import map_of_disjunctions
+
+
+class Element(cogbuilder.Builder[map_of_disjunctions.Element]):
+    _internal: map_of_disjunctions.Element
+
+    def __init__(self):
+        self._internal = map_of_disjunctions.Element()
+
+    def build(self) -> map_of_disjunctions.Element:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def panel(self, panel: cogbuilder.Builder[map_of_disjunctions.Panel]) -> typing.Self:    
+        panel_resource = panel.build()
+        self._internal.panel = panel_resource
+    
+        return self
+    
+    def library_panel(self, library_panel: cogbuilder.Builder[map_of_disjunctions.LibraryPanel]) -> typing.Self:    
+        library_panel_resource = library_panel.build()
+        self._internal.library_panel = library_panel_resource
+    
+        return self
+    
+
+
+class Panel(cogbuilder.Builder[map_of_disjunctions.Panel]):
+    _internal: map_of_disjunctions.Panel
+
+    def __init__(self):
+        self._internal = map_of_disjunctions.Panel()        
+        self._internal.kind = "Panel"
+
+    def build(self) -> map_of_disjunctions.Panel:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def title(self, title: str) -> typing.Self:    
+        self._internal.title = title
+    
+        return self
+    
+
+
+class LibraryPanel(cogbuilder.Builder[map_of_disjunctions.LibraryPanel]):
+    _internal: map_of_disjunctions.LibraryPanel
+
+    def __init__(self):
+        self._internal = map_of_disjunctions.LibraryPanel()        
+        self._internal.kind = "Library"
+
+    def build(self) -> map_of_disjunctions.LibraryPanel:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def text(self, text: str) -> typing.Self:    
+        self._internal.text = text
+    
+        return self
+    
+
+
+class Dashboard(cogbuilder.Builder[map_of_disjunctions.Dashboard]):
+    _internal: map_of_disjunctions.Dashboard
+
+    def __init__(self):
+        self._internal = map_of_disjunctions.Dashboard()
+
+    def build(self) -> map_of_disjunctions.Dashboard:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def panels(self, panels: dict[str, cogbuilder.Builder[map_of_disjunctions.Element]]) -> typing.Self:    
+        panels_resources = { key1: val1.build() for (key1, val1) in panels.items() }
+        self._internal.panels = panels_resources
+    
+        return self
+    
+
+
+class PanelOrLibraryPanel(cogbuilder.Builder[map_of_disjunctions.PanelOrLibraryPanel]):
+    _internal: map_of_disjunctions.PanelOrLibraryPanel
+
+    def __init__(self):
+        self._internal = map_of_disjunctions.PanelOrLibraryPanel()
+
+    def build(self) -> map_of_disjunctions.PanelOrLibraryPanel:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def panel(self, panel: cogbuilder.Builder[map_of_disjunctions.Panel]) -> typing.Self:    
+        panel_resource = panel.build()
+        self._internal.panel = panel_resource
+    
+        return self
+    
+    def library_panel(self, library_panel: cogbuilder.Builder[map_of_disjunctions.LibraryPanel]) -> typing.Self:    
+        library_panel_resource = library_panel.build()
+        self._internal.library_panel = library_panel_resource
+    
+        return self
+    

--- a/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/dashboardBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/dashboardBuilder.gen.ts
@@ -1,0 +1,30 @@
+import * as cog from '../cog';
+import * as mapOfDisjunctions from '../mapOfDisjunctions';
+
+export class DashboardBuilder implements cog.Builder<mapOfDisjunctions.Dashboard> {
+    protected readonly internal: mapOfDisjunctions.Dashboard;
+
+    constructor() {
+        this.internal = mapOfDisjunctions.defaultDashboard();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfDisjunctions.Dashboard {
+        return this.internal;
+    }
+
+    panels(panels: Record<string, cog.Builder<mapOfDisjunctions.Element>>): this {
+        const panelsResource = (function() {
+            let results1 = {};
+            for (const key1 in panels) {
+                const val1 = panels[key1];
+                results1[key1] = val1.build();
+            }
+            return results1;
+        }());
+        this.internal.panels = panelsResource;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/elementBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/elementBuilder.gen.ts
@@ -1,0 +1,29 @@
+import * as cog from '../cog';
+import * as mapOfDisjunctions from '../mapOfDisjunctions';
+
+export class ElementBuilder implements cog.Builder<mapOfDisjunctions.Element> {
+    protected readonly internal: mapOfDisjunctions.Element;
+
+    constructor() {
+        this.internal = mapOfDisjunctions.defaultElement();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfDisjunctions.Element {
+        return this.internal;
+    }
+
+    panel(panel: cog.Builder<mapOfDisjunctions.Panel>): this {
+        const panelResource = panel.build();
+        this.internal.Panel = panelResource;
+        return this;
+    }
+
+    libraryPanel(libraryPanel: cog.Builder<mapOfDisjunctions.LibraryPanel>): this {
+        const libraryPanelResource = libraryPanel.build();
+        this.internal.LibraryPanel = libraryPanelResource;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/libraryPanelBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/libraryPanelBuilder.gen.ts
@@ -1,0 +1,23 @@
+import * as cog from '../cog';
+import * as mapOfDisjunctions from '../mapOfDisjunctions';
+
+export class LibraryPanelBuilder implements cog.Builder<mapOfDisjunctions.LibraryPanel> {
+    protected readonly internal: mapOfDisjunctions.LibraryPanel;
+
+    constructor() {
+        this.internal = mapOfDisjunctions.defaultLibraryPanel();
+        this.internal.kind = "Library";
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfDisjunctions.LibraryPanel {
+        return this.internal;
+    }
+
+    text(text: string): this {
+        this.internal.text = text;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/panelBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/panelBuilder.gen.ts
@@ -1,0 +1,23 @@
+import * as cog from '../cog';
+import * as mapOfDisjunctions from '../mapOfDisjunctions';
+
+export class PanelBuilder implements cog.Builder<mapOfDisjunctions.Panel> {
+    protected readonly internal: mapOfDisjunctions.Panel;
+
+    constructor() {
+        this.internal = mapOfDisjunctions.defaultPanel();
+        this.internal.kind = "Panel";
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfDisjunctions.Panel {
+        return this.internal;
+    }
+
+    title(title: string): this {
+        this.internal.title = title;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/panelOrLibraryPanelBuilder.gen.ts
+++ b/testdata/jennies/builders/map_of_disjunctions/TypescriptBuilder/src/mapOfDisjunctions/panelOrLibraryPanelBuilder.gen.ts
@@ -1,0 +1,29 @@
+import * as cog from '../cog';
+import * as mapOfDisjunctions from '../mapOfDisjunctions';
+
+export class PanelOrLibraryPanelBuilder implements cog.Builder<mapOfDisjunctions.PanelOrLibraryPanel> {
+    protected readonly internal: mapOfDisjunctions.PanelOrLibraryPanel;
+
+    constructor() {
+        this.internal = mapOfDisjunctions.defaultPanelOrLibraryPanel();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): mapOfDisjunctions.PanelOrLibraryPanel {
+        return this.internal;
+    }
+
+    panel(panel: cog.Builder<mapOfDisjunctions.Panel>): this {
+        const panelResource = panel.build();
+        this.internal.Panel = panelResource;
+        return this;
+    }
+
+    libraryPanel(libraryPanel: cog.Builder<mapOfDisjunctions.LibraryPanel>): this {
+        const libraryPanelResource = libraryPanel.build();
+        this.internal.LibraryPanel = libraryPanelResource;
+        return this;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/builders_context.json
+++ b/testdata/jennies/builders/map_of_disjunctions/builders_context.json
@@ -1,0 +1,881 @@
+{
+  "Schemas": [
+    {
+      "Package": "map_of_disjunctions",
+      "Metadata": {},
+      "EntryPointType": {
+        "Kind": "",
+        "Nullable": false
+      },
+      "Objects": {
+        "Element": {
+          "Name": "Element",
+          "Type": {
+            "Kind": "ref",
+            "Nullable": false,
+            "Ref": {
+              "ReferredPkg": "map_of_disjunctions",
+              "ReferredType": "PanelOrLibraryPanel"
+            },
+            "PassesTrail": [
+              "DisjunctionToType[disjunction → ref]"
+            ]
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "Element"
+          }
+        },
+        "Panel": {
+          "Name": "Panel",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "kind",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string",
+                      "Value": "Panel"
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "Panel"
+          }
+        },
+        "LibraryPanel": {
+          "Name": "LibraryPanel",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "kind",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string",
+                      "Value": "Library"
+                    }
+                  },
+                  "Required": true
+                },
+                {
+                  "Name": "text",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "LibraryPanel"
+          }
+        },
+        "Dashboard": {
+          "Name": "Dashboard",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "panels",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_disjunctions",
+                          "ReferredType": "Element"
+                        }
+                      }
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "Dashboard"
+          }
+        },
+        "PanelOrLibraryPanel": {
+          "Name": "PanelOrLibraryPanel",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "Panel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  },
+                  "Required": false
+                },
+                {
+                  "Name": "LibraryPanel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  },
+                  "Required": false
+                }
+              ]
+            },
+            "Hints": {
+              "disjunction_of_refs": {
+                "Branches": [
+                  {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  },
+                  {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  }
+                ],
+                "Discriminator": "kind",
+                "DiscriminatorMapping": {
+                  "Library": "LibraryPanel",
+                  "Panel": "Panel"
+                }
+              }
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "PanelOrLibraryPanel"
+          },
+          "PassesTrail": [
+            "DisjunctionToType[created]"
+          ]
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "For": {
+        "Name": "Element",
+        "Type": {
+          "Kind": "ref",
+          "Nullable": false,
+          "Ref": {
+            "ReferredPkg": "map_of_disjunctions",
+            "ReferredType": "PanelOrLibraryPanel"
+          },
+          "PassesTrail": [
+            "DisjunctionToType[disjunction → ref]"
+          ]
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_disjunctions",
+          "ReferredType": "Element"
+        }
+      },
+      "Package": "map_of_disjunctions",
+      "Name": "Element",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "Panel",
+          "Args": [
+            {
+              "Name": "Panel",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": true,
+                "Ref": {
+                  "ReferredPkg": "map_of_disjunctions",
+                  "ReferredType": "Panel"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "Panel",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "Panel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        },
+        {
+          "Name": "LibraryPanel",
+          "Args": [
+            {
+              "Name": "LibraryPanel",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": true,
+                "Ref": {
+                  "ReferredPkg": "map_of_disjunctions",
+                  "ReferredType": "LibraryPanel"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "LibraryPanel",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "LibraryPanel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "For": {
+        "Name": "Panel",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string",
+                    "Value": "Panel"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_disjunctions",
+          "ReferredType": "Panel"
+        }
+      },
+      "Package": "map_of_disjunctions",
+      "Name": "Panel",
+      "Constructor": {
+        "Assignments": [
+          {
+            "Path": [
+              {
+                "Identifier": "kind",
+                "Index": null,
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string",
+                    "Value": "Panel"
+                  }
+                },
+                "Root": false
+              }
+            ],
+            "Value": {
+              "Constant": "Panel"
+            },
+            "Method": "direct"
+          }
+        ]
+      },
+      "Options": [
+        {
+          "Name": "title",
+          "Args": [
+            {
+              "Name": "title",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "title",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "For": {
+        "Name": "LibraryPanel",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "kind",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string",
+                    "Value": "Library"
+                  }
+                },
+                "Required": true
+              },
+              {
+                "Name": "text",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_disjunctions",
+          "ReferredType": "LibraryPanel"
+        }
+      },
+      "Package": "map_of_disjunctions",
+      "Name": "LibraryPanel",
+      "Constructor": {
+        "Assignments": [
+          {
+            "Path": [
+              {
+                "Identifier": "kind",
+                "Index": null,
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string",
+                    "Value": "Library"
+                  }
+                },
+                "Root": false
+              }
+            ],
+            "Value": {
+              "Constant": "Library"
+            },
+            "Method": "direct"
+          }
+        ]
+      },
+      "Options": [
+        {
+          "Name": "text",
+          "Args": [
+            {
+              "Name": "text",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "text",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "text",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "For": {
+        "Name": "Dashboard",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "panels",
+                "Type": {
+                  "Kind": "map",
+                  "Nullable": false,
+                  "Map": {
+                    "IndexType": {
+                      "Kind": "scalar",
+                      "Nullable": false,
+                      "Scalar": {
+                        "ScalarKind": "string"
+                      }
+                    },
+                    "ValueType": {
+                      "Kind": "ref",
+                      "Nullable": false,
+                      "Ref": {
+                        "ReferredPkg": "map_of_disjunctions",
+                        "ReferredType": "Element"
+                      }
+                    }
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_disjunctions",
+          "ReferredType": "Dashboard"
+        }
+      },
+      "Package": "map_of_disjunctions",
+      "Name": "Dashboard",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "panels",
+          "Args": [
+            {
+              "Name": "panels",
+              "Type": {
+                "Kind": "map",
+                "Nullable": false,
+                "Map": {
+                  "IndexType": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "ValueType": {
+                    "Kind": "ref",
+                    "Nullable": false,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Element"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "panels",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_disjunctions",
+                          "ReferredType": "Element"
+                        }
+                      }
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "panels",
+                  "Type": {
+                    "Kind": "map",
+                    "Nullable": false,
+                    "Map": {
+                      "IndexType": {
+                        "Kind": "scalar",
+                        "Nullable": false,
+                        "Scalar": {
+                          "ScalarKind": "string"
+                        }
+                      },
+                      "ValueType": {
+                        "Kind": "ref",
+                        "Nullable": false,
+                        "Ref": {
+                          "ReferredPkg": "map_of_disjunctions",
+                          "ReferredType": "Element"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "For": {
+        "Name": "PanelOrLibraryPanel",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "Panel",
+                "Type": {
+                  "Kind": "ref",
+                  "Nullable": true,
+                  "Ref": {
+                    "ReferredPkg": "map_of_disjunctions",
+                    "ReferredType": "Panel"
+                  }
+                },
+                "Required": false
+              },
+              {
+                "Name": "LibraryPanel",
+                "Type": {
+                  "Kind": "ref",
+                  "Nullable": true,
+                  "Ref": {
+                    "ReferredPkg": "map_of_disjunctions",
+                    "ReferredType": "LibraryPanel"
+                  }
+                },
+                "Required": false
+              }
+            ]
+          },
+          "Hints": {
+            "disjunction_of_refs": {
+              "Branches": [
+                {
+                  "Kind": "ref",
+                  "Nullable": false,
+                  "Ref": {
+                    "ReferredPkg": "map_of_disjunctions",
+                    "ReferredType": "Panel"
+                  }
+                },
+                {
+                  "Kind": "ref",
+                  "Nullable": false,
+                  "Ref": {
+                    "ReferredPkg": "map_of_disjunctions",
+                    "ReferredType": "LibraryPanel"
+                  }
+                }
+              ],
+              "Discriminator": "kind",
+              "DiscriminatorMapping": {
+                "Library": "LibraryPanel",
+                "Panel": "Panel"
+              }
+            }
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "map_of_disjunctions",
+          "ReferredType": "PanelOrLibraryPanel"
+        },
+        "PassesTrail": [
+          "DisjunctionToType[created]"
+        ]
+      },
+      "Package": "map_of_disjunctions",
+      "Name": "PanelOrLibraryPanel",
+      "Constructor": {},
+      "Options": [
+        {
+          "Name": "Panel",
+          "Args": [
+            {
+              "Name": "Panel",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": true,
+                "Ref": {
+                  "ReferredPkg": "map_of_disjunctions",
+                  "ReferredType": "Panel"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "Panel",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "Panel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "Panel"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        },
+        {
+          "Name": "LibraryPanel",
+          "Args": [
+            {
+              "Name": "LibraryPanel",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": true,
+                "Ref": {
+                  "ReferredPkg": "map_of_disjunctions",
+                  "ReferredType": "LibraryPanel"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "LibraryPanel",
+                  "Index": null,
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  },
+                  "Root": false
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "LibraryPanel",
+                  "Type": {
+                    "Kind": "ref",
+                    "Nullable": true,
+                    "Ref": {
+                      "ReferredPkg": "map_of_disjunctions",
+                      "ReferredType": "LibraryPanel"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/builders/map_of_disjunctions/schema.cue
+++ b/testdata/jennies/builders/map_of_disjunctions/schema.cue
@@ -1,0 +1,19 @@
+package map_of_disjunctions
+
+Element: Panel | LibraryPanel
+
+Panel: {
+	kind: "Panel"
+	title: string
+}
+
+LibraryPanel: {
+	kind: "Library"
+	text: string
+}
+
+Dashboard: {
+	panels: {
+		[string]: Element
+	}
+}


### PR DESCRIPTION
This PR solves two issues of how to manage the disjunctions in the converters.
* We hadn't implemented the way of how to iterate maps of disjunctions.
* We didn't handle the case when we find a reference that it could be a disjunction.

The example could be [elements: [ElementReference.name]: Element | *{}](https://github.com/grafana/grafana/blob/main/apps/dashboard/kinds/v2beta1/dashboard_spec.cue#L18), from the v2 schema. `Element` is a disjunction and it was detected as reference.

To try to give you a bit of context, the converter uses each builder, to get each existing option (included the ones defined by configuration) to setup the proper value, builder, etc into it. 

When we have an array or a map of disjunctions, the result should be similar to [this](https://github.com/grafana/grafana-foundation-sdk/blob/v11.6.x%2Bcog-v0.0.x/go/dashboard/dashboard_converter_gen.go#L340-L363). We iterate the values and check which is the value and set it. 

<details>
<summary> Example map output </summary>

```go
if input.Elements != nil {
    for _, item := range input.Elements {
        if item.PanelKind != nil {
            buffer.WriteString(`Panel(`)
            arg0 := fmt.Sprintf("%#v", key)
            buffer.WriteString(arg0)
            buffer.WriteString(", ")
            arg1 := PanelConverter(*item.PanelKind)
            buffer.WriteString(arg1)

            buffer.WriteString(")")

            calls = append(calls, buffer.String())
            buffer.Reset()
	}
        if item.LibraryPanelKind != nil {
            buffer.WriteString(`LibraryPanel(`)
            arg0 := fmt.Sprintf("%#v", key)
            buffer.WriteString(arg0)
            buffer.WriteString(", ")
            arg1 := LibraryPanelKindConverter(*item.LibraryPanelKind)
            buffer.WriteString(arg1)

            buffer.WriteString(")")

            calls = append(calls, buffer.String())
            buffer.Reset()
        }
    }
}
```
</details>

<details>
<summary> Example array output</summary>

```go
if input.Variables != nil && len(input.Variables) >= 1 {
    for _, item := range input.Variables {
        if item.QueryVariableKind != nil {
            buffer.WriteString(`QueryVariable(`)
            arg0 := QueryVariableConverter(*item.QueryVariableKind)
            buffer.WriteString(arg0)

            buffer.WriteString(")")

            calls = append(calls, buffer.String())
            buffer.Reset()
        }
        if item.TextVariableKind != nil {
            buffer.WriteString(`TextVariable(`)
            arg0 := TextVariableConverter(*item.TextVariableKind)
            buffer.WriteString(arg0)

            buffer.WriteString(")")

            calls = append(calls, buffer.String())
            buffer.Reset()
        }
       // Rest of checks
    }
}
```
</details>
