### PR TITLE
PHP: Override fromArray function when we extend from another class

### DIFF
--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -148,7 +148,26 @@ func (jenny RawTypes) formatObject(context languages.Context, schema *ast.Schema
 
 		buffer.WriteString(enum)
 	case ast.KindRef:
-		buffer.WriteString(fmt.Sprintf("class %s extends %s {}", defName, jenny.typeFormatter.formatType(def.Type)))
+		parentRef := jenny.typeFormatter.formatType(def.Type)
+		if jenny.config.GenerateJSONMarshaller {
+			fromArray := strings.Join([]string{
+				"/**",
+				" * @param array<string, mixed> $inputData",
+				" */",
+				"public static function fromArray(array $inputData): static",
+				"{",
+				"    $base = parent::fromArray($inputData);",
+				"    $obj = new static();",
+				"    foreach (get_object_vars($base) as $key => $value) {",
+				"        $obj->$key = $value;",
+				"    }",
+				"    return $obj;",
+				"}",
+			}, "\n")
+			buffer.WriteString(fmt.Sprintf("class %s extends %s\n{\n%s\n}", defName, parentRef, tools.Indent(fromArray, 4)))
+		} else {
+			buffer.WriteString(fmt.Sprintf("class %s extends %s {}", defName, parentRef))
+		}
 	case ast.KindStruct:
 		structDef, err := jenny.formatStructDef(context, schema, def)
 		if err != nil {

--- a/testdata/jennies/rawtypes/reference_of_reference/PHPRawTypes/src/ReferenceOfReference/OtherStruct.php
+++ b/testdata/jennies/rawtypes/reference_of_reference/PHPRawTypes/src/ReferenceOfReference/OtherStruct.php
@@ -2,4 +2,18 @@
 
 namespace Grafana\Foundation\ReferenceOfReference;
 
-class OtherStruct extends \Grafana\Foundation\ReferenceOfReference\AnotherStruct {}
+class OtherStruct extends \Grafana\Foundation\ReferenceOfReference\AnotherStruct
+{
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): static
+    {
+        $base = parent::fromArray($inputData);
+        $obj = new self();
+        foreach (get_object_vars($base) as $key => $value) {
+            $obj->$key = $value;
+        }
+        return $obj;
+    }
+}

--- a/testdata/jennies/rawtypes/reference_of_reference/PHPRawTypes/src/ReferenceOfReference/OtherStruct.php
+++ b/testdata/jennies/rawtypes/reference_of_reference/PHPRawTypes/src/ReferenceOfReference/OtherStruct.php
@@ -10,7 +10,7 @@ class OtherStruct extends \Grafana\Foundation\ReferenceOfReference\AnotherStruct
     public static function fromArray(array $inputData): static
     {
         $base = parent::fromArray($inputData);
-        $obj = new self();
+        $obj = new static();
         foreach (get_object_vars($base) as $key => $value) {
             $obj->$key = $value;
         }

--- a/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStruct.php
+++ b/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStruct.php
@@ -2,4 +2,18 @@
 
 namespace Grafana\Foundation\Refs;
 
-class RefToSomeStruct extends \Grafana\Foundation\Refs\SomeStruct {}
+class RefToSomeStruct extends \Grafana\Foundation\Refs\SomeStruct
+{
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): static
+    {
+        $base = parent::fromArray($inputData);
+        $obj = new self();
+        foreach (get_object_vars($base) as $key => $value) {
+            $obj->$key = $value;
+        }
+        return $obj;
+    }
+}

--- a/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStruct.php
+++ b/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStruct.php
@@ -10,7 +10,7 @@ class RefToSomeStruct extends \Grafana\Foundation\Refs\SomeStruct
     public static function fromArray(array $inputData): static
     {
         $base = parent::fromArray($inputData);
-        $obj = new self();
+        $obj = new static();
         foreach (get_object_vars($base) as $key => $value) {
             $obj->$key = $value;
         }

--- a/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStructFromOtherPackage.php
+++ b/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStructFromOtherPackage.php
@@ -10,7 +10,7 @@ class RefToSomeStructFromOtherPackage extends \Grafana\Foundation\Otherpkg\SomeD
     public static function fromArray(array $inputData): static
     {
         $base = parent::fromArray($inputData);
-        $obj = new self();
+        $obj = new static();
         foreach (get_object_vars($base) as $key => $value) {
             $obj->$key = $value;
         }

--- a/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStructFromOtherPackage.php
+++ b/testdata/jennies/rawtypes/refs/PHPRawTypes/src/Refs/RefToSomeStructFromOtherPackage.php
@@ -2,4 +2,18 @@
 
 namespace Grafana\Foundation\Refs;
 
-class RefToSomeStructFromOtherPackage extends \Grafana\Foundation\Otherpkg\SomeDistantStruct {}
+class RefToSomeStructFromOtherPackage extends \Grafana\Foundation\Otherpkg\SomeDistantStruct
+{
+    /**
+     * @param array<string, mixed> $inputData
+     */
+    public static function fromArray(array $inputData): static
+    {
+        $base = parent::fromArray($inputData);
+        $obj = new self();
+        foreach (get_object_vars($base) as $key => $value) {
+            $obj->$key = $value;
+        }
+        return $obj;
+    }
+}


### PR DESCRIPTION
Trying to solve: https://github.com/grafana/grafana-foundation-sdk/actions/runs/24992559113/job/73181451024?pr=1191

When we have a class that extends from another, if we don't override fromArray, it tries to use the child class, failing in the type of the expected class.