### PR TITLE
Terraform: Attributes with references

### DIFF
--- a/internal/jennies/terraform/attributes.go
+++ b/internal/jennies/terraform/attributes.go
@@ -22,6 +22,33 @@ func newAttributesGenerator(cfg Config, typeFormatter *typeFormatter, packageMap
 	}
 }
 
+func attributesVarName(name string) string {
+	return tools.UpperCamelCase(name) + "Attributes"
+}
+
+// generateForAllObjects generates a named `var XxxAttributes` for each struct object in the schema,
+// skipping the object named skipObjectName (used to avoid duplicating the entry point).
+func (a *attributes) generateForAllObjects(schema *ast.Schema, skipObjectName string) (string, error) {
+	var buffer strings.Builder
+
+	a.packageMapper("github.com/hashicorp/terraform-plugin-framework/resource/schema")
+
+	schema.Objects.Iterate(func(_ string, obj ast.Object) {
+		if obj.Name == skipObjectName {
+			return
+		}
+		if !obj.Type.IsStruct() {
+			return
+		}
+
+		buffer.WriteString(fmt.Sprintf("var %s = map[string]schema.Attribute{\n", attributesVarName(obj.Name)))
+		buffer.WriteString(a.typeFormatter.formatFieldAttributes(obj.Type.AsStruct().Fields))
+		buffer.WriteString("}\n\n")
+	})
+
+	return buffer.String(), nil
+}
+
 func (a *attributes) generateForSchema(schema *ast.Schema) (string, error) {
 	var buffer strings.Builder
 
@@ -29,7 +56,21 @@ func (a *attributes) generateForSchema(schema *ast.Schema) (string, error) {
 	buffer.WriteString("var SpecAttributes = map[string]schema.Attribute{\n")
 
 	schema.Objects.Iterate(func(_ string, obj ast.Object) {
-		if !obj.Type.IsAnyOf(ast.KindDisjunction, ast.KindRef, ast.KindConstantRef, ast.KindEnum, ast.KindIntersection) && !obj.Type.IsDisjunctionOfAnyKind() {
+		if obj.Type.IsAnyOf(ast.KindDisjunction, ast.KindRef, ast.KindConstantRef, ast.KindEnum, ast.KindIntersection) || obj.Type.IsDisjunctionOfAnyKind() {
+			return
+		}
+		if obj.Type.IsStruct() {
+			required := "Required: true,"
+			if obj.Type.Nullable {
+				required = "Optional: true,"
+			}
+			comments := ""
+			if c := formatComments(obj.Comments); c != "" {
+				comments = fmt.Sprintf("Description: %s,\n", c)
+			}
+			buffer.WriteString(fmt.Sprintf("\"%s\": schema.SingleNestedAttribute{\n%s\n%sAttributes: %s,\n},\n",
+				tools.SnakeCase(obj.Name), required, comments, attributesVarName(obj.Name)))
+		} else {
 			buffer.WriteString(a.typeFormatter.formatTypeAttributeForObject(obj, formatComments(obj.Comments)))
 		}
 	})

--- a/internal/jennies/terraform/attributes.go
+++ b/internal/jennies/terraform/attributes.go
@@ -42,7 +42,9 @@ func (a *attributes) generateForAllObjects(schema *ast.Schema, skipObjectName st
 		}
 
 		buffer.WriteString(fmt.Sprintf("var %s = map[string]schema.Attribute{\n", attributesVarName(obj.Name)))
+		a.typeFormatter.structDepth[obj.Name]++
 		buffer.WriteString(a.typeFormatter.formatFieldAttributes(obj.Type.AsStruct().Fields))
+		a.typeFormatter.structDepth[obj.Name]--
 		buffer.WriteString("}\n\n")
 	})
 

--- a/internal/jennies/terraform/rawtypes.go
+++ b/internal/jennies/terraform/rawtypes.go
@@ -111,8 +111,19 @@ func (jenny RawTypes) generateSchema(context languages.Context, schema *ast.Sche
 		return nil, err
 	}
 
-	var attrs string
 	entryPointRef := schema.EntryPointType.Ref
+	skipObjectName := ""
+	if entryPointRef != nil {
+		skipObjectName = entryPointRef.ReferredType
+	}
+
+	allObjVars, err := attributesGenerator.generateForAllObjects(schema, skipObjectName)
+	if err != nil {
+		return nil, err
+	}
+	buffer.WriteString(allObjVars)
+
+	var attrs string
 	if entryPointRef != nil {
 		obj, ok := context.LocateObject(entryPointRef.ReferredPkg, entryPointRef.ReferredType)
 		if !ok {

--- a/internal/jennies/terraform/types.go
+++ b/internal/jennies/terraform/types.go
@@ -16,6 +16,7 @@ type typeFormatter struct {
 	imports       *common.DirectImportMap
 	packageMapper func(pkg string) string
 	validators    *validators
+	structDepth   map[string]int
 }
 
 func defaultTypeFormatter(config Config, context languages.Context, imports *common.DirectImportMap, packageMapper func(pkg string) string) *typeFormatter {
@@ -24,6 +25,7 @@ func defaultTypeFormatter(config Config, context languages.Context, imports *com
 		context:       context,
 		imports:       imports,
 		packageMapper: packageMapper,
+		structDepth:   make(map[string]int),
 	}
 
 	tf.validators = newValidators(tf)
@@ -215,7 +217,11 @@ func (formatter *typeFormatter) formatFieldAttributes(fields []ast.StructField) 
 		if field.Type.IsIntersection() {
 			continue
 		}
-		buffer.WriteString(fmt.Sprintf("\"%s\": %s\n", tools.SnakeCase(field.Name), formatter.formatTypeAttribute(field.Type, "")))
+		attr := formatter.formatTypeAttribute(field.Type, "")
+		if attr == "" {
+			continue
+		}
+		buffer.WriteString(fmt.Sprintf("\"%s\": %s\n", tools.SnakeCase(field.Name), attr))
 	}
 
 	return buffer.String()
@@ -431,6 +437,22 @@ func (formatter *typeFormatter) formatReferenceAttribute(def ast.Type) string {
 		if def.Nullable {
 			required = "Optional: true,"
 		}
+
+		if formatter.structDepth[obj.Name] >= 2 {
+			// Already inlining this struct: break the cycle by returning empty.
+			return ""
+		}
+
+		if formatter.structDepth[obj.Name] == 1 {
+			// Self-referential: inline attributes instead of referencing the var
+			// to avoid a Go initialization cycle.
+			formatter.structDepth[obj.Name]++
+			attrs := formatter.formatFieldAttributes(obj.Type.AsStruct().Fields)
+			formatter.structDepth[obj.Name]--
+			return fmt.Sprintf("schema.SingleNestedAttribute{\n%s\nAttributes: map[string]schema.Attribute{\n%s},\n},\n",
+				required, attrs)
+		}
+
 		return fmt.Sprintf("schema.SingleNestedAttribute{\n%s\nAttributes: %s,\n},\n",
 			required, attributesVarName(obj.Name))
 	}

--- a/internal/jennies/terraform/types.go
+++ b/internal/jennies/terraform/types.go
@@ -241,12 +241,6 @@ func (formatter *typeFormatter) formatArrayAttributes(def ast.Type) string {
 			return "unknown"
 		}
 
-		if !obj.Type.IsEnum() {
-			buffer.WriteString("schema.ListNestedAttribute{\n")
-			buffer.WriteString(fmt.Sprintf("NestedObject: schema.NestedAttributeObject {\n"))
-			buffer.WriteString("Attributes: map[string]schema.Attribute {\n")
-		}
-
 		switch obj.Type.Kind {
 		case ast.KindEnum:
 			buffer.WriteString("schema.ListAttribute{\n")
@@ -255,24 +249,41 @@ func (formatter *typeFormatter) formatArrayAttributes(def ast.Type) string {
 				enumType = "types.Int64Type"
 			}
 			buffer.WriteString(fmt.Sprintf("ElementType: %s,\n", enumType))
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
+			if arrayValidator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", arrayValidator))
+			} else if validator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", validator))
+			}
 		case ast.KindStruct:
-			buffer.WriteString(formatter.formatFieldAttributes(obj.Type.AsStruct().Fields))
+			buffer.WriteString("schema.ListNestedAttribute{\n")
+			buffer.WriteString("NestedObject: schema.NestedAttributeObject{\n")
+			buffer.WriteString(fmt.Sprintf("Attributes: %s,\n", attributesVarName(obj.Name)))
+			buffer.WriteString("},\n")
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
+			if arrayValidator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", arrayValidator))
+			} else if validator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", validator))
+			}
 		default:
+			buffer.WriteString("schema.ListNestedAttribute{\n")
+			buffer.WriteString("NestedObject: schema.NestedAttributeObject{\n")
+			buffer.WriteString("Attributes: map[string]schema.Attribute{\n")
 			buffer.WriteString(formatter.formatTypeAttributeForObject(obj, formatComments(obj.Comments)))
-		}
-
-		if defVal != "" {
-			buffer.WriteString(defVal)
-		}
-
-		if arrayValidator != "" {
-			buffer.WriteString(fmt.Sprintf("Validators: %s", arrayValidator))
-		} else if validator != "" {
-			buffer.WriteString(fmt.Sprintf("Validators: %s", validator))
-		}
-
-		if !obj.Type.IsEnum() {
 			buffer.WriteString("},\n},\n")
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
+			if arrayValidator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", arrayValidator))
+			} else if validator != "" {
+				buffer.WriteString(fmt.Sprintf("Validators: %s", validator))
+			}
 		}
 
 	default:
@@ -309,12 +320,6 @@ func (formatter *typeFormatter) formatMapAttributes(def ast.Type) string {
 			return "unknown"
 		}
 
-		if !obj.Type.IsEnum() {
-			buffer.WriteString("schema.MapNestedAttribute{\n")
-			buffer.WriteString(fmt.Sprintf("NestedObject: schema.NestedAttributeObject {\n"))
-			buffer.WriteString("Attributes: map[string]schema.Attribute {\n")
-		}
-
 		switch obj.Type.Kind {
 		case ast.KindEnum:
 			buffer.WriteString("schema.MapAttribute{\n")
@@ -323,18 +328,26 @@ func (formatter *typeFormatter) formatMapAttributes(def ast.Type) string {
 				enumType = "types.Int64Type"
 			}
 			buffer.WriteString(fmt.Sprintf("ElementType: %s,\n", enumType))
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
 		case ast.KindStruct:
-			buffer.WriteString(formatter.formatFieldAttributes(obj.Type.AsStruct().Fields))
+			buffer.WriteString("schema.MapNestedAttribute{\n")
+			buffer.WriteString("NestedObject: schema.NestedAttributeObject{\n")
+			buffer.WriteString(fmt.Sprintf("Attributes: %s,\n", attributesVarName(obj.Name)))
+			buffer.WriteString("},\n")
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
 		default:
+			buffer.WriteString("schema.MapNestedAttribute{\n")
+			buffer.WriteString("NestedObject: schema.NestedAttributeObject{\n")
+			buffer.WriteString("Attributes: map[string]schema.Attribute{\n")
 			buffer.WriteString(formatter.formatTypeAttributeForObject(obj, formatComments(obj.Comments)))
-		}
-
-		if defVal != "" {
-			buffer.WriteString(defVal)
-		}
-
-		if !obj.Type.IsEnum() {
 			buffer.WriteString("},\n},\n")
+			if defVal != "" {
+				buffer.WriteString(defVal)
+			}
 		}
 	default:
 		buffer.WriteString("schema.MapAttribute{\n ")
@@ -411,6 +424,15 @@ func (formatter *typeFormatter) formatReferenceAttribute(def ast.Type) string {
 	obj, ok := formatter.context.LocateObject(def.AsRef().ReferredPkg, def.AsRef().ReferredType)
 	if !ok {
 		return "unknown"
+	}
+
+	if obj.Type.IsStruct() {
+		required := "Required: true,"
+		if def.Nullable {
+			required = "Optional: true,"
+		}
+		return fmt.Sprintf("schema.SingleNestedAttribute{\n%s\nAttributes: %s,\n},\n",
+			required, attributesVarName(obj.Name))
 	}
 
 	obj.Type.Default = def.Default

--- a/testdata/jennies/rawtypes/arrays/TerraformRawTypes/arrays/types_gen.go
+++ b/testdata/jennies/rawtypes/arrays/TerraformRawTypes/arrays/types_gen.go
@@ -16,27 +16,24 @@ type ArrayOfRefs []SomeStruct
 
 type ArrayOfArrayOfNumbers types.List
 
+var SomeStructAttributes = map[string]schema.Attribute{
+"field_any": schema.ObjectAttribute{
+ Required: true,
+},
+
+}
+
 var SpecAttributes = map[string]schema.Attribute{
 "array_of_strings": schema.ListAttribute{
  ElementType: types.StringType,
 },
 "some_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: SomeStructAttributes,
 },
 "array_of_refs": schema.ListNestedAttribute{
-NestedObject: schema.NestedAttributeObject {
-Attributes: map[string]schema.Attribute {
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+NestedObject: schema.NestedAttributeObject{
+Attributes: SomeStructAttributes,
 },
 },
 "array_of_array_of_numbers": schema.ListAttribute{

--- a/testdata/jennies/rawtypes/constant_reference_as_default/TerraformRawTypes/constant_reference_as_default/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/TerraformRawTypes/constant_reference_as_default/types_gen.go
@@ -13,14 +13,7 @@ type MyStruct struct {
 OptString types.String `tfsdk:"optString"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"constant_ref_string": schema.StringAttribute{
- Required: true,
-Default: stringdefault.StaticString("AString"),
-},
-"my_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var MyStructAttributes = map[string]schema.Attribute{
 "a_string": schema.StringAttribute{
  Required: true,
 Default: stringdefault.StaticString("AString"),
@@ -31,6 +24,15 @@ Default: stringdefault.StaticString("AString"),
 Default: stringdefault.StaticString("AString"),
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"constant_ref_string": schema.StringAttribute{
+ Required: true,
+Default: stringdefault.StaticString("AString"),
 },
+"my_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: MyStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/TerraformRawTypes/constant_reference_discriminator/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/TerraformRawTypes/constant_reference_discriminator/types_gen.go
@@ -44,62 +44,96 @@ type GridLayoutWithoutValueOrRowsLayoutWithoutValue struct {
 RowsLayoutWithoutValue RowsLayoutWithoutValue `tfsdk:"RowsLayoutWithoutValue"`
  }
 
+var GridLayoutUsingValueAttributes = map[string]schema.Attribute{
+"kind": schema.StringAttribute{
+ Required: true,
+Default: stringdefault.StaticString("GridLayout"),
+},
+
+"grid_layout_property": schema.StringAttribute{
+ Required: true,
+},
+
+}
+
+var RowsLayoutUsingValueAttributes = map[string]schema.Attribute{
+"kind": schema.StringAttribute{
+ Required: true,
+Default: stringdefault.StaticString("RowsLayout"),
+},
+
+"rows_layout_property": schema.StringAttribute{
+ Required: true,
+},
+
+}
+
+var GridLayoutWithoutValueAttributes = map[string]schema.Attribute{
+"kind": schema.StringAttribute{
+ Required: true,
+Default: stringdefault.StaticString("GridLayout"),
+},
+
+"grid_layout_property": schema.StringAttribute{
+ Required: true,
+},
+
+}
+
+var RowsLayoutWithoutValueAttributes = map[string]schema.Attribute{
+"kind": schema.StringAttribute{
+ Required: true,
+Default: stringdefault.StaticString("RowsLayout"),
+},
+
+"rows_layout_property": schema.StringAttribute{
+ Required: true,
+},
+
+}
+
+var GridLayoutUsingValueOrRowsLayoutUsingValueAttributes = map[string]schema.Attribute{
+"grid_layout_using_value": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: GridLayoutUsingValueAttributes,
+},
+
+"rows_layout_using_value": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: RowsLayoutUsingValueAttributes,
+},
+
+}
+
+var GridLayoutWithoutValueOrRowsLayoutWithoutValueAttributes = map[string]schema.Attribute{
+"grid_layout_without_value": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: GridLayoutWithoutValueAttributes,
+},
+
+"rows_layout_without_value": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: RowsLayoutWithoutValueAttributes,
+},
+
+}
+
 var SpecAttributes = map[string]schema.Attribute{
 "grid_layout_using_value": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"kind": schema.StringAttribute{
- Required: true,
-Default: stringdefault.StaticString("GridLayout"),
-},
-
-"grid_layout_property": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: GridLayoutUsingValueAttributes,
 },
 "rows_layout_using_value": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"kind": schema.StringAttribute{
- Required: true,
-Default: stringdefault.StaticString("RowsLayout"),
-},
-
-"rows_layout_property": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: RowsLayoutUsingValueAttributes,
 },
 "grid_layout_without_value": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"kind": schema.StringAttribute{
- Required: true,
-Default: stringdefault.StaticString("GridLayout"),
-},
-
-"grid_layout_property": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: GridLayoutWithoutValueAttributes,
 },
 "rows_layout_without_value": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"kind": schema.StringAttribute{
- Required: true,
-Default: stringdefault.StaticString("RowsLayout"),
-},
-
-"rows_layout_property": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: RowsLayoutWithoutValueAttributes,
 },
 "grid_layout_kind_type": schema.StringAttribute{
  Required: true,

--- a/testdata/jennies/rawtypes/constant_references/TerraformRawTypes/constant_references/types_gen.go
+++ b/testdata/jennies/rawtypes/constant_references/TerraformRawTypes/constant_references/types_gen.go
@@ -28,10 +28,7 @@ type StructB struct {
 MyValue types.String `tfsdk:"myValue"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"parent_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var ParentStructAttributes = map[string]schema.Attribute{
 "my_enum": schema.StringAttribute{
  Required: true,
 Validators: []validator.String{
@@ -40,11 +37,9 @@ stringvalidator.OneOf("ValueA", "ValueB", "ValueC"),
 
 },
 
-},
-},
-"struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var StructAttributes = map[string]schema.Attribute{
 "my_value": schema.StringAttribute{
  Required: true,
 },
@@ -57,11 +52,9 @@ stringvalidator.OneOf("ValueA", "ValueB", "ValueC"),
 
 },
 
-},
-},
-"struct_a": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var StructAAttributes = map[string]schema.Attribute{
 "my_enum": schema.StringAttribute{
  Required: true,
 Validators: []validator.String{
@@ -78,11 +71,9 @@ stringvalidator.OneOf("ValueA", "ValueB", "ValueC"),
 
 },
 
-},
-},
-"struct_b": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var StructBAttributes = map[string]schema.Attribute{
 "my_enum": schema.StringAttribute{
  Required: true,
 Validators: []validator.String{
@@ -95,6 +86,23 @@ stringvalidator.OneOf("ValueA", "ValueB", "ValueC"),
  Required: true,
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"parent_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: ParentStructAttributes,
 },
+"struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: StructAttributes,
+},
+"struct_a": schema.SingleNestedAttribute{
+Required: true,
+Attributes: StructAAttributes,
+},
+"struct_b": schema.SingleNestedAttribute{
+Required: true,
+Attributes: StructBAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/constraints/TerraformRawTypes/constraints/types_gen.go
+++ b/testdata/jennies/rawtypes/constraints/TerraformRawTypes/constraints/types_gen.go
@@ -25,10 +25,7 @@ UniqueList types.List `tfsdk:"uniqueList"`
 FullConstraintList types.List `tfsdk:"fullConstraintList"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "id": schema.Int64Attribute{
  Required: true,
 Validators: []validator.Int64{
@@ -116,6 +113,11 @@ listvalidator.UniqueValues(),
 },
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/dashboard/TerraformRawTypes/dashboard/types_gen.go
+++ b/testdata/jennies/rawtypes/dashboard/TerraformRawTypes/dashboard/types_gen.go
@@ -33,17 +33,50 @@ Targets types.List `tfsdk:"targets"`
 FieldConfig FieldConfigSource `tfsdk:"fieldConfig"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"dashboard": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var DashboardAttributes = map[string]schema.Attribute{
 "title": schema.StringAttribute{
  Required: true,
 },
 
 "panels": schema.ListNestedAttribute{
-NestedObject: schema.NestedAttributeObject {
-Attributes: map[string]schema.Attribute {
+NestedObject: schema.NestedAttributeObject{
+Attributes: PanelAttributes,
+},
+},
+
+}
+
+var DataSourceRefAttributes = map[string]schema.Attribute{
+"type": schema.StringAttribute{
+ Optional: true,
+},
+
+"uid": schema.StringAttribute{
+ Optional: true,
+},
+
+}
+
+var FieldConfigSourceAttributes = map[string]schema.Attribute{
+"defaults": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: FieldConfigAttributes,
+},
+
+}
+
+var FieldConfigAttributes = map[string]schema.Attribute{
+"unit": schema.StringAttribute{
+ Optional: true,
+},
+
+"custom": schema.ObjectAttribute{
+ Optional: true,
+},
+
+}
+
+var PanelAttributes = map[string]schema.Attribute{
 "title": schema.StringAttribute{
  Required: true,
 },
@@ -53,17 +86,8 @@ Attributes: map[string]schema.Attribute {
 },
 
 "datasource": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"type": schema.StringAttribute{
- Optional: true,
-},
-
-"uid": schema.StringAttribute{
- Optional: true,
-},
-
-},
+Optional: true,
+Attributes: DataSourceRefAttributes,
 },
 
 "options": schema.ObjectAttribute{
@@ -75,129 +99,31 @@ Attributes: map[string]schema.Attribute{
 },
 
 "field_config": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: FieldConfigSourceAttributes,
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"dashboard": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"defaults": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"unit": schema.StringAttribute{
- Optional: true,
-},
-
-"custom": schema.ObjectAttribute{
- Optional: true,
-},
-
-},
-},
-
-},
-},
-
-},
-},
-},
-
-},
+Attributes: DashboardAttributes,
 },
 "data_source_ref": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"type": schema.StringAttribute{
- Optional: true,
-},
-
-"uid": schema.StringAttribute{
- Optional: true,
-},
-
-},
+Attributes: DataSourceRefAttributes,
 },
 "field_config_source": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"defaults": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"unit": schema.StringAttribute{
- Optional: true,
-},
-
-"custom": schema.ObjectAttribute{
- Optional: true,
-},
-
-},
-},
-
-},
+Attributes: FieldConfigSourceAttributes,
 },
 "field_config": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"unit": schema.StringAttribute{
- Optional: true,
-},
-
-"custom": schema.ObjectAttribute{
- Optional: true,
-},
-
-},
+Attributes: FieldConfigAttributes,
 },
 "panel": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"title": schema.StringAttribute{
- Required: true,
-},
-
-"type": schema.StringAttribute{
- Required: true,
-},
-
-"datasource": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"type": schema.StringAttribute{
- Optional: true,
-},
-
-"uid": schema.StringAttribute{
- Optional: true,
-},
-
-},
-},
-
-"options": schema.ObjectAttribute{
- Optional: true,
-},
-
-"targets": schema.ListAttribute{
- ElementType: unknown,
-},
-
-"field_config": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"defaults": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"unit": schema.StringAttribute{
- Optional: true,
-},
-
-"custom": schema.ObjectAttribute{
- Optional: true,
-},
-
-},
-},
-
-},
-},
-
-},
+Attributes: PanelAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/disjunction_of_numbers/TerraformRawTypes/disjunction_of_numbers/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunction_of_numbers/TerraformRawTypes/disjunction_of_numbers/types_gen.go
@@ -13,5 +13,20 @@ Float64 types.Float64 `tfsdk:"Float64"`
 Float32 types.Float32 `tfsdk:"Float32"`
  }
 
+var Int64OrFloat64OrFloat32Attributes = map[string]schema.Attribute{
+"int64": schema.Int64Attribute{
+ Optional: true,
+},
+
+"float64": schema.Float64Attribute{
+ Optional: true,
+},
+
+"float32": schema.Float32Attribute{
+ Optional: true,
+},
+
+}
+
 var SpecAttributes = map[string]schema.Attribute{
 }

--- a/testdata/jennies/rawtypes/disjunctions/TerraformRawTypes/disjunctions/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions/TerraformRawTypes/disjunctions/types_gen.go
@@ -46,13 +46,7 @@ SomeOtherStruct SomeOtherStruct `tfsdk:"SomeOtherStruct"`
 YetAnotherStruct YetAnotherStruct `tfsdk:"YetAnotherStruct"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"string_or_null": schema.StringAttribute{
- Optional: true,
-},
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "type": schema.StringAttribute{
  Required: true,
 Default: stringdefault.StaticString("some-struct"),
@@ -62,11 +56,9 @@ Default: stringdefault.StaticString("some-struct"),
  Required: true,
 },
 
-},
-},
-"some_other_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var SomeOtherStructAttributes = map[string]schema.Attribute{
 "type": schema.StringAttribute{
  Required: true,
 Default: stringdefault.StaticString("some-other-struct"),
@@ -76,11 +68,9 @@ Default: stringdefault.StaticString("some-other-struct"),
  Required: true,
 },
 
-},
-},
-"yet_another_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var YetAnotherStructAttributes = map[string]schema.Attribute{
 "type": schema.StringAttribute{
  Required: true,
 Default: stringdefault.StaticString("yet-another-struct"),
@@ -90,6 +80,63 @@ Default: stringdefault.StaticString("yet-another-struct"),
  Required: true,
 },
 
+}
+
+var StringOrBoolAttributes = map[string]schema.Attribute{
+"string": schema.StringAttribute{
+ Optional: true,
 },
+
+"bool": schema.BoolAttribute{
+ Optional: true,
+},
+
+}
+
+var BoolOrSomeStructAttributes = map[string]schema.Attribute{
+"bool": schema.BoolAttribute{
+ Optional: true,
+},
+
+"some_struct": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: SomeStructAttributes,
+},
+
+}
+
+var SomeStructOrSomeOtherStructOrYetAnotherStructAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: SomeStructAttributes,
+},
+
+"some_other_struct": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: SomeOtherStructAttributes,
+},
+
+"yet_another_struct": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: YetAnotherStructAttributes,
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"string_or_null": schema.StringAttribute{
+ Optional: true,
+},
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
+},
+"some_other_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeOtherStructAttributes,
+},
+"yet_another_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: YetAnotherStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/TerraformRawTypes/disjunctions_of_scalars_and_refs/types_gen.go
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/TerraformRawTypes/disjunctions_of_scalars_and_refs/types_gen.go
@@ -3,6 +3,7 @@ package disjunctions_of_scalars_and_refs
 import (
 	 "github.com/hashicorp/terraform-plugin-framework/types"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	stringdefault "github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 )
 
 type DisjunctionOfScalarsAndRefs = StringOrBoolOrArrayOfStringOrMyRefAOrMyRefB
@@ -23,23 +24,53 @@ MyRefA MyRefA `tfsdk:"MyRefA"`
 MyRefB MyRefB `tfsdk:"MyRefB"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"my_ref_a": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var MyRefAAttributes = map[string]schema.Attribute{
 "foo": schema.StringAttribute{
  Required: true,
 },
 
-},
-},
-"my_ref_b": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var MyRefBAttributes = map[string]schema.Attribute{
 "bar": schema.Int64Attribute{
  Required: true,
 },
 
+}
+
+var StringOrBoolOrArrayOfStringOrMyRefAOrMyRefBAttributes = map[string]schema.Attribute{
+"string": schema.StringAttribute{
+ Optional: true,
+Default: stringdefault.StaticString("a"),
 },
+
+"bool": schema.BoolAttribute{
+ Optional: true,
+},
+
+"array_of_string": schema.ListAttribute{
+ ElementType: types.StringType,
+},
+
+"my_ref_a": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: MyRefAAttributes,
+},
+
+"my_ref_b": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: MyRefBAttributes,
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"my_ref_a": schema.SingleNestedAttribute{
+Required: true,
+Attributes: MyRefAAttributes,
+},
+"my_ref_b": schema.SingleNestedAttribute{
+Required: true,
+Attributes: MyRefBAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/TerraformRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/TerraformRawTypes/defaults/types_gen.go
@@ -33,10 +33,7 @@ type DefaultsStructPartialComplexField struct {
 IntVal types.Int64 `tfsdk:"intVal"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"nested_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var NestedStructAttributes = map[string]schema.Attribute{
 "string_val": schema.StringAttribute{
  Required: true,
 },
@@ -45,128 +42,60 @@ Attributes: map[string]schema.Attribute{
  Required: true,
 },
 
-},
-},
-"struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var StructAttributes = map[string]schema.Attribute{
 "all_fields": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"string_val": schema.StringAttribute{
- Required: true,
-},
-
-"int_val": schema.Int64Attribute{
- Required: true,
-},
-
-},
+Attributes: NestedStructAttributes,
 },
 
 "partial_fields": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"string_val": schema.StringAttribute{
- Required: true,
-},
-
-"int_val": schema.Int64Attribute{
- Required: true,
-},
-
-},
+Attributes: NestedStructAttributes,
 },
 
 "empty_fields": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"string_val": schema.StringAttribute{
- Required: true,
-},
-
-"int_val": schema.Int64Attribute{
- Required: true,
-},
-
-},
+Attributes: NestedStructAttributes,
 },
 
 "complex_field": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"uid": schema.StringAttribute{
- Required: true,
-},
-
-"nested": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"nested_val": schema.StringAttribute{
- Required: true,
-},
-
-},
-},
-
-"array": schema.ListAttribute{
- ElementType: types.StringType,
-},
-
-},
+Attributes: DefaultsStructComplexFieldAttributes,
 },
 
 "partial_complex_field": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"uid": schema.StringAttribute{
- Required: true,
+Attributes: DefaultsStructPartialComplexFieldAttributes,
 },
 
-"int_val": schema.Int64Attribute{
- Required: true,
-},
+}
 
-},
-},
-
-},
-},
-"defaults_struct_complex_field_nested": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var DefaultsStructComplexFieldNestedAttributes = map[string]schema.Attribute{
 "nested_val": schema.StringAttribute{
  Required: true,
 },
 
-},
-},
-"defaults_struct_complex_field": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var DefaultsStructComplexFieldAttributes = map[string]schema.Attribute{
 "uid": schema.StringAttribute{
  Required: true,
 },
 
 "nested": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"nested_val": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: DefaultsStructComplexFieldNestedAttributes,
 },
 
 "array": schema.ListAttribute{
  ElementType: types.StringType,
 },
 
-},
-},
-"defaults_struct_partial_complex_field": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var DefaultsStructPartialComplexFieldAttributes = map[string]schema.Attribute{
 "uid": schema.StringAttribute{
  Required: true,
 },
@@ -175,6 +104,27 @@ Attributes: map[string]schema.Attribute{
  Required: true,
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"nested_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: NestedStructAttributes,
 },
+"struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: StructAttributes,
+},
+"defaults_struct_complex_field_nested": schema.SingleNestedAttribute{
+Required: true,
+Attributes: DefaultsStructComplexFieldNestedAttributes,
+},
+"defaults_struct_complex_field": schema.SingleNestedAttribute{
+Required: true,
+Attributes: DefaultsStructComplexFieldAttributes,
+},
+"defaults_struct_partial_complex_field": schema.SingleNestedAttribute{
+Required: true,
+Attributes: DefaultsStructPartialComplexFieldAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/intersections/TerraformRawTypes/intersections/types_gen.go
+++ b/testdata/jennies/rawtypes/intersections/TerraformRawTypes/intersections/types_gen.go
@@ -31,23 +31,15 @@ Contains types.String `tfsdk:"contains"`
 
 
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_bool": schema.BoolAttribute{
  Required: true,
 Default: booldefault.StaticBool(true),
 },
 
-},
-},
-"common": schema.SingleNestedAttribute{
-Required: true,
-Description: `
-Base properties for all metrics
-`,
-Attributes: map[string]schema.Attribute{
+}
+
+var CommonAttributes = map[string]schema.Attribute{
 "name": schema.StringAttribute{
  Required: true,
 },
@@ -68,6 +60,18 @@ stringvalidator.OneOf("default", "time"),
 
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
+"common": schema.SingleNestedAttribute{
+Required: true,
+Description: `
+Base properties for all metrics
+`,
+Attributes: CommonAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/maps/TerraformRawTypes/maps/types_gen.go
+++ b/testdata/jennies/rawtypes/maps/TerraformRawTypes/maps/types_gen.go
@@ -18,6 +18,13 @@ type MapOfStringToRef types.Map
 
 type MapOfStringToMapOfStringToBool types.Map
 
+var SomeStructAttributes = map[string]schema.Attribute{
+"field_any": schema.ObjectAttribute{
+ Required: true,
+},
+
+}
+
 var SpecAttributes = map[string]schema.Attribute{
 "map_of_string_to_any": schema.MapAttribute{
  ElementType: types.DynamicType,
@@ -27,21 +34,11 @@ var SpecAttributes = map[string]schema.Attribute{
 },
 "some_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: SomeStructAttributes,
 },
 "map_of_string_to_ref": schema.MapNestedAttribute{
-NestedObject: schema.NestedAttributeObject {
-Attributes: map[string]schema.Attribute {
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+NestedObject: schema.NestedAttributeObject{
+Attributes: SomeStructAttributes,
 },
 },
 "map_of_string_to_map_of_string_to_bool": schema.MapAttribute{

--- a/testdata/jennies/rawtypes/nullable_fields/TerraformRawTypes/nullable_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/nullable_fields/TerraformRawTypes/nullable_fields/types_gen.go
@@ -26,28 +26,15 @@ type NullableFieldsStructF struct {
  A types.String `tfsdk:"a"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var StructAttributes = map[string]schema.Attribute{
 "a": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"field": schema.StringAttribute{
- Required: true,
-},
-
-},
+Optional: true,
+Attributes: MyObjectAttributes,
 },
 
 "b": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"field": schema.StringAttribute{
- Required: true,
-},
-
-},
+Optional: true,
+Attributes: MyObjectAttributes,
 },
 
 "c": schema.StringAttribute{
@@ -63,13 +50,8 @@ Attributes: map[string]schema.Attribute{
 },
 
 "f": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"a": schema.StringAttribute{
- Required: true,
-},
-
-},
+Optional: true,
+Attributes: NullableFieldsStructFAttributes,
 },
 
 "g": schema.StringAttribute{
@@ -77,16 +59,30 @@ Attributes: map[string]schema.Attribute{
 Default: stringdefault.StaticString("hey"),
 },
 
-},
-},
-"my_object": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var MyObjectAttributes = map[string]schema.Attribute{
 "field": schema.StringAttribute{
  Required: true,
 },
 
+}
+
+var NullableFieldsStructFAttributes = map[string]schema.Attribute{
+"a": schema.StringAttribute{
+ Required: true,
 },
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: StructAttributes,
+},
+"my_object": schema.SingleNestedAttribute{
+Required: true,
+Attributes: MyObjectAttributes,
 },
 "constant_ref": schema.StringAttribute{
  Required: true,
@@ -94,11 +90,6 @@ Default: stringdefault.StaticString("hey"),
 },
 "nullable_fields_struct_f": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"a": schema.StringAttribute{
- Required: true,
-},
-
-},
+Attributes: NullableFieldsStructFAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/package-with-dashes/TerraformRawTypes/withdashes/types_gen.go
+++ b/testdata/jennies/rawtypes/package-with-dashes/TerraformRawTypes/withdashes/types_gen.go
@@ -17,14 +17,27 @@ type StringOrBool struct {
 Bool types.Bool `tfsdk:"Bool"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_any": schema.ObjectAttribute{
  Required: true,
 },
 
+}
+
+var StringOrBoolAttributes = map[string]schema.Attribute{
+"string": schema.StringAttribute{
+ Optional: true,
 },
+
+"bool": schema.BoolAttribute{
+ Optional: true,
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/refs/TerraformRawTypes/refs/types_gen.go
+++ b/testdata/jennies/rawtypes/refs/TerraformRawTypes/refs/types_gen.go
@@ -13,14 +13,16 @@ type RefToSomeStruct = SomeStruct
 
 type RefToSomeStructFromOtherPackage = unknown
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_any": schema.ObjectAttribute{
  Required: true,
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/self_referential_struct/GoRawTypes/self_referential_struct/types_gen.go
+++ b/testdata/jennies/rawtypes/self_referential_struct/GoRawTypes/self_referential_struct/types_gen.go
@@ -1,0 +1,107 @@
+package self_referential_struct
+
+import (
+	"encoding/json"
+	cog "github.com/grafana/cog/generated/cog"
+	"errors"
+	"fmt"
+)
+
+// Node represents a node in a singly-linked list.
+// The next field points to the following node, or is absent if this is the last node.
+type Node struct {
+    Value string `json:"value"`
+    Next *Node `json:"next,omitempty"`
+}
+
+// NewNode creates a new Node object.
+func NewNode() *Node {
+	return &Node{
+}
+}
+// UnmarshalJSONStrict implements a custom JSON unmarshalling logic to decode `Node` from JSON.
+// Note: the unmarshalling done by this function is strict. It will fail over required fields being absent from the input, fields having an incorrect type, unexpected fields being present, …
+func (resource *Node) UnmarshalJSONStrict(raw []byte) error {
+	if raw == nil {
+		return nil
+	}
+	var errs cog.BuildErrors
+
+	fields := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	// Field "value"
+	if fields["value"] != nil {
+		if string(fields["value"]) != "null" {
+			if err := json.Unmarshal(fields["value"], &resource.Value); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("value", err)...)
+			}
+		} else {errs = append(errs, cog.MakeBuildErrors("value", errors.New("required field is null"))...)
+		
+		}
+		delete(fields, "value")
+	} else {errs = append(errs, cog.MakeBuildErrors("value", errors.New("required field is missing from input"))...)
+	}
+	// Field "next"
+	if fields["next"] != nil {
+		if string(fields["next"]) != "null" {
+			
+			resource.Next = &Node{}
+			if err := resource.Next.UnmarshalJSONStrict(fields["next"]); err != nil {
+				errs = append(errs, cog.MakeBuildErrors("next", err)...)
+			}
+		
+		}
+		delete(fields, "next")
+	
+	}
+
+	for field := range fields {
+		errs = append(errs, cog.MakeBuildErrors("Node", fmt.Errorf("unexpected field '%s'", field))...)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+
+// Equals tests the equality of two `Node` objects.
+func (resource Node) Equals(other Node) bool {
+		if resource.Value != other.Value {
+			return false
+		}
+		if resource.Next == nil && other.Next != nil || resource.Next != nil && other.Next == nil {
+			return false
+		}
+
+		if resource.Next != nil {
+		if !resource.Next.Equals(*other.Next) {
+			return false
+		}
+		}
+
+	return true
+}
+
+
+// Validate checks all the validation constraints that may be defined on `Node` fields for violations and returns them.
+func (resource Node) Validate() error {
+	var errs cog.BuildErrors
+		if resource.Next != nil {
+		if err := resource.Next.Validate(); err != nil {
+			errs = append(errs, cog.MakeBuildErrors("next", err)...)
+		}
+		}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
+

--- a/testdata/jennies/rawtypes/self_referential_struct/JSONSchema/self_referential_struct.jsonschema.json
+++ b/testdata/jennies/rawtypes/self_referential_struct/JSONSchema/self_referential_struct.jsonschema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "next": {
+          "$ref": "#/definitions/Node"
+        }
+      },
+      "description": "Node represents a node in a singly-linked list.\nThe next field points to the following node, or is absent if this is the last node."
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/JavaRawTypes/self_referential_struct/Node.java
+++ b/testdata/jennies/rawtypes/self_referential_struct/JavaRawTypes/self_referential_struct/Node.java
@@ -1,0 +1,16 @@
+package self_referential_struct;
+
+
+// Node represents a node in a singly-linked list.
+// The next field points to the following node, or is absent if this is the last node.
+public class Node {
+    public String value;
+    public Node next;
+    public Node() {
+        this.value = "";
+    }
+    public Node(String value,Node next) {
+        this.value = value;
+        this.next = next;
+    }
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/OpenAPI/self_referential_struct.openapi.json
+++ b/testdata/jennies/rawtypes/self_referential_struct/OpenAPI/self_referential_struct.openapi.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "self_referential_struct",
+    "version": "0.0.0",
+    "x-schema-identifier": "",
+    "x-schema-kind": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Node": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "next": {
+            "$ref": "#/components/schemas/Node"
+          }
+        },
+        "description": "Node represents a node in a singly-linked list.\nThe next field points to the following node, or is absent if this is the last node."
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/PHPRawTypes/src/SelfReferentialStruct/Node.php
+++ b/testdata/jennies/rawtypes/self_referential_struct/PHPRawTypes/src/SelfReferentialStruct/Node.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Grafana\Foundation\SelfReferentialStruct;
+
+/**
+ * Node represents a node in a singly-linked list.
+ * The next field points to the following node, or is absent if this is the last node.
+ */
+class Node implements \JsonSerializable
+{
+    public string $value;
+
+    public ?\Grafana\Foundation\SelfReferentialStruct\Node $next;
+
+    /**
+     * @param string|null $value
+     * @param \Grafana\Foundation\SelfReferentialStruct\Node|null $next
+     */
+    public function __construct(?string $value = null, ?\Grafana\Foundation\SelfReferentialStruct\Node $next = null)
+    {
+        $this->value = $value ?: "";
+        $this->next = $next;
+    }
+
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): self
+    {
+        /** @var array{value?: string, next?: mixed} $inputData */
+        $data = $inputData;
+        return new self(
+            value: $data["value"] ?? null,
+            next: isset($data["next"]) ? (function($input) {
+    	/** @var array{value?: string, next?: mixed} */
+    $val = $input;
+    	return \Grafana\Foundation\SelfReferentialStruct\Node::fromArray($val);
+    })($data["next"]) : null,
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function jsonSerialize(): mixed
+    {
+        $data = new \stdClass;
+        $data->value = $this->value;
+        if (isset($this->next)) {
+            $data->next = $this->next;
+        }
+        return $data;
+    }
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/PythonRawTypes/models/self_referential_struct.py
+++ b/testdata/jennies/rawtypes/self_referential_struct/PythonRawTypes/models/self_referential_struct.py
@@ -1,0 +1,34 @@
+import typing
+
+
+class Node:
+    """
+    Node represents a node in a singly-linked list.
+    The next field points to the following node, or is absent if this is the last node.
+    """
+
+    value: str
+    next_val: typing.Optional['Node']
+
+    def __init__(self, value: str = "", next_val: typing.Optional['Node'] = None) -> None:
+        self.value = value
+        self.next_val = next_val
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "value": self.value,
+        }
+        if self.next_val is not None:
+            payload["next"] = self.next_val
+        return payload
+
+    @classmethod
+    def from_json(cls, data: dict[str, typing.Any]) -> typing.Self:
+        args: dict[str, typing.Any] = {}
+        
+        if "value" in data:
+            args["value"] = data["value"]
+        if "next" in data:
+            args["next_val"] = Node.from_json(data["next"])        
+
+        return cls(**args)

--- a/testdata/jennies/rawtypes/self_referential_struct/TerraformRawTypes/self_referential_struct/types_gen.go
+++ b/testdata/jennies/rawtypes/self_referential_struct/TerraformRawTypes/self_referential_struct/types_gen.go
@@ -1,0 +1,41 @@
+package self_referential_struct
+
+import (
+	 "github.com/hashicorp/terraform-plugin-framework/types"
+	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// Node represents a node in a singly-linked list.
+// The next field points to the following node, or is absent if this is the last node.
+type Node struct {
+ Value types.String `tfsdk:"value"`
+Next Node `tfsdk:"next"`
+ }
+
+var NodeAttributes = map[string]schema.Attribute{
+"value": schema.StringAttribute{
+ Required: true,
+},
+
+"next": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: map[string]schema.Attribute{
+"value": schema.StringAttribute{
+ Required: true,
+},
+
+},
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"node": schema.SingleNestedAttribute{
+Required: true,
+Description: `
+Node represents a node in a singly-linked list.
+The next field points to the following node, or is absent if this is the last node.
+`,
+Attributes: NodeAttributes,
+},
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/TypescriptRawTypes/src/selfReferentialStruct/types.gen.ts
+++ b/testdata/jennies/rawtypes/self_referential_struct/TypescriptRawTypes/src/selfReferentialStruct/types.gen.ts
@@ -1,0 +1,11 @@
+// Node represents a node in a singly-linked list.
+// The next field points to the following node, or is absent if this is the last node.
+export interface Node {
+	value: string;
+	next?: Node;
+}
+
+export const defaultNode = (): Node => ({
+	value: "",
+});
+

--- a/testdata/jennies/rawtypes/self_referential_struct/ir.json
+++ b/testdata/jennies/rawtypes/self_referential_struct/ir.json
@@ -1,0 +1,52 @@
+{
+  "Package": "self_referential_struct",
+  "Metadata": {},
+  "EntryPointType": {
+    "Kind": "",
+    "Nullable": false
+  },
+  "Objects": {
+    "Node": {
+      "Name": "Node",
+      "Comments": [
+        "Node represents a node in a singly-linked list.",
+        "The next field points to the following node, or is absent if this is the last node."
+      ],
+      "SelfRef": {
+        "ReferredPkg": "self_referential_struct",
+        "ReferredType": "Node"
+      },
+      "Type": {
+        "Kind": "struct",
+        "Nullable": false,
+        "Struct": {
+          "Fields": [
+            {
+              "Name": "value",
+              "Required": true,
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            },
+            {
+              "Name": "next",
+              "Required": false,
+              "Type": {
+                "Kind": "ref",
+                "Nullable": false,
+                "Ref": {
+                  "ReferredPkg": "self_referential_struct",
+                  "ReferredType": "Node"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/testdata/jennies/rawtypes/self_referential_struct/schema.cue
+++ b/testdata/jennies/rawtypes/self_referential_struct/schema.cue
@@ -1,0 +1,8 @@
+package self_referential_struct
+
+// Node represents a node in a singly-linked list.
+// The next field points to the following node, or is absent if this is the last node.
+Node: {
+	value: string
+	next?: Node
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/TerraformRawTypes/struct_complex_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/TerraformRawTypes/struct_complex_fields/types_gen.go
@@ -43,55 +43,20 @@ type StringOrSomeOtherStruct struct {
 SomeOtherStruct SomeOtherStruct `tfsdk:"SomeOtherStruct"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Description: `
-This struct does things.
-`,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_ref": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: SomeOtherStructAttributes,
 },
 
 "field_disjunction_of_scalars": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"string": schema.StringAttribute{
- Optional: true,
-},
-
-"bool": schema.BoolAttribute{
- Optional: true,
-},
-
-},
+Attributes: StringOrBoolAttributes,
 },
 
 "field_mixed_disjunction": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"string": schema.StringAttribute{
- Optional: true,
-},
-
-"some_other_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
-},
-
-},
+Attributes: StringOrSomeOtherStructAttributes,
 },
 
 "field_disjunction_with_null": schema.StringAttribute{
@@ -116,12 +81,7 @@ stringvalidator.OneOf(">", "<"),
 
 "field_anonymous_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: StructComplexFieldsSomeStructFieldAnonymousStructAttributes,
 },
 
 "field_ref_to_constant": schema.StringAttribute{
@@ -129,7 +89,52 @@ Attributes: map[string]schema.Attribute{
 Default: stringdefault.StaticString("straight"),
 },
 
+}
+
+var SomeOtherStructAttributes = map[string]schema.Attribute{
+"field_any": schema.ObjectAttribute{
+ Required: true,
 },
+
+}
+
+var StructComplexFieldsSomeStructFieldAnonymousStructAttributes = map[string]schema.Attribute{
+"field_any": schema.ObjectAttribute{
+ Required: true,
+},
+
+}
+
+var StringOrBoolAttributes = map[string]schema.Attribute{
+"string": schema.StringAttribute{
+ Optional: true,
+},
+
+"bool": schema.BoolAttribute{
+ Optional: true,
+},
+
+}
+
+var StringOrSomeOtherStructAttributes = map[string]schema.Attribute{
+"string": schema.StringAttribute{
+ Optional: true,
+},
+
+"some_other_struct": schema.SingleNestedAttribute{
+Optional: true,
+Attributes: SomeOtherStructAttributes,
+},
+
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Description: `
+This struct does things.
+`,
+Attributes: SomeStructAttributes,
 },
 "connection_path": schema.StringAttribute{
  Required: true,
@@ -137,20 +142,10 @@ Default: stringdefault.StaticString("straight"),
 },
 "some_other_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: SomeOtherStructAttributes,
 },
 "struct_complex_fields_some_struct_field_anonymous_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: StructComplexFieldsSomeStructFieldAnonymousStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/struct_with_defaults/TerraformRawTypes/defaults/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_defaults/TerraformRawTypes/defaults/types_gen.go
@@ -17,10 +17,7 @@ FieldFloat32 types.Float32 `tfsdk:"FieldFloat32"`
 FieldInt32 types.Int32 `tfsdk:"FieldInt32"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_bool": schema.BoolAttribute{
  Required: true,
 Default: booldefault.StaticBool(true),
@@ -46,6 +43,11 @@ Default: float32default.StaticFloat32(42.42),
 Default: int32default.StaticInt32(42),
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/TerraformRawTypes/struct_optional_fields/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/TerraformRawTypes/struct_optional_fields/types_gen.go
@@ -25,18 +25,10 @@ type StructOptionalFieldsSomeStructFieldAnonymousStruct struct {
 
 
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_ref": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Optional: true,
+Attributes: SomeOtherStructAttributes,
 },
 
 "field_string": schema.StringAttribute{
@@ -56,33 +48,37 @@ stringvalidator.OneOf(">", "<"),
 },
 
 "field_anonymous_struct": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+Optional: true,
+Attributes: StructOptionalFieldsSomeStructFieldAnonymousStructAttributes,
+},
+
+}
+
+var SomeOtherStructAttributes = map[string]schema.Attribute{
 "field_any": schema.ObjectAttribute{
  Required: true,
 },
 
-},
+}
+
+var StructOptionalFieldsSomeStructFieldAnonymousStructAttributes = map[string]schema.Attribute{
+"field_any": schema.ObjectAttribute{
+ Required: true,
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Attributes: SomeStructAttributes,
 },
 "some_other_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: SomeOtherStructAttributes,
 },
 "struct_optional_fields_some_struct_field_anonymous_struct": schema.SingleNestedAttribute{
 Required: true,
-Attributes: map[string]schema.Attribute{
-"field_any": schema.ObjectAttribute{
- Required: true,
-},
-
-},
+Attributes: StructOptionalFieldsSomeStructFieldAnonymousStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/TerraformRawTypes/basic/types_gen.go
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/TerraformRawTypes/basic/types_gen.go
@@ -30,16 +30,7 @@ FieldInt32 types.Int32 `tfsdk:"FieldInt32"`
 FieldInt64 types.Int64 `tfsdk:"FieldInt64"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"some_struct": schema.SingleNestedAttribute{
-Required: true,
-Description: `
-This
-is
-a
-comment
-`,
-Attributes: map[string]schema.Attribute{
+var SomeStructAttributes = map[string]schema.Attribute{
 "field_any": schema.ObjectAttribute{
  Required: true,
 },
@@ -101,6 +92,17 @@ Default: stringdefault.StaticString("auto"),
  Required: true,
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"some_struct": schema.SingleNestedAttribute{
+Required: true,
+Description: `
+This
+is
+a
+comment
+`,
+Attributes: SomeStructAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/time_hint/TerraformRawTypes/time_hint/types_gen.go
+++ b/testdata/jennies/rawtypes/time_hint/TerraformRawTypes/time_hint/types_gen.go
@@ -13,14 +13,7 @@ type ObjWithTimeField struct {
 Duration timetypes.GoDurationType `tfsdk:"duration"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"obj_time": schema.StringAttribute{
- Required: true,
-CustomType: timetypes.RFC3339Type{},
-},
-"obj_with_time_field": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var ObjWithTimeFieldAttributes = map[string]schema.Attribute{
 "registered_at": schema.StringAttribute{
  Required: true,
 CustomType: timetypes.RFC3339Type{},
@@ -31,6 +24,15 @@ CustomType: timetypes.RFC3339Type{},
 CustomType: timetypes.GoDurationType{},
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"obj_time": schema.StringAttribute{
+ Required: true,
+CustomType: timetypes.RFC3339Type{},
 },
+"obj_with_time_field": schema.SingleNestedAttribute{
+Required: true,
+Attributes: ObjWithTimeFieldAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/variant_dataquery/TerraformRawTypes/variant_dataquery/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_dataquery/TerraformRawTypes/variant_dataquery/types_gen.go
@@ -10,10 +10,7 @@ type Query struct {
 Instant types.Bool `tfsdk:"instant"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"query": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var QueryAttributes = map[string]schema.Attribute{
 "expr": schema.StringAttribute{
  Required: true,
 },
@@ -22,6 +19,11 @@ Attributes: map[string]schema.Attribute{
  Optional: true,
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"query": schema.SingleNestedAttribute{
+Required: true,
+Attributes: QueryAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/TerraformRawTypes/variant_panelcfg_full/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/TerraformRawTypes/variant_panelcfg_full/types_gen.go
@@ -13,23 +13,27 @@ type FieldConfig struct {
  TimeseriesFieldConfigOption types.String `tfsdk:"timeseries_field_config_option"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"options": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var OptionsAttributes = map[string]schema.Attribute{
 "timeseries_option": schema.StringAttribute{
  Required: true,
 },
 
-},
-},
-"field_config": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+}
+
+var FieldConfigAttributes = map[string]schema.Attribute{
 "timeseries_field_config_option": schema.StringAttribute{
  Required: true,
 },
 
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"options": schema.SingleNestedAttribute{
+Required: true,
+Attributes: OptionsAttributes,
 },
+"field_config": schema.SingleNestedAttribute{
+Required: true,
+Attributes: FieldConfigAttributes,
 },
 }

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/TerraformRawTypes/variant_panelcfg_only_options/types_gen.go
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/TerraformRawTypes/variant_panelcfg_only_options/types_gen.go
@@ -9,14 +9,16 @@ type Options struct {
  Content types.String `tfsdk:"content"`
  }
 
-var SpecAttributes = map[string]schema.Attribute{
-"options": schema.SingleNestedAttribute{
-Required: true,
-Attributes: map[string]schema.Attribute{
+var OptionsAttributes = map[string]schema.Attribute{
 "content": schema.StringAttribute{
  Required: true,
 },
 
-},
+}
+
+var SpecAttributes = map[string]schema.Attribute{
+"options": schema.SingleNestedAttribute{
+Required: true,
+Attributes: OptionsAttributes,
 },
 }


### PR DESCRIPTION
It updates Terraform attributes to generate vars per different structs. It minimises the dependency cycle issue that we found.

If it doesn't able to do it, it skips the field to avoid to break the generation.