### PR TITLE
JSON Schema: Support relative $ref paths

### DIFF
--- a/internal/codegen/jsonschema.go
+++ b/internal/codegen/jsonschema.go
@@ -57,6 +57,7 @@ func (input *JSONSchemaInput) LoadSchemas(ctx context.Context) (ast.Schemas, err
 	schema, err := jsonschema.GenerateAST(schemaReader, jsonschema.Config{
 		Package:        input.packageName(),
 		SchemaMetadata: input.schemaMetadata(),
+		SchemaPath:     input.Path,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/jsonschema/generator_test.go
+++ b/internal/jsonschema/generator_test.go
@@ -1,6 +1,7 @@
 package jsonschema
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,7 +19,11 @@ func TestGenerateAST(t *testing.T) {
 	test.Run(t, func(tc *testutils.Test[string]) {
 		req := require.New(tc)
 
-		schemaAst, err := GenerateAST(tc.OpenInput("schema.json"), Config{Package: "grafanatest"})
+		const schemaFile = "schema.json"
+		schemaAst, err := GenerateAST(tc.OpenInput(schemaFile), Config{
+			Package:    "grafanatest",
+			SchemaPath: filepath.Join(tc.RootDir, schemaFile),
+		})
 		req.NoError(err)
 		req.NotNil(schemaAst)
 

--- a/testdata/jsonschema/relative_refs/GenerateAST/ir.json
+++ b/testdata/jsonschema/relative_refs/GenerateAST/ir.json
@@ -1,0 +1,82 @@
+{
+  "Package": "grafanatest",
+  "Metadata": {},
+  "EntryPoint": "MainType",
+  "EntryPointType": {
+    "Kind": "ref",
+    "Nullable": false,
+    "Ref": {
+      "ReferredPkg": "grafanatest",
+      "ReferredType": "MainType"
+    }
+  },
+  "Objects": {
+    "CommonType": {
+      "Name": "CommonType",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "id",
+              "Comments": [
+                "The identifier"
+              ],
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "CommonType"
+      }
+    },
+    "MainType": {
+      "Name": "MainType",
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "common",
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "grafanatest",
+                  "ReferredType": "CommonType"
+                }
+              },
+              "Required": true
+            },
+            {
+              "Name": "name",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              },
+              "Required": true
+            }
+          ]
+        }
+      },
+      "SelfRef": {
+        "ReferredPkg": "grafanatest",
+        "ReferredType": "MainType"
+      }
+    }
+  }
+}

--- a/testdata/jsonschema/relative_refs/refs/common/schema.json
+++ b/testdata/jsonschema/relative_refs/refs/common/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "CommonType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier"
+        }
+      },
+      "required": ["id"]
+    }
+  }
+}

--- a/testdata/jsonschema/relative_refs/schema.json
+++ b/testdata/jsonschema/relative_refs/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/MainType",
+  "definitions": {
+    "MainType": {
+      "type": "object",
+      "properties": {
+        "common": {
+          "$ref": "./refs/common/schema.json#/definitions/CommonType"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["common", "name"]
+    }
+  }
+}


### PR DESCRIPTION
Currently, if you have a JSON Schema that contains a `$ref` attribute pointing to a relative file path, `cog` fails because it resolves the path relative to the current working directory. As far as I know, JSON Schema tools typically resolve such paths relative to the schema file itself — which, in my opinion, makes more sense. Otherwise, you’d need to adjust schema references depending on the working directory, which would be almost unusable.

After some research, I realized that, when adding the schema resource [here](https://github.com/grafana/cog/blob/main/internal/jsonschema/generator.go#L51), to the `Compiler` we use from github.com/santhosh-tekuri/jsonschema, then it automatically resolves the relative path, as the schema preserves the original URI (the file path), instead of the generalist `"schema"` we used to define, that made no possible to resolve relative paths.

I have added a test (see `testdata/jsonschema/relative_refs`), and tested it manually with https://github.com/grafana/k6-summary/blob/check-jsonschema/schemas/summary/1.0.0/schema.json, which is the schema I was using when I detected this issue.

~**Note:** What I'm not 100% sure is whether there might be any security implications by keeping the schema URI as the original schema file path.~ Discussed in https://github.com/grafana/cog/pull/872#discussion_r2449104379.