### PR TITLE
Disjunctions for specs should be oneOf

### DIFF
--- a/internal/jennies/jsonschema/schema.go
+++ b/internal/jennies/jsonschema/schema.go
@@ -348,7 +348,7 @@ func (jenny Schema) formatDisjunction(typeDef ast.Type) Definition {
 	definition := orderedmap.New[string, any]()
 	branches := tools.Map(typeDef.AsDisjunction().Branches, jenny.formatType)
 
-	definition.Set("anyOf", branches)
+	definition.Set("oneOf", branches)
 
 	return definition
 }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/JSONSchema/constant_reference_discriminator.jsonschema.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/JSONSchema/constant_reference_discriminator.jsonschema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "LayoutWithValue": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/GridLayoutUsingValue"
         },
@@ -44,7 +44,7 @@
       }
     },
     "LayoutWithoutValue": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/GridLayoutWithoutValue"
         },

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/OpenAPI/constant_reference_discriminator.openapi.json
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/OpenAPI/constant_reference_discriminator.openapi.json
@@ -10,7 +10,7 @@
   "components": {
     "schemas": {
       "LayoutWithValue": {
-        "anyOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/GridLayoutUsingValue"
           },
@@ -52,7 +52,7 @@
         }
       },
       "LayoutWithoutValue": {
-        "anyOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/GridLayoutWithoutValue"
           },

--- a/testdata/jennies/rawtypes/disjunctions/JSONSchema/disjunctions.jsonschema.json
+++ b/testdata/jennies/rawtypes/disjunctions/JSONSchema/disjunctions.jsonschema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "RefreshRate": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "string"
         },
@@ -34,7 +34,7 @@
       }
     },
     "BoolOrRef": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "boolean"
         },
@@ -78,7 +78,7 @@
       }
     },
     "SeveralRefs": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/SomeStruct"
         },

--- a/testdata/jennies/rawtypes/disjunctions/OpenAPI/disjunctions.openapi.json
+++ b/testdata/jennies/rawtypes/disjunctions/OpenAPI/disjunctions.openapi.json
@@ -10,7 +10,7 @@
   "components": {
     "schemas": {
       "RefreshRate": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "string"
           },
@@ -42,7 +42,7 @@
         }
       },
       "BoolOrRef": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "boolean"
           },
@@ -86,7 +86,7 @@
         }
       },
       "SeveralRefs": {
-        "anyOf": [
+        "oneOf": [
           {
             "$ref": "#/components/schemas/SomeStruct"
           },

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/JSONSchema/disjunctions_of_scalars_and_refs.jsonschema.json
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/JSONSchema/disjunctions_of_scalars_and_refs.jsonschema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "DisjunctionOfScalarsAndRefs": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "string",
           "const": "a"

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/OpenAPI/disjunctions_of_scalars_and_refs.openapi.json
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/OpenAPI/disjunctions_of_scalars_and_refs.openapi.json
@@ -10,7 +10,7 @@
   "components": {
     "schemas": {
       "DisjunctionOfScalarsAndRefs": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "string",
             "const": "a"

--- a/testdata/jennies/rawtypes/package-with-dashes/JSONSchema/with-dashes.jsonschema.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/JSONSchema/with-dashes.jsonschema.json
@@ -15,7 +15,7 @@
       }
     },
     "RefreshRate": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "string"
         },

--- a/testdata/jennies/rawtypes/package-with-dashes/OpenAPI/with-dashes.openapi.json
+++ b/testdata/jennies/rawtypes/package-with-dashes/OpenAPI/with-dashes.openapi.json
@@ -23,7 +23,7 @@
         }
       },
       "RefreshRate": {
-        "anyOf": [
+        "oneOf": [
           {
             "type": "string"
           },

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/JSONSchema/struct_complex_fields.jsonschema.json
@@ -20,7 +20,7 @@
           "$ref": "#/definitions/SomeOtherStruct"
         },
         "FieldDisjunctionOfScalars": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "string"
             },
@@ -30,7 +30,7 @@
           ]
         },
         "FieldMixedDisjunction": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "string"
             },

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/OpenAPI/struct_complex_fields.openapi.json
@@ -28,7 +28,7 @@
             "$ref": "#/components/schemas/SomeOtherStruct"
           },
           "FieldDisjunctionOfScalars": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "string"
               },
@@ -38,7 +38,7 @@
             ]
           },
           "FieldMixedDisjunction": {
-            "anyOf": [
+            "oneOf": [
               {
                 "type": "string"
               },


### PR DESCRIPTION
Disjunctions should be always `oneOf` since we don't have with any special annotation of extra information to identify a disjunction as `anyOf`. If we need it in the future we have to implement that.