### PR TITLE
Custom templates: Add template helpers

### DIFF
--- a/internal/jennies/common/customtemplate.go
+++ b/internal/jennies/common/customtemplate.go
@@ -68,6 +68,7 @@ func (jenny CustomTemplates) generateForTemplatesDirectory(context languages.Con
 				"registryToSemver": jenny.registryToSemver,
 			}),
 			template.Funcs(jenny.TmplFuncs),
+			template.Funcs(TypesTemplateHelpers(context)),
 			template.Parse(string(templateContent)),
 		)
 		if err != nil {


### PR DESCRIPTION
Template helpers miss template helpers functions.

This custom template code is used in PHP and it needs that to use `objectExists` function in custom templates.