### PR TITLE
Cue: Add missing URL interpolator

### DIFF
--- a/internal/codegen/cue.go
+++ b/internal/codegen/cue.go
@@ -110,6 +110,7 @@ func (input *CueInput) interpolateParameters(interpolator ParametersInterpolator
 	input.InputBase.interpolateParameters(interpolator)
 
 	input.Entrypoint = interpolator(input.Entrypoint)
+	input.URL = interpolator(input.URL)
 	input.CueImports = tools.Map(input.CueImports, interpolator)
 }
 


### PR DESCRIPTION
It allows us to pass the release version to the url to change it by configuration.