### PR TITLE
Add yaml tags to set proper names in the configuration

### DIFF
--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -142,8 +142,8 @@ type ConverterConfig struct {
 type RuntimeConfig struct {
 	Package            string
 	Name               string
-	NameFunc           string
-	DiscriminatorField string
+	NameFunc           string `yaml:"name_func"`
+	DiscriminatorField string `yaml:"discriminator_field"`
 }
 
 type ConverterGenerator struct {


### PR DESCRIPTION
To avoid problems with `UpperCamelCase` values, we have to add the yaml tag.