### PR TITLE
feat(csharp): add C# code generation target

### DIFF
--- a/config/foundation_sdk.tests.yaml
+++ b/config/foundation_sdk.tests.yaml
@@ -7,6 +7,7 @@ parameters:
   go_package_root: 'github.com/grafana/cog/testdata/generated'
   php_namespace_root: 'Grafana\Foundation'
   java_package_path: 'com.grafana.foundation'
+  csharp_namespace_root: 'Grafana.Foundation'
 
 inputs:
   - cue:
@@ -28,3 +29,6 @@ output:
         generate_strict_unmarshaller: true
         generate_equal: true
         generate_validate: true
+    - csharp:
+        namespace_root: '%csharp_namespace_root%'
+        generate_json_converters: true

--- a/docs/pipelines/creating_pipeline.md
+++ b/docs/pipelines/creating_pipeline.md
@@ -307,6 +307,47 @@ output:
           - '%__config_dir%/templates/go/overrides'
 ```
 
+### C#
+
+```yaml
+output:
+  # …
+
+  languages:
+    - csharp:
+        # Root namespace for generated types. Generated source files land
+        # under `src/<namespace-as-folders>/<Package>/<Type>.cs`.
+        # Default: 'Grafana.Foundation'
+        namespace_root: 'Org.Package'
+
+        # Disables runtime-related code generation (e.g. `Cog.IBuilder<T>`).
+        # Note: builders can NOT be generated with this flag turned on, as
+        # they rely on the runtime to function.
+        # Default: false
+        skip_runtime: false
+
+        # Controls the generation of `System.Text.Json`-style
+        # `JsonConverter<T>` classes alongside generated types. Required
+        # for disjunction/discriminator support.
+        # Default: false
+        generate_json_converters: true
+
+        # Controls the generation of `Equals()` and `GetHashCode()`
+        # overrides on types.
+        # Default: false
+        generate_equality: false
+
+        # List of directories containing templates describing files to be
+        # added to the generated output.
+        extra_files_templates:
+          - '%__config_dir%/templates/csharp/extra'
+
+        # List of directories containing templates defining blocks used to
+        # override parts of builders/types/....
+        overrides_templates:
+          - '%__config_dir%/templates/csharp/overrides'
+```
+
 ### Java
 
 ```yaml

--- a/internal/codegen/output.go
+++ b/internal/codegen/output.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"github.com/grafana/cog/internal/jennies/csharp"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/java"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
@@ -61,6 +62,7 @@ func (output *Output) interpolateParameters(interpolator ParametersInterpolator)
 }
 
 type OutputLanguage struct {
+	CSharp     *csharp.Config     `yaml:"csharp"`
 	Go         *golang.Config     `yaml:"go"`
 	Java       *java.Config       `yaml:"java"`
 	JSONSchema *jsonschema.Config `yaml:"jsonschema"`
@@ -87,6 +89,10 @@ func (outputLanguage *OutputLanguage) interpolateParameters(output *Output, inte
 	if outputLanguage.Java != nil {
 		outputLanguage.Java.InterpolateParameters(interpolator)
 		outputLanguage.Java.ExtraFilesTemplatesData = output.TemplatesData
+	}
+	if outputLanguage.CSharp != nil {
+		outputLanguage.CSharp.InterpolateParameters(interpolator)
+		outputLanguage.CSharp.ExtraFilesTemplatesData = output.TemplatesData
 	}
 	if outputLanguage.Typescript != nil {
 		outputLanguage.Typescript.InterpolateParameters(interpolator)

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/jennies/csharp"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/jennies/java"
 	"github.com/grafana/cog/internal/jennies/jsonschema"
@@ -307,6 +308,8 @@ func (pipeline *Pipeline) OutputLanguages() (languages.Languages, error) {
 		switch {
 		case output.Go != nil:
 			outputs[golang.LanguageRef] = golang.New(*output.Go)
+		case output.CSharp != nil:
+			outputs[csharp.LanguageRef] = csharp.New(*output.CSharp)
 		case output.Java != nil:
 			outputs[java.LanguageRef] = java.New(*output.Java)
 		case output.JSONSchema != nil:

--- a/internal/jennies/common/codejen.go
+++ b/internal/jennies/common/codejen.go
@@ -55,7 +55,7 @@ func GeneratedCommentHeader(config languages.Config) codejen.FileMapper {
 	return func(f codejen.File) (codejen.File, error) {
 		var leader string
 		switch filepath.Ext(f.RelativePath) {
-		case ".ts", ".go", ".java":
+		case ".ts", ".go", ".java", ".cs":
 			leader = "//"
 		case ".yml", ".yaml", ".py":
 			leader = "#"

--- a/internal/jennies/csharp/builder.go
+++ b/internal/jennies/csharp/builder.go
@@ -1,0 +1,126 @@
+package csharp
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+// Builder emits one fluent builder class per ast.Builder in the input
+// context. Each builder lives next to its target type at
+// <ProjectPath>/<Pkg>/<Name>Builder.cs and implements
+// `Cog.IBuilder<TargetType>`. The implementation closely mirrors the
+// Java jenny so the generated APIs stay aligned across targets.
+type Builder struct {
+	config        Config
+	tmpl          *template.Template
+	imports       *importMap
+	typeFormatter *typeFormatter
+
+	apiRefCollector *common.APIReferenceCollector
+}
+
+func (jenny Builder) JennyName() string {
+	return "CSharpBuilder"
+}
+
+func (jenny Builder) Generate(context languages.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0, len(context.Builders))
+	for _, builder := range context.Builders {
+		out, err := jenny.genBuilder(context, builder)
+		if err != nil {
+			return nil, err
+		}
+		filename := filepath.Join(
+			jenny.config.ProjectPath,
+			formatPackageName(builder.Package),
+			fmt.Sprintf("%sBuilder.cs", jenny.builderName(builder)),
+		)
+		files = append(files, *codejen.NewFile(filename, out, jenny))
+	}
+	return files, nil
+}
+
+// builderTemplate carries the data passed into the builder template.
+type builderTemplate struct {
+	Namespace            string
+	Imports              fmt.Stringer
+	ObjectName           string
+	BuilderName          string
+	BuilderSignatureType string
+	Constructor          ast.Constructor
+	Options              []ast.Option
+	Properties           []ast.StructField
+}
+
+func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) ([]byte, error) {
+	namespace := jenny.config.formatNamespace(builder.Package)
+
+	jenny.imports = newImportMap(jenny.config.namespaceRoot(), namespace)
+	jenny.typeFormatter = newTypeFormatter(context, jenny.config, jenny.imports)
+
+	object, _ := context.LocateObject(builder.For.SelfRef.ReferredPkg, builder.For.SelfRef.ReferredType)
+
+	data := builderTemplate{
+		Namespace:            namespace,
+		Imports:              jenny.imports,
+		ObjectName:           formatObjectName(object.Name),
+		BuilderName:          jenny.builderName(builder),
+		BuilderSignatureType: jenny.builderSignature(builder.Package, object),
+		Constructor:          builder.Constructor,
+		Options:              builder.Options,
+		Properties:           builder.Properties,
+	}
+
+	jenny.apiRefCollector.BuilderMethod(builder, common.MethodReference{
+		Name:     "Build",
+		Comments: []string{"Builds the object."},
+		Return:   formatObjectName(builder.Name),
+	})
+
+	// Cog.IBuilder<T> resolves via parent-namespace lookup
+	// (`<NamespaceRoot>.Cog` is a sibling of every generated package),
+	// so no explicit `using Grafana.Foundation.Cog;` is needed.
+
+	return jenny.tmpl.Funcs(map[string]any{
+		"formatBuilderFieldType":   jenny.typeFormatter.formatBuilderFieldType,
+		"emptyValueForType":        func(def ast.Type) string { return jenny.typeFormatter.emptyValueForTypeOpts(def, true) },
+		"typeHasBuilder":           jenny.typeFormatter.typeHasBuilder,
+		"resolvesToComposableSlot": jenny.typeFormatter.resolvesToComposableSlot,
+		"formatAssignmentPath":     jenny.typeFormatter.formatAssignmentPath,
+		"formatPath":               jenny.typeFormatter.formatFieldPath,
+		"formatRefType":            jenny.typeFormatter.formatRefType,
+		"formatType":               jenny.typeFormatter.formatFieldType,
+		"formatPathIndex":          jenny.typeFormatter.formatPathIndex,
+	}).RenderAsBytes("builders/builder.tmpl", data)
+}
+
+// builderName picks the C# class name for a builder. When the builder
+// targets a type from a different package we prefix it with the source
+// package name to avoid clashes (mirrors Java's foreign-builder
+// naming).
+func (jenny Builder) builderName(builder ast.Builder) string {
+	if builder.For.SelfRef.ReferredPkg != builder.Package {
+		return formatObjectName(builder.Package) + formatObjectName(builder.Name)
+	}
+	return formatObjectName(builder.Name)
+}
+
+// builderSignature picks the type that ends up in
+// `Cog.IBuilder<…>`. For composable-slot variants this becomes the
+// variant interface (e.g. `Cog.Variants.Dataquery`); otherwise it is
+// the target object's name. Imports are added as a side effect.
+func (jenny Builder) builderSignature(pkg string, obj ast.Object) string {
+	if obj.Type.IsDataqueryVariant() {
+		return fmt.Sprintf("Cog.Variants.%s", formatObjectName(obj.Type.ImplementedVariant()))
+	}
+	if pkg != obj.SelfRef.ReferredPkg {
+		jenny.imports.addPackage(obj.SelfRef.ReferredPkg)
+	}
+	return formatObjectName(obj.Name)
+}

--- a/internal/jennies/csharp/builder_test.go
+++ b/internal/jennies/csharp/builder_test.go
@@ -1,0 +1,44 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuilder_Generate verifies that the C# Builder jenny emits the
+// expected fluent builder classes for every fixture under
+// testdata/jennies/builders/. Goldens land under
+// testdata/jennies/builders/<case>/CSharpBuilder/.
+func TestBuilder_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite[languages.Context]{
+		TestDataRoot: "../../../testdata/jennies/builders",
+		Name:         "CSharpBuilder",
+	}
+
+	cfg := Config{GenerateBuilders: true}
+	cfg.InterpolateParameters(func(input string) string { return input })
+
+	language := New(cfg)
+	jenny := Builder{
+		config:          language.config,
+		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
+		apiRefCollector: common.NewAPIReferenceCollector(),
+	}
+
+	test.Run(t, func(tc *testutils.Test[languages.Context]) {
+		req := require.New(tc)
+
+		context := tc.UnmarshalJSONInput(testutils.BuildersContextInputFile)
+		context, err := languages.GenerateBuilderNilChecks(language, context)
+		req.NoError(err)
+
+		files, err := jenny.Generate(context)
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/csharp/converters.go
+++ b/internal/jennies/csharp/converters.go
@@ -1,0 +1,454 @@
+package csharp
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+// Converters emits one `<T>JsonConverter.cs` per disjunction-derived
+// struct, providing System.Text.Json (de)serialization for types that
+// can't be expressed as plain POCOs (sum types).
+//
+// Three disjunction shapes are supported, mirroring the Java jenny:
+//   - HintDisjunctionOfScalars         (e.g. `string | bool | int64`)
+//   - HintDiscriminatedDisjunctionOfRefs (e.g. `KindA | KindB`)
+//   - HintDisjunctionOfScalarsAndRefs   (e.g. `string | KindA`)
+type Converters struct {
+	config        Config
+	tmpl          *template.Template
+	context       languages.Context
+	typeFormatter *typeFormatter
+}
+
+func (jenny *Converters) JennyName() string {
+	return "CSharpJsonConverters"
+}
+
+func (jenny *Converters) Generate(context languages.Context) (codejen.Files, error) {
+	jenny.context = context
+	jenny.typeFormatter = newTypeFormatter(context, jenny.config, nil)
+
+	files := make(codejen.Files, 0)
+	for _, schema := range context.Schemas {
+		var iterErr error
+		schema.Objects.Iterate(func(_ string, object ast.Object) {
+			if iterErr != nil || !needsCustomConverter(object) {
+				return
+			}
+			f, err := jenny.genConverter(schema.Package, object)
+			if err != nil {
+				iterErr = err
+				return
+			}
+			files = append(files, *f)
+		})
+		if iterErr != nil {
+			return nil, iterErr
+		}
+	}
+	return files, nil
+}
+
+func (jenny *Converters) genConverter(pkg string, object ast.Object) (*codejen.File, error) {
+	namespace := jenny.config.formatNamespace(pkg)
+	pkgFolder := formatPackageName(pkg)
+	name := formatObjectName(object.Name)
+	filename := filepath.Join(jenny.config.ProjectPath, pkgFolder, name+"JsonConverter.cs")
+
+	// Imports collected during type formatting are discarded for now —
+	// converter templates emit their `using` directives statically.
+	tf := jenny.typeFormatter.withImports(newImportMap(jenny.config.NamespaceRoot, namespace))
+
+	t := object.Type
+	switch {
+	case t.HasHint(ast.HintDisjunctionOfScalars):
+		out, err := jenny.renderScalars(namespace, name, object, tf)
+		if err != nil {
+			return nil, err
+		}
+		return codejen.NewFile(filename, out, jenny), nil
+	case t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs):
+		out, err := jenny.renderRefs(namespace, name, object)
+		if err != nil {
+			return nil, err
+		}
+		return codejen.NewFile(filename, out, jenny), nil
+	case t.HasHint(ast.HintDisjunctionOfScalarsAndRefs):
+		out, err := jenny.renderScalarsAndRefs(namespace, name, object, tf)
+		if err != nil {
+			return nil, err
+		}
+		return codejen.NewFile(filename, out, jenny), nil
+	}
+	return nil, fmt.Errorf("converter requested for non-disjunction object %q", object.Name)
+}
+
+// scalarBranchModel describes one branch of a scalar disjunction for
+// the converter template. After grouping, multiple source branches
+// may share the same token (e.g. several numeric kinds → `Number`),
+// in which case the int/float branches are folded into the same case
+// body and dispatched at runtime via `reader.TryGetInt64`.
+type scalarBranchModel struct {
+	Field    string   // formatted C# field name on the parent struct
+	Tokens   []string // JsonTokenType members that select this branch (Utf8JsonReader path)
+	ReadExpr string   // expression used to read the value from the reader
+	// WriteAccess is appended to the field reference in the Write
+	// path, e.g. ".Value" so we serialise the underlying value of a
+	// `bool?` rather than the Nullable<bool> wrapper.
+	WriteAccess string
+	// Numeric grouping companions for the Utf8JsonReader path.
+	IntField    string
+	IntReadExpr string
+	IntWrite    string
+
+	// JsonElement-path fields, populated by scalarBranchesForElement
+	// for templates that read via a JsonDocument tree.
+	ValueKinds    []string // JsonValueKind members that select this branch
+	ElementGet    string   // method-call segment after `root.` (e.g. "GetString()")
+	IntElementGet string   // sibling Get* used for the integer branch in numeric grouping
+	DeserializeAs string   // when ElementGet is empty, deserialise raw JSON into this type
+}
+
+func (jenny *Converters) renderScalars(namespace, name string, object ast.Object, tf *typeFormatter) ([]byte, error) {
+	branches := scalarBranches(object.Type.AsStruct().Fields, tf)
+	return jenny.tmpl.RenderAsBytes("marshalling/disjunction_of_scalars.tmpl", map[string]any{
+		"Namespace": namespace,
+		"Name":      name,
+		"Branches":  branches,
+	})
+}
+
+// refCaseModel describes one entry in a discriminated-disjunction
+// switch.
+type refCaseModel struct {
+	Discriminator string // discriminator value, ignored when CatchAll is true
+	CatchAll      bool
+	Field         string
+	TypeRef       string // C# type expression for the branch
+}
+
+func (jenny *Converters) renderRefs(namespace, name string, object ast.Object) ([]byte, error) {
+	disjunctionHint, ok := object.Type.Hints[ast.HintDiscriminatedDisjunctionOfRefs].(ast.DisjunctionType)
+	if !ok {
+		return nil, fmt.Errorf("disjunction hint missing or of wrong type for %q", object.Name)
+	}
+
+	cases := make([]refCaseModel, 0, len(disjunctionHint.DiscriminatorMapping))
+	hasCatchAll := false
+	for discValue, refType := range disjunctionHint.DiscriminatorMapping {
+		isCatchAll := discValue == "cog_discriminator_catch_all"
+		if isCatchAll {
+			hasCatchAll = true
+		}
+		cases = append(cases, refCaseModel{
+			Discriminator: discValue,
+			CatchAll:      isCatchAll,
+			Field:         formatFieldName(refType),
+			TypeRef:       formatObjectName(refType),
+		})
+	}
+	// Catch-all entry sorts last so the `default:` label appears at the
+	// bottom of the switch; remaining entries sorted alphabetically for
+	// stable output across runs.
+	sort.SliceStable(cases, func(i, j int) bool {
+		if cases[i].CatchAll != cases[j].CatchAll {
+			return !cases[i].CatchAll
+		}
+		return cases[i].Discriminator < cases[j].Discriminator
+	})
+
+	return jenny.tmpl.RenderAsBytes("marshalling/disjunction_of_refs.tmpl", map[string]any{
+		"Namespace":     namespace,
+		"Name":          name,
+		"Discriminator": disjunctionHint.Discriminator,
+		"Cases":         cases,
+		"HasCatchAll":   hasCatchAll,
+	})
+}
+
+func (jenny *Converters) renderScalarsAndRefs(namespace, name string, object ast.Object, tf *typeFormatter) ([]byte, error) {
+	scalarFields := make([]ast.StructField, 0)
+	refFields := make([]ast.StructField, 0)
+	var anyField *ast.StructField
+	for _, field := range object.Type.AsStruct().Fields {
+		f := field
+		switch {
+		case f.Type.IsScalar() && f.Type.AsScalar().ScalarKind == ast.KindAny:
+			// `any`-typed branches are dispatched as a JSON-object
+			// catch-all rather than via TokenType, since `object`
+			// would otherwise shadow every ref branch.
+			anyField = &f
+		case f.Type.IsScalar() || f.Type.IsArray():
+			scalarFields = append(scalarFields, f)
+		case f.Type.IsRef():
+			refFields = append(refFields, f)
+		}
+	}
+
+	scalarBranches := scalarBranchesForElement(scalarFields, tf)
+
+	refModels := make([]refCaseModel, 0, len(refFields))
+	for _, field := range refFields {
+		refModels = append(refModels, refCaseModel{
+			Field:   formatFieldName(field.Name),
+			TypeRef: tf.formatFieldType(field.Type),
+		})
+	}
+
+	data := map[string]any{
+		"Namespace":      namespace,
+		"Name":           name,
+		"ScalarBranches": scalarBranches,
+		"RefBranches":    refModels,
+		"HasAnyBranch":   anyField != nil,
+	}
+	if anyField != nil {
+		data["AnyField"] = formatFieldName(anyField.Name)
+	}
+
+	return jenny.tmpl.RenderAsBytes("marshalling/disjunction_of_scalars_and_refs.tmpl", data)
+}
+
+// scalarBranches builds dispatch metadata for scalar/array fields.
+// Branches sharing the same JsonTokenType are merged so the generated
+// `switch` has unique case labels. Numeric kinds (`Number`) are
+// disambiguated at runtime via `reader.TryGetInt64`: an integer-typed
+// branch wins when present, with the floating-point branch as the
+// fallback. Subsequent same-token branches beyond the first two are
+// dropped — disjunctions of three+ numeric kinds aren't expressible
+// without losing information from JSON anyway.
+func scalarBranches(fields []ast.StructField, tf *typeFormatter) []scalarBranchModel {
+	out := make([]scalarBranchModel, 0, len(fields))
+	tokenIdx := make(map[string]int, len(fields))
+
+	for _, field := range fields {
+		fieldName := formatFieldName(field.Name)
+		var b scalarBranchModel
+		switch {
+		case field.Type.IsArray():
+			elementType := tf.formatFieldType(field.Type.AsArray().ValueType)
+			b = scalarBranchModel{
+				Field:    fieldName,
+				Tokens:   []string{"StartArray"},
+				ReadExpr: fmt.Sprintf("JsonSerializer.Deserialize<List<%s>>(ref reader, options)", elementType),
+			}
+		case field.Type.IsScalar():
+			tokens, readExpr, writeAccess := scalarBranchInfo(field.Type.AsScalar().ScalarKind)
+			b = scalarBranchModel{
+				Field:       fieldName,
+				Tokens:      tokens,
+				ReadExpr:    readExpr,
+				WriteAccess: writeAccess,
+			}
+		default:
+			continue
+		}
+
+		key := tokenKey(b.Tokens)
+		if idx, exists := tokenIdx[key]; exists && key == "Number" {
+			existing := out[idx]
+			// Promote the integer branch into the primary slot when the
+			// existing branch is a float, so `TryGetInt64` is checked
+			// first.
+			if isIntegerRead(b.ReadExpr) && !isIntegerRead(existing.ReadExpr) {
+				existing.IntField = b.Field
+				existing.IntReadExpr = b.ReadExpr
+				existing.IntWrite = b.WriteAccess
+			} else {
+				existing.IntField = existing.Field
+				existing.IntReadExpr = existing.ReadExpr
+				existing.IntWrite = existing.WriteAccess
+				existing.Field = b.Field
+				existing.ReadExpr = b.ReadExpr
+				existing.WriteAccess = b.WriteAccess
+			}
+			out[idx] = existing
+			continue
+		}
+		if _, exists := tokenIdx[key]; exists {
+			// Non-numeric duplicate (e.g. two `String` branches): drop
+			// silently — first branch wins.
+			continue
+		}
+		tokenIdx[key] = len(out)
+		out = append(out, b)
+	}
+	return out
+}
+
+func tokenKey(tokens []string) string {
+	if len(tokens) == 1 {
+		return tokens[0]
+	}
+	// Multi-token branches (e.g. True+False for bool) get a unique key.
+	key := tokens[0]
+	for _, t := range tokens[1:] {
+		key += "|" + t
+	}
+	return key
+}
+
+func isIntegerRead(expr string) bool {
+	switch expr {
+	case
+		"reader.GetSByte()",
+		"reader.GetByte()",
+		"reader.GetInt16()",
+		"reader.GetUInt16()",
+		"reader.GetInt32()",
+		"reader.GetUInt32()",
+		"reader.GetInt64()",
+		"reader.GetUInt64()":
+		return true
+	}
+	return false
+}
+
+// scalarBranchesForElement is the JsonElement-flavoured analogue of
+// scalarBranches. Used by the scalars-and-refs template, which reads
+// the input into a JsonDocument before dispatching.
+func scalarBranchesForElement(fields []ast.StructField, tf *typeFormatter) []scalarBranchModel {
+	out := make([]scalarBranchModel, 0, len(fields))
+	kindIdx := make(map[string]int, len(fields))
+
+	for _, field := range fields {
+		fieldName := formatFieldName(field.Name)
+		var b scalarBranchModel
+		switch {
+		case field.Type.IsArray():
+			elementType := tf.formatFieldType(field.Type.AsArray().ValueType)
+			b = scalarBranchModel{
+				Field:         fieldName,
+				ValueKinds:    []string{"Array"},
+				DeserializeAs: fmt.Sprintf("List<%s>", elementType),
+			}
+		case field.Type.IsScalar():
+			kinds, elemGet, writeAccess := elementBranchInfo(field.Type.AsScalar().ScalarKind)
+			b = scalarBranchModel{
+				Field:       fieldName,
+				ValueKinds:  kinds,
+				ElementGet:  elemGet,
+				WriteAccess: writeAccess,
+			}
+		default:
+			continue
+		}
+
+		key := tokenKey(b.ValueKinds)
+		if idx, exists := kindIdx[key]; exists && key == "Number" {
+			existing := out[idx]
+			if isIntegerElementGet(b.ElementGet) && !isIntegerElementGet(existing.ElementGet) {
+				existing.IntField = b.Field
+				existing.IntElementGet = b.ElementGet
+				existing.IntWrite = b.WriteAccess
+			} else {
+				existing.IntField = existing.Field
+				existing.IntElementGet = existing.ElementGet
+				existing.IntWrite = existing.WriteAccess
+				existing.Field = b.Field
+				existing.ElementGet = b.ElementGet
+				existing.WriteAccess = b.WriteAccess
+			}
+			out[idx] = existing
+			continue
+		}
+		if _, exists := kindIdx[key]; exists {
+			continue
+		}
+		kindIdx[key] = len(out)
+		out = append(out, b)
+	}
+	return out
+}
+
+// elementBranchInfo maps a scalar kind to the JsonValueKind(s) it
+// reacts to and the JsonElement getter used to read the value.
+func elementBranchInfo(kind ast.ScalarKind) (kinds []string, elementGet string, writeAccess string) {
+	switch kind {
+	case ast.KindString:
+		return []string{"String"}, "GetString()", ""
+	case ast.KindBool:
+		return []string{"True", "False"}, "GetBoolean()", ".Value"
+	case ast.KindInt8:
+		return []string{"Number"}, "GetSByte()", ".Value"
+	case ast.KindUint8, ast.KindBytes:
+		return []string{"Number"}, "GetByte()", ".Value"
+	case ast.KindInt16:
+		return []string{"Number"}, "GetInt16()", ".Value"
+	case ast.KindUint16:
+		return []string{"Number"}, "GetUInt16()", ".Value"
+	case ast.KindInt32:
+		return []string{"Number"}, "GetInt32()", ".Value"
+	case ast.KindUint32:
+		return []string{"Number"}, "GetUInt32()", ".Value"
+	case ast.KindInt64:
+		return []string{"Number"}, "GetInt64()", ".Value"
+	case ast.KindUint64:
+		return []string{"Number"}, "GetUInt64()", ".Value"
+	case ast.KindFloat32:
+		return []string{"Number"}, "GetSingle()", ".Value"
+	case ast.KindFloat64:
+		return []string{"Number"}, "GetDouble()", ".Value"
+	}
+	return nil, "", ""
+}
+
+func isIntegerElementGet(expr string) bool {
+	switch expr {
+	case
+		"GetSByte()",
+		"GetByte()",
+		"GetInt16()",
+		"GetUInt16()",
+		"GetInt32()",
+		"GetUInt32()",
+		"GetInt64()",
+		"GetUInt64()":
+		return true
+	}
+	return false
+}
+
+// scalarBranchInfo maps a scalar kind to the JsonTokenType(s) it
+// reacts to, the reader expression used to read it, and whether
+// `.Value` must be appended on writes (true for nullable value-types).
+func scalarBranchInfo(kind ast.ScalarKind) (tokens []string, readExpr string, writeAccess string) {
+	switch kind {
+	case ast.KindString:
+		return []string{"String"}, "reader.GetString()", ""
+	case ast.KindBool:
+		return []string{"True", "False"}, "reader.GetBoolean()", ".Value"
+	case ast.KindInt8:
+		return []string{"Number"}, "reader.GetSByte()", ".Value"
+	case ast.KindUint8, ast.KindBytes:
+		return []string{"Number"}, "reader.GetByte()", ".Value"
+	case ast.KindInt16:
+		return []string{"Number"}, "reader.GetInt16()", ".Value"
+	case ast.KindUint16:
+		return []string{"Number"}, "reader.GetUInt16()", ".Value"
+	case ast.KindInt32:
+		return []string{"Number"}, "reader.GetInt32()", ".Value"
+	case ast.KindUint32:
+		return []string{"Number"}, "reader.GetUInt32()", ".Value"
+	case ast.KindInt64:
+		return []string{"Number"}, "reader.GetInt64()", ".Value"
+	case ast.KindUint64:
+		return []string{"Number"}, "reader.GetUInt64()", ".Value"
+	case ast.KindFloat32:
+		return []string{"Number"}, "reader.GetSingle()", ".Value"
+	case ast.KindFloat64:
+		return []string{"Number"}, "reader.GetDouble()", ".Value"
+	case ast.KindAny:
+		return []string{"StartObject"}, "JsonSerializer.Deserialize<object>(ref reader, options)", ""
+	}
+	return []string{"None"}, "default!", ""
+}
+
+// sortRefCases left intentionally removed — sort.SliceStable is used
+// directly inside renderRefs.

--- a/internal/jennies/csharp/converters_test.go
+++ b/internal/jennies/csharp/converters_test.go
@@ -1,0 +1,46 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConverters_Generate covers the JsonConverter<T> output emitted
+// by the Converters jenny for the three supported disjunction shapes
+// (scalars, discriminated refs, scalars+refs).
+//
+// Reuses the IR fixtures under testdata/jennies/serializers/, which
+// are raw disjunctions that the compiler passes turn into structs.
+// Goldens land under testdata/jennies/serializers/<case>/CSharpJsonConverters/.
+func TestConverters_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
+		TestDataRoot: "../../../testdata/jennies/serializers",
+		Name:         "CSharpJsonConverters",
+	}
+
+	cfg := Config{GenerateJSONConverters: true}
+	cfg.InterpolateParameters(func(input string) string { return input })
+
+	tmpl := initTemplates(cfg, common.NewAPIReferenceCollector())
+	jenny := &Converters{config: cfg, tmpl: tmpl}
+	compilerPasses := New(cfg).CompilerPasses()
+
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
+		req := require.New(tc)
+
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		req.NoError(err)
+		req.Len(processedAsts, 1)
+
+		files, err := jenny.Generate(languages.Context{Schemas: processedAsts})
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/csharp/imports.go
+++ b/internal/jennies/csharp/imports.go
@@ -1,0 +1,83 @@
+package csharp
+
+import (
+	"sort"
+	"strings"
+)
+
+// importMap collects the set of `using` directives needed by a generated
+// C# source file. Imports are de-duplicated by namespace and emitted in
+// alphabetical order.
+//
+// `namespaceRoot` is prepended to schema-package imports so they are
+// fully qualified (e.g. "Dashboard" -> "Grafana.Foundation.Dashboard").
+// Built-in BCL namespaces (anything beginning with `System` or
+// `System.*`) are passed through unchanged.
+type importMap struct {
+	namespaceRoot string
+	currentNs     string // namespace of the file being generated; never imported
+	namespaces    map[string]struct{}
+}
+
+func newImportMap(namespaceRoot string, currentNs string) *importMap {
+	return &importMap{
+		namespaceRoot: namespaceRoot,
+		currentNs:     currentNs,
+		namespaces:    make(map[string]struct{}),
+	}
+}
+
+// addPackage records a `using` for a schema package (the namespace root
+// is applied automatically). A no-op when the package corresponds to
+// the file's own namespace.
+func (im *importMap) addPackage(pkg string) {
+	if pkg == "" {
+		return
+	}
+	ns := qualifyNamespace(im.namespaceRoot, formatPackageName(pkg))
+	if ns == im.currentNs {
+		return
+	}
+	im.namespaces[ns] = struct{}{}
+}
+
+// addNamespace records a `using` for a fully-qualified namespace (e.g.
+// "System.Text.Json.Serialization"). No prefixing is performed.
+func (im *importMap) addNamespace(ns string) {
+	if ns == "" || ns == im.currentNs {
+		return
+	}
+	im.namespaces[ns] = struct{}{}
+}
+
+// String renders the collected imports as a sorted block of `using`
+// statements terminated by a trailing newline. Returns the empty
+// string when no imports were recorded.
+func (im *importMap) String() string {
+	if len(im.namespaces) == 0 {
+		return ""
+	}
+
+	statements := make([]string, 0, len(im.namespaces))
+	for ns := range im.namespaces {
+		statements = append(statements, "using "+ns+";")
+	}
+	sort.Strings(statements)
+
+	return strings.Join(statements, "\n") + "\n"
+}
+
+// qualifyNamespace prefixes a schema-package import with the configured
+// namespace root, leaving BCL namespaces (System*) untouched.
+func qualifyNamespace(namespaceRoot string, pkg string) string {
+	if pkg == "" {
+		return pkg
+	}
+	if pkg == "System" || strings.HasPrefix(pkg, "System.") {
+		return pkg
+	}
+	if namespaceRoot == "" {
+		return pkg
+	}
+	return namespaceRoot + "." + pkg
+}

--- a/internal/jennies/csharp/jennies.go
+++ b/internal/jennies/csharp/jennies.go
@@ -1,0 +1,162 @@
+package csharp
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/ast/compiler"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/tools"
+)
+
+const LanguageRef = "csharp"
+
+// defaultNamespaceRoot is used when Config.NamespaceRoot is empty.
+const defaultNamespaceRoot = "Grafana.Foundation"
+
+// Config holds the C# code-generation options.
+//
+// The C# jenny targets .NET 10 with nullable reference types enabled and
+// uses System.Text.Json for (de)serialization. Generated files are laid out
+// as <ProjectPath>/<Package>/<Type>.cs and grouped under a single
+// `<NamespaceRoot>.csproj` project for v1 (see plan: Phase 6 may split it
+// into per-package projects later).
+type Config struct {
+	// ProjectPath is the on-disk root for generated sources. Computed from
+	// NamespaceRoot during InterpolateParameters; not user-configurable.
+	ProjectPath string `yaml:"-"`
+
+	// NamespaceRoot is the C# namespace prefix applied to every generated
+	// package. Each schema package becomes `<NamespaceRoot>.<Package>`.
+	// Defaults to "Grafana.Foundation" when empty.
+	NamespaceRoot string `yaml:"namespace_root"`
+
+	// OverridesTemplatesDirectories holds a list of directories containing
+	// templates defining blocks used to override parts of
+	// builders/types/....
+	OverridesTemplatesDirectories []string `yaml:"overrides_templates"`
+	// OverridesTemplatesFS holds an embedded filesystem containing
+	// override templates.
+	OverridesTemplatesFS fs.FS `yaml:"-"`
+	// OverridesTemplateFuncs holds additional template functions to be
+	// injected into the override templates.
+	OverridesTemplateFuncs map[string]any `yaml:"-"`
+
+	// ExtraFilesTemplatesDirectories holds a list of directories
+	// containing templates describing files to be added to the generated
+	// output.
+	ExtraFilesTemplatesDirectories []string `yaml:"extra_files_templates"`
+
+	// ExtraFilesTemplatesData holds additional data to be injected into
+	// the templates described in ExtraFilesTemplatesDirectories.
+	ExtraFilesTemplatesData map[string]string `yaml:"-"`
+
+	// SkipRuntime disables runtime-related code generation when enabled.
+	// Builders can NOT be generated with this flag turned on, as they
+	// rely on the runtime to function.
+	SkipRuntime bool `yaml:"skip_runtime"`
+
+	// GenerateEquality controls the generation of `Equals()` and
+	// `GetHashCode()` overrides on types.
+	GenerateEquality bool `yaml:"generate_equality"`
+
+	// GenerateJSONConverters controls the generation of
+	// System.Text.Json `JsonConverter<T>` types alongside generated
+	// classes. Required for disjunction/discriminator support.
+	GenerateJSONConverters bool `yaml:"generate_json_converters"`
+
+	GenerateBuilders   bool `yaml:"-"`
+	GenerateConverters bool `yaml:"-"`
+}
+
+// namespaceRoot returns the configured namespace root or the default.
+func (config *Config) namespaceRoot() string {
+	if config.NamespaceRoot != "" {
+		return config.NamespaceRoot
+	}
+	return defaultNamespaceRoot
+}
+
+// formatNamespace converts a schema package name into a fully-qualified C#
+// namespace, e.g. "dashboard" -> "Grafana.Foundation.Dashboard".
+func (config *Config) formatNamespace(pkg string) string {
+	return fmt.Sprintf("%s.%s", config.namespaceRoot(), pascalCase(pkg))
+}
+
+func (config *Config) InterpolateParameters(interpolator func(input string) string) {
+	config.NamespaceRoot = interpolator(config.NamespaceRoot)
+	config.OverridesTemplatesDirectories = tools.Map(config.OverridesTemplatesDirectories, interpolator)
+	config.ExtraFilesTemplatesDirectories = tools.Map(config.ExtraFilesTemplatesDirectories, interpolator)
+	// Sources land under src/<NamespaceRoot-as-folders>/ so a future
+	// switch to per-package .csproj projects is a no-op for source paths.
+	config.ProjectPath = filepath.Join("src", strings.ReplaceAll(config.namespaceRoot(), ".", string(filepath.Separator)))
+}
+
+func (config *Config) MergeWithGlobal(global languages.Config) Config {
+	newConfig := *config
+	newConfig.GenerateBuilders = global.Builders
+	// Converters are disabled at the global level for v1, mirroring the
+	// Java jenny. Re-enable once Phase 5 is implemented.
+	newConfig.GenerateConverters = false
+	return newConfig
+}
+
+type Language struct {
+	config          Config
+	apiRefCollector *common.APIReferenceCollector
+}
+
+func New(config Config) *Language {
+	return &Language{
+		config:          config,
+		apiRefCollector: common.NewAPIReferenceCollector(),
+	}
+}
+
+func (language *Language) Name() string {
+	return LanguageRef
+}
+
+func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
+	_ = language.config.MergeWithGlobal(globalConfig)
+
+	jenny := codejen.JennyListWithNamer(func(_ languages.Context) string {
+		return LanguageRef
+	})
+	// Phase 1: scaffold only — no jennies are registered yet. Subsequent
+	// phases (raw types, marshalling, builders) will populate this list.
+	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+
+	return jenny
+}
+
+func (language *Language) CompilerPasses() compiler.Passes {
+	// Mirror Java's pass list as the starting point — C# shares the same
+	// type-system constraints (nominal, nullable refs, no untagged unions).
+	return compiler.Passes{
+		&compiler.AnonymousStructsToNamed{},
+		&compiler.NotRequiredFieldAsNullableType{},
+		&compiler.DisjunctionWithNullToOptional{},
+		&compiler.DisjunctionOfConstantsToEnum{},
+		&compiler.AnonymousEnumToExplicitType{},
+		&compiler.FlattenDisjunctions{},
+		&compiler.DisjunctionInferMapping{},
+		&compiler.UndiscriminatedDisjunctionToAny{},
+		&compiler.DisjunctionToType{},
+		&compiler.RemoveIntersections{},
+		&compiler.InlineObjectsWithTypes{InlineTypes: []ast.Kind{ast.KindScalar, ast.KindMap, ast.KindArray}},
+	}
+}
+
+func (language *Language) NullableKinds() languages.NullableConfig {
+	return languages.NullableConfig{
+		Kinds:              []ast.Kind{ast.KindMap, ast.KindArray, ast.KindRef, ast.KindStruct},
+		ProtectArrayAppend: true,
+		AnyIsNullable:      true,
+	}
+}

--- a/internal/jennies/csharp/jennies.go
+++ b/internal/jennies/csharp/jennies.go
@@ -123,13 +123,15 @@ func (language *Language) Name() string {
 }
 
 func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyList[languages.Context] {
-	_ = language.config.MergeWithGlobal(globalConfig)
+	config := language.config.MergeWithGlobal(globalConfig)
+	tmpl := initTemplates(config, language.apiRefCollector)
 
 	jenny := codejen.JennyListWithNamer(func(_ languages.Context) string {
 		return LanguageRef
 	})
-	// Phase 1: scaffold only — no jennies are registered yet. Subsequent
-	// phases (raw types, marshalling, builders) will populate this list.
+	jenny.AppendOneToMany(
+		RawTypes{config: config, tmpl: tmpl},
+	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 
 	return jenny

--- a/internal/jennies/csharp/jennies.go
+++ b/internal/jennies/csharp/jennies.go
@@ -132,6 +132,12 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	jenny.AppendOneToMany(
 		RawTypes{config: config, tmpl: tmpl},
 		common.If(config.GenerateJSONConverters && !config.SkipRuntime, &Converters{config: config, tmpl: tmpl}),
+		common.If(config.GenerateBuilders && !config.SkipRuntime, Runtime{config: config, tmpl: tmpl}),
+		common.If(config.GenerateBuilders && !config.SkipRuntime, Builder{
+			config:          config,
+			tmpl:            tmpl,
+			apiRefCollector: language.apiRefCollector,
+		}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/csharp/jennies.go
+++ b/internal/jennies/csharp/jennies.go
@@ -131,6 +131,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	})
 	jenny.AppendOneToMany(
 		RawTypes{config: config, tmpl: tmpl},
+		common.If(config.GenerateJSONConverters && !config.SkipRuntime, &Converters{config: config, tmpl: tmpl}),
 	)
 	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
 

--- a/internal/jennies/csharp/jsonmarshalling.go
+++ b/internal/jennies/csharp/jsonmarshalling.go
@@ -1,0 +1,97 @@
+package csharp
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+// jsonMarshaller centralises System.Text.Json related code generation
+// hooks. Activated only when Config.GenerateJSONConverters is true; all
+// methods return the empty string / no-op otherwise so callers can use
+// them unconditionally.
+type jsonMarshaller struct {
+	config Config
+}
+
+func newJSONMarshaller(config Config) jsonMarshaller {
+	return jsonMarshaller{config: config}
+}
+
+// enabled reports whether JSON-marshalling code should be emitted.
+func (j jsonMarshaller) enabled() bool {
+	return j.config.GenerateJSONConverters
+}
+
+// fieldPropertyAttribute returns the `[JsonPropertyName("origName")]`
+// attribute for a struct field, ensuring round-tripping with the
+// original (typically camelCase) JSON name even though our generated
+// fields are PascalCased.
+func (j jsonMarshaller) fieldPropertyAttribute(field ast.StructField) string {
+	if !j.enabled() {
+		return ""
+	}
+	return fmt.Sprintf("[JsonPropertyName(%q)]", field.Name)
+}
+
+// classConverterAttribute returns `[JsonConverter(typeof(<T>JsonConverter))]`
+// for disjunction-derived structs that need a custom converter, or the
+// empty string otherwise. The Phase 4 builder layer will emit the
+// matching JsonConverter<T> class via the Converters jenny.
+func (j jsonMarshaller) classConverterAttribute(object ast.Object) string {
+	if !j.enabled() || !needsCustomConverter(object) {
+		return ""
+	}
+	return fmt.Sprintf("[JsonConverter(typeof(%sJsonConverter))]", formatObjectName(object.Name))
+}
+
+// enumConverterAttribute returns the `[JsonConverter]` attribute for
+// string enums so that values are serialized as their original string
+// payload (declared via [JsonStringEnumMemberName("...")]).
+func (j jsonMarshaller) enumConverterAttribute(name string) string {
+	if !j.enabled() {
+		return ""
+	}
+	return fmt.Sprintf("[JsonConverter(typeof(JsonStringEnumConverter<%s>))]", name)
+}
+
+// needsCustomConverter reports whether the type requires a generated
+// JsonConverter<T> alongside its class definition.
+//
+// We mirror the Java jenny's set of disjunction hints: scalar-only,
+// discriminated-refs, and the scalars+refs combination.
+func needsCustomConverter(object ast.Object) bool {
+	if !object.Type.IsStruct() {
+		return false
+	}
+	t := object.Type
+	return t.HasHint(ast.HintDisjunctionOfScalars) ||
+		t.HasHint(ast.HintDiscriminatedDisjunctionOfRefs) ||
+		t.HasHint(ast.HintDisjunctionOfScalarsAndRefs)
+}
+
+// disjunctionFieldType wraps a value-type scalar in `T?` so a "branch
+// not selected" can be distinguished from "branch holds the zero value".
+// Reference types are already nullable under NRT and need no change.
+func disjunctionFieldType(typeExpr string, fieldType ast.Type) string {
+	if !isCSharpValueType(fieldType) {
+		return typeExpr
+	}
+	return typeExpr + "?"
+}
+
+// isCSharpValueType reports whether the C# type emitted for `t` is a
+// value type (and therefore needs an explicit `?` suffix to be
+// nullable).
+func isCSharpValueType(t ast.Type) bool {
+	if !t.IsScalar() {
+		return false
+	}
+	switch t.AsScalar().ScalarKind {
+	case ast.KindString, ast.KindAny, ast.KindBytes:
+		return false
+	default:
+		// All numeric scalars (incl. bool) are value types.
+		return true
+	}
+}

--- a/internal/jennies/csharp/rawtypes.go
+++ b/internal/jennies/csharp/rawtypes.go
@@ -1,0 +1,313 @@
+package csharp
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+// RawTypes is the C# equivalent of [java.RawTypes]: it walks every
+// schema in the input context and emits one `.cs` file per object
+// (struct, enum, ref, intersection) plus an aggregated `Constants.cs`
+// per package collecting concrete scalar values.
+//
+// Phase 2 scope: structs, enums, intersections-as-classes,
+// concrete-scalar constants. Disjunctions, JSON converters and
+// equality overrides are deliberately deferred.
+type RawTypes struct {
+	config Config
+	tmpl   *template.Template
+
+	// Reset per-file in genFilesForObject.
+	imports       *importMap
+	typeFormatter *typeFormatter
+}
+
+func (jenny RawTypes) JennyName() string {
+	return "CSharpRawTypes"
+}
+
+func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
+	files := make(codejen.Files, 0)
+	jenny.typeFormatter = newTypeFormatter(context, jenny.config, nil)
+
+	for _, schema := range context.Schemas {
+		out, err := jenny.genFilesForSchema(schema)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, out...)
+	}
+
+	return files, nil
+}
+
+func (jenny RawTypes) genFilesForSchema(schema *ast.Schema) (codejen.Files, error) {
+	files := make(codejen.Files, 0)
+	scalars := make(map[string]ast.ScalarType)
+	pkgFolder := formatPackageName(schema.Package)
+	namespace := jenny.config.formatNamespace(schema.Package)
+
+	var iterErr error
+	schema.Objects.Iterate(func(_ string, object ast.Object) {
+		if iterErr != nil {
+			return
+		}
+
+		// Concrete scalar definitions are aggregated into a single
+		// Constants.cs per package.
+		if object.Type.IsScalar() {
+			if object.Type.AsScalar().IsConcrete() {
+				scalars[object.Name] = object.Type.AsScalar()
+			}
+			return
+		}
+
+		output, err := jenny.generateObject(namespace, object)
+		if err != nil {
+			iterErr = err
+			return
+		}
+		if output == nil {
+			return
+		}
+
+		filename := filepath.Join(jenny.config.ProjectPath, pkgFolder, formatObjectName(object.Name)+".cs")
+		files = append(files, *codejen.NewFile(filename, output, jenny))
+	})
+	if iterErr != nil {
+		return nil, iterErr
+	}
+
+	if len(scalars) > 0 {
+		output, err := jenny.formatConstants(namespace, scalars)
+		if err != nil {
+			return nil, err
+		}
+		filename := filepath.Join(jenny.config.ProjectPath, pkgFolder, "Constants.cs")
+		files = append(files, *codejen.NewFile(filename, output, jenny))
+	}
+
+	return files, nil
+}
+
+func (jenny RawTypes) generateObject(namespace string, object ast.Object) ([]byte, error) {
+	switch object.Type.Kind {
+	case ast.KindStruct:
+		return jenny.formatStruct(namespace, object)
+	case ast.KindEnum:
+		return jenny.formatEnum(namespace, object)
+	case ast.KindRef:
+		return jenny.formatRefAlias(namespace, object)
+	case ast.KindIntersection:
+		return jenny.formatIntersection(namespace, object)
+	}
+	return nil, nil
+}
+
+// renderClass renders the class template against the given model.
+// All field/arg type expressions in `data` must already be formatted
+// strings — the template no longer calls formatType so that imports
+// are guaranteed to be populated before the {{ .Imports }} block runs.
+func (jenny RawTypes) renderClass(data classTemplate) ([]byte, error) {
+	return jenny.tmpl.RenderAsBytes("types/class.tmpl", data)
+}
+
+func (jenny RawTypes) formatStruct(namespace string, object ast.Object) ([]byte, error) {
+	jenny.imports = newImportMap(jenny.config.namespaceRoot(), namespace)
+	jenny.typeFormatter = jenny.typeFormatter.withImports(jenny.imports)
+
+	fields := object.Type.AsStruct().Fields
+	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, nil, fields)
+
+	return jenny.renderClass(cls)
+}
+
+// formatRefAlias emits a thin C# subclass for a top-level type that is
+// just a ref to another type. Mirrors the Java jenny's behaviour.
+func (jenny RawTypes) formatRefAlias(namespace string, object ast.Object) ([]byte, error) {
+	jenny.imports = newImportMap(jenny.config.namespaceRoot(), namespace)
+	jenny.typeFormatter = jenny.typeFormatter.withImports(jenny.imports)
+
+	ref := object.Type.AsRef()
+	parent := jenny.typeFormatter.formatReference(ref)
+
+	cls := classTemplate{
+		Namespace: namespace,
+		Name:      formatObjectName(object.Name),
+		Imports:   jenny.imports,
+		Comments:  object.Comments,
+		Extends:   []string{parent},
+	}
+	return jenny.renderClass(cls)
+}
+
+func (jenny RawTypes) formatIntersection(namespace string, object ast.Object) ([]byte, error) {
+	jenny.imports = newImportMap(jenny.config.namespaceRoot(), namespace)
+	jenny.typeFormatter = jenny.typeFormatter.withImports(jenny.imports)
+
+	intersection := object.Type.AsIntersection()
+	extends := make([]string, 0)
+	fields := make([]ast.StructField, 0)
+	inheritedFieldNames := make(map[string]bool)
+
+	for _, branch := range intersection.Branches {
+		if branch.IsRef() {
+			if obj, found := jenny.typeFormatter.context.LocateObjectByRef(branch.AsRef()); found && obj.Type.IsStruct() {
+				for _, field := range obj.Type.AsStruct().Fields {
+					inheritedFieldNames[field.Name] = true
+				}
+			}
+		}
+	}
+
+	for _, branch := range intersection.Branches {
+		switch branch.Kind {
+		case ast.KindRef:
+			extends = append(extends, jenny.typeFormatter.formatReference(branch.AsRef()))
+		case ast.KindStruct:
+			for _, field := range branch.AsStruct().Fields {
+				if inheritedFieldNames[field.Name] {
+					continue
+				}
+				fields = append(fields, field)
+			}
+		}
+	}
+
+	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, extends, fields)
+	return jenny.renderClass(cls)
+}
+
+// buildClassTemplate populates the template-facing classTemplate struct
+// from a struct's fields, generating the field declarations and the
+// two constructors' assignment lists.
+func (jenny RawTypes) buildClassTemplate(namespace string, name string, comments []string, extends []string, fields []ast.StructField) classTemplate {
+	clsFields := make([]classField, 0, len(fields))
+	defaults := make([]assignment, 0, len(fields))
+	args := make([]classArg, 0, len(fields))
+	argAssignments := make([]assignment, 0, len(fields))
+
+	for _, field := range fields {
+		fieldName := formatFieldName(field.Name)
+		argName := formatArgName(field.Name)
+		typeExpr := jenny.typeFormatter.formatFieldType(field.Type)
+
+		clsFields = append(clsFields, classField{
+			Name:     fieldName,
+			Type:     typeExpr,
+			Comments: field.Comments,
+		})
+
+		// Default-constructor assignment: explicit default, or empty value.
+		var defaultExpr string
+		if field.Type.Default != nil {
+			defaultExpr = jenny.formatDefault(field.Type, field.Type.Default)
+		} else if field.Required && !field.Type.Nullable {
+			defaultExpr = jenny.typeFormatter.emptyValueForType(field.Type)
+		}
+		if defaultExpr != "" {
+			defaults = append(defaults, assignment{Name: fieldName, Value: defaultExpr})
+		}
+
+		args = append(args, classArg{Name: argName, Type: typeExpr})
+		argAssignments = append(argAssignments, assignment{
+			Name:         fieldName,
+			ValueFromArg: argName,
+		})
+	}
+
+	return classTemplate{
+		Namespace:          namespace,
+		Name:               name,
+		Imports:            jenny.imports,
+		Comments:           comments,
+		Extends:            extends,
+		Fields:             clsFields,
+		DefaultAssignments: defaults,
+		HasArgsConstructor: len(args) > 0,
+		Args:               args,
+		ArgAssignments:     argAssignments,
+	}
+}
+
+// formatDefault renders a literal expression for a field's default value.
+// Only scalar defaults are supported in Phase 2 — refs and enums fall
+// back to the type's "empty" value.
+func (jenny RawTypes) formatDefault(t ast.Type, value any) string {
+	if t.IsScalar() {
+		return formatScalarValue(t.AsScalar().ScalarKind, value)
+	}
+	return jenny.typeFormatter.emptyValueForType(t)
+}
+
+func (jenny RawTypes) formatEnum(namespace string, object ast.Object) ([]byte, error) {
+	enumDef := object.Type.AsEnum()
+	if len(enumDef.Values) == 0 {
+		return nil, nil
+	}
+
+	isString := enumDef.Values[0].Type.IsScalar() && enumDef.Values[0].Type.AsScalar().ScalarKind == ast.KindString
+
+	values := make([]EnumValue, 0, len(enumDef.Values))
+	for _, v := range enumDef.Values {
+		var raw any
+		if isString {
+			s, _ := v.Value.(string)
+			raw = s
+		} else {
+			raw = formatScalarValue(v.Type.AsScalar().ScalarKind, v.Value)
+		}
+		values = append(values, EnumValue{
+			Name:     formatEnumMemberName(v.Name),
+			RawValue: raw,
+		})
+	}
+
+	data := enumTemplate{
+		Namespace:       namespace,
+		Name:            formatObjectName(object.Name),
+		Comments:        object.Comments,
+		IsString:        isString,
+		NeedsEnumMember: isString,
+		Values:          values,
+	}
+
+	return jenny.tmpl.RenderAsBytes("types/enum.tmpl", data)
+}
+
+func (jenny RawTypes) formatConstants(namespace string, scalars map[string]ast.ScalarType) ([]byte, error) {
+	consts := make([]constant, 0, len(scalars))
+	for name, scalar := range scalars {
+		consts = append(consts, constant{
+			Name:  name,
+			Type:  formatScalarType(scalar),
+			Value: formatScalarValue(scalar.ScalarKind, scalar.Value),
+		})
+	}
+	sort.SliceStable(consts, func(i, j int) bool { return consts[i].Name < consts[j].Name })
+
+	return jenny.tmpl.RenderAsBytes("types/constants.tmpl", constantsTemplate{
+		Namespace: namespace,
+		Name:      "Constants",
+		Constants: consts,
+	})
+}
+
+// formatEnumMemberName converts a raw enum-value name into a valid C#
+// PascalCased identifier.
+func formatEnumMemberName(name string) string {
+	if name == "" {
+		return "Default"
+	}
+	formatted := pascalCase(name)
+	// Identifier cannot start with a digit.
+	if formatted == "" || (formatted[0] >= '0' && formatted[0] <= '9') {
+		formatted = "V" + formatted
+	}
+	return escapeVarName(formatted)
+}

--- a/internal/jennies/csharp/rawtypes.go
+++ b/internal/jennies/csharp/rawtypes.go
@@ -1,6 +1,7 @@
 package csharp
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -23,8 +24,9 @@ type RawTypes struct {
 	tmpl   *template.Template
 
 	// Reset per-file in genFilesForObject.
-	imports       *importMap
-	typeFormatter *typeFormatter
+	imports        *importMap
+	typeFormatter  *typeFormatter
+	jsonMarshaller jsonMarshaller
 }
 
 func (jenny RawTypes) JennyName() string {
@@ -34,6 +36,7 @@ func (jenny RawTypes) JennyName() string {
 func (jenny RawTypes) Generate(context languages.Context) (codejen.Files, error) {
 	files := make(codejen.Files, 0)
 	jenny.typeFormatter = newTypeFormatter(context, jenny.config, nil)
+	jenny.jsonMarshaller = newJSONMarshaller(jenny.config)
 
 	for _, schema := range context.Schemas {
 		out, err := jenny.genFilesForSchema(schema)
@@ -122,7 +125,7 @@ func (jenny RawTypes) formatStruct(namespace string, object ast.Object) ([]byte,
 	jenny.typeFormatter = jenny.typeFormatter.withImports(jenny.imports)
 
 	fields := object.Type.AsStruct().Fields
-	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, nil, fields)
+	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, nil, fields, object)
 
 	return jenny.renderClass(cls)
 }
@@ -179,39 +182,66 @@ func (jenny RawTypes) formatIntersection(namespace string, object ast.Object) ([
 		}
 	}
 
-	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, extends, fields)
+	cls := jenny.buildClassTemplate(namespace, formatObjectName(object.Name), object.Comments, extends, fields, object)
 	return jenny.renderClass(cls)
 }
 
 // buildClassTemplate populates the template-facing classTemplate struct
 // from a struct's fields, generating the field declarations and the
 // two constructors' assignment lists.
-func (jenny RawTypes) buildClassTemplate(namespace string, name string, comments []string, extends []string, fields []ast.StructField) classTemplate {
+//
+// `object` is threaded through so the model can pick up
+// disjunction-derived hints (used to nullable-ify value-type scalars
+// and skip default initialization).
+func (jenny RawTypes) buildClassTemplate(namespace string, name string, comments []string, extends []string, fields []ast.StructField, object ast.Object) classTemplate {
 	clsFields := make([]classField, 0, len(fields))
 	defaults := make([]assignment, 0, len(fields))
 	args := make([]classArg, 0, len(fields))
 	argAssignments := make([]assignment, 0, len(fields))
 
+	isDisjunctionStruct := needsCustomConverter(object)
+	jsonEnabled := jenny.jsonMarshaller.enabled()
+	// Nullable value-type fields and the suppression of default
+	// assignments are only required when we'll emit a custom
+	// JsonConverter that relies on `null` as the branch sentinel. With
+	// JSON marshalling disabled we keep the plain POCO shape so the
+	// type stays usable as a regular DTO.
+	disjunctionPOCO := isDisjunctionStruct && jsonEnabled
+
 	for _, field := range fields {
 		fieldName := formatFieldName(field.Name)
 		argName := formatArgName(field.Name)
 		typeExpr := jenny.typeFormatter.formatFieldType(field.Type)
+		if disjunctionPOCO {
+			typeExpr = disjunctionFieldType(typeExpr, field.Type)
+		}
+
+		var attrs []string
+		if jsonEnabled {
+			if attr := jenny.jsonMarshaller.fieldPropertyAttribute(field); attr != "" {
+				attrs = append(attrs, attr)
+			}
+		}
 
 		clsFields = append(clsFields, classField{
-			Name:     fieldName,
-			Type:     typeExpr,
-			Comments: field.Comments,
+			Name:       fieldName,
+			Type:       typeExpr,
+			Comments:   field.Comments,
+			Attributes: attrs,
 		})
 
-		// Default-constructor assignment: explicit default, or empty value.
-		var defaultExpr string
-		if field.Type.Default != nil {
-			defaultExpr = jenny.formatDefault(field.Type, field.Type.Default)
-		} else if field.Required && !field.Type.Nullable {
-			defaultExpr = jenny.typeFormatter.emptyValueForType(field.Type)
-		}
-		if defaultExpr != "" {
-			defaults = append(defaults, assignment{Name: fieldName, Value: defaultExpr})
+		// Disjunction-derived structs leave fields un-initialised so
+		// that `null` is the unambiguous "branch not selected" marker.
+		if !disjunctionPOCO {
+			var defaultExpr string
+			if field.Type.Default != nil {
+				defaultExpr = jenny.formatDefault(field.Type, field.Type.Default)
+			} else if field.Required && !field.Type.Nullable {
+				defaultExpr = jenny.typeFormatter.emptyValueForType(field.Type)
+			}
+			if defaultExpr != "" {
+				defaults = append(defaults, assignment{Name: fieldName, Value: defaultExpr})
+			}
 		}
 
 		args = append(args, classArg{Name: argName, Type: typeExpr})
@@ -221,11 +251,24 @@ func (jenny RawTypes) buildClassTemplate(namespace string, name string, comments
 		})
 	}
 
+	var classAttrs []string
+	if jsonEnabled {
+		if attr := jenny.jsonMarshaller.classConverterAttribute(object); attr != "" {
+			classAttrs = append(classAttrs, attr)
+			jenny.imports.addNamespace("System.Text.Json.Serialization")
+		}
+		if len(clsFields) > 0 {
+			// At least one [JsonPropertyName] attribute will be emitted.
+			jenny.imports.addNamespace("System.Text.Json.Serialization")
+		}
+	}
+
 	return classTemplate{
 		Namespace:          namespace,
 		Name:               name,
 		Imports:            jenny.imports,
 		Comments:           comments,
+		ClassAttributes:    classAttrs,
 		Extends:            extends,
 		Fields:             clsFields,
 		DefaultAssignments: defaults,
@@ -268,13 +311,24 @@ func (jenny RawTypes) formatEnum(namespace string, object ast.Object) ([]byte, e
 		})
 	}
 
+	var enumImports fmt.Stringer
+	var enumAttrs []string
+	if isString && jenny.jsonMarshaller.enabled() {
+		im := newImportMap(jenny.config.namespaceRoot(), namespace)
+		im.addNamespace("System.Text.Json.Serialization")
+		enumImports = im
+		enumAttrs = append(enumAttrs, jenny.jsonMarshaller.enumConverterAttribute(formatObjectName(object.Name)))
+	}
+
 	data := enumTemplate{
-		Namespace:       namespace,
-		Name:            formatObjectName(object.Name),
-		Comments:        object.Comments,
-		IsString:        isString,
-		NeedsEnumMember: isString,
-		Values:          values,
+		Namespace:      namespace,
+		Name:           formatObjectName(object.Name),
+		Comments:       object.Comments,
+		IsString:       isString,
+		Imports:        enumImports,
+		EnumAttributes: enumAttrs,
+		JSONEnabled:    jenny.jsonMarshaller.enabled(),
+		Values:         values,
 	}
 
 	return jenny.tmpl.RenderAsBytes("types/enum.tmpl", data)

--- a/internal/jennies/csharp/rawtypes_test.go
+++ b/internal/jennies/csharp/rawtypes_test.go
@@ -1,0 +1,41 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawTypes_Generate(t *testing.T) {
+	test := testutils.GoldenFilesTestSuite[ast.Schema]{
+		TestDataRoot: "../../../testdata/jennies/rawtypes",
+		Name:         "CSharpRawTypes",
+	}
+
+	cfg := Config{}
+	cfg.InterpolateParameters(func(input string) string { return input })
+
+	jenny := RawTypes{config: cfg, tmpl: initTemplates(cfg, common.NewAPIReferenceCollector())}
+	compilerPasses := New(cfg).CompilerPasses()
+
+	test.Run(t, func(tc *testutils.Test[ast.Schema]) {
+		req := require.New(tc)
+
+		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
+		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		req.NoError(err)
+
+		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
+
+		files, err := jenny.Generate(languages.Context{
+			Schemas: processedAsts,
+		})
+		req.NoError(err)
+
+		tc.WriteFiles(files)
+	})
+}

--- a/internal/jennies/csharp/runtime.go
+++ b/internal/jennies/csharp/runtime.go
@@ -1,0 +1,34 @@
+package csharp
+
+import (
+	"path/filepath"
+
+	"github.com/grafana/codejen"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+// Runtime emits the small set of runtime helpers that generated
+// builders depend on (currently just `Cog.IBuilder<T>`). The runtime
+// lives under `<ProjectPath>/Cog/` in the `<NamespaceRoot>.Cog`
+// namespace.
+type Runtime struct {
+	config Config
+	tmpl   *template.Template
+}
+
+func (jenny Runtime) JennyName() string {
+	return "CSharpRuntime"
+}
+
+func (jenny Runtime) Generate(_ languages.Context) (codejen.Files, error) {
+	builder, err := jenny.tmpl.RenderAsBytes("runtime/builder.tmpl", map[string]any{
+		"Namespace": jenny.config.formatNamespace("cog"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return codejen.Files{
+		*codejen.NewFile(filepath.Join(jenny.config.ProjectPath, "Cog", "IBuilder.cs"), builder, jenny),
+	}, nil
+}

--- a/internal/jennies/csharp/runtime_test.go
+++ b/internal/jennies/csharp/runtime_test.go
@@ -1,0 +1,33 @@
+package csharp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/languages"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRuntime_Generate sanity-checks that the runtime jenny emits the
+// IBuilder<T> interface at the expected location with the expected
+// namespace. Goldens aren't used because the runtime is a single,
+// trivial file — a smoke test is enough.
+func TestRuntime_Generate(t *testing.T) {
+	cfg := Config{GenerateBuilders: true}
+	cfg.InterpolateParameters(func(s string) string { return s })
+
+	jenny := Runtime{
+		config: cfg,
+		tmpl:   initTemplates(cfg, common.NewAPIReferenceCollector()),
+	}
+	files, err := jenny.Generate(languages.Context{})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	require.Equal(t, "src/Grafana/Foundation/Cog/IBuilder.cs", files[0].RelativePath)
+	body := string(files[0].Data)
+	require.True(t, strings.Contains(body, "namespace Grafana.Foundation.Cog;"), body)
+	require.True(t, strings.Contains(body, "public interface IBuilder<out T>"), body)
+	require.True(t, strings.Contains(body, "T Build();"), body)
+}

--- a/internal/jennies/csharp/templates/builders/args.tmpl
+++ b/internal/jennies/csharp/templates/builders/args.tmpl
@@ -1,0 +1,11 @@
+{{- /* Renders a comma-separated parameter list. When IsBuilder is
+       true (called from the Builder template), arguments whose type
+       has a registered builder are wrapped in `Cog.IBuilder<T>` so the
+       caller can pass either a built instance or a fluent builder.
+*/ -}}
+{{- define "args" }}
+    {{- range $i, $arg := .Arguments }}
+        {{- if gt $i 0 }}, {{- end }}
+        {{- if $.IsBuilder }}{{ $arg.Type | formatBuilderFieldType }}{{ else }}{{ $arg.Type | formatType }}{{ end }} {{ $arg.Name | escapeVar | lowerCamelCase }}
+    {{- end }}
+{{- end }}

--- a/internal/jennies/csharp/templates/builders/assignments.tmpl
+++ b/internal/jennies/csharp/templates/builders/assignments.tmpl
@@ -1,0 +1,131 @@
+{{- /* Builder option assignment.
+       Drives constraint validation, nil-checks for nested parent
+       initialisation, builder-typed argument unfolding, and the
+       final write into `this.@internal.<path>`.
+*/ -}}
+{{- define "assignment" }}
+    {{- template "constraints" .Assignment.Constraints }}
+    {{- range .Assignment.NilChecks }}
+        {{- template "nil_check" . }}
+    {{- end }}
+
+    {{- template "assignment_setup" (dict "Assignment" .Assignment "Value" .Assignment.Value) }}
+
+    {{- $value := include "assignment_value" (dict "Assignment" .Assignment "IntoType" .Assignment.Path.Last.Type "Value" .Assignment.Value) -}}
+
+    {{- $preTmpl := print "pre_assignment_" .BuilderName "_" .OptionName }}
+    {{- includeIfExists $preTmpl (dict) -}}
+
+    {{- template "assignment_method" (dict "Method" .Assignment.Method "Path" .Assignment.Path "Value" $value) -}}
+
+    {{- $postTmpl := print "post_assignment_" .BuilderName "_" .OptionName }}
+    {{- includeIfExists $postTmpl (dict) -}}
+{{- end }}
+
+{{- /* Pre-assignment scratch work — declares envelope locals and
+       collects builder-typed arguments into their built form.
+*/ -}}
+{{- define "assignment_setup" }}
+    {{- with .Value.Envelope }}
+        {{- range .Values }}
+        {{- template "assignment_setup" (dict "Assignment" $.Assignment "Value" .Value) }}
+        {{- end }}
+
+        {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
+    {{- end }}
+    {{- with .Value.Argument }}
+        {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
+        {{- $builtResultName := (print .Name "Resource") }}
+        {{- if or .Type.IsArray .Type.IsMap }}
+        {{- $builtResultName = (print .Name "Resources") }}
+        {{ .Type | formatType }} {{ $builtResultName | escapeVar | lowerCamelCase }} = {{ .Type | emptyValueForType }};
+        {{- end }}
+
+        {{- template "unfold_builders" (dict "Depth" 1 "InputType" .Type "OriginalInputVar" (.Name | escapeVar | lowerCamelCase) "InputVar" (.Name | escapeVar | lowerCamelCase) "AssignmentPath" $.Assignment.Path "ResultVar" ($builtResultName | escapeVar | lowerCamelCase)) }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- /* Renders the value being assigned (RHS), accounting for builder
+       unfolding, envelopes, and constant references.
+*/ -}}
+{{- define "assignment_value" }}
+    {{- if .Value.Argument }}
+        {{- with .Value.Argument }}
+        {{- if or (typeHasBuilder .Type) (resolvesToComposableSlot .Type) }}
+            {{- if or .Type.IsMap .Type.IsArray }}
+            {{- .Name | escapeVar | lowerCamelCase }}Resources
+            {{- else }}
+            {{- .Name | escapeVar | lowerCamelCase }}Resource
+            {{- end }}
+        {{- else }}
+            {{- .Name | escapeVar | lowerCamelCase }}
+        {{- end }}
+        {{- end }}
+    {{- else if .Value.Envelope }}
+        {{- with .Value.Envelope }}
+        {{- .Type | formatType | lowerCamelCase }}
+        {{- end }}
+    {{- else }}
+        {{- formatRefType .IntoType .Value.Constant }}
+    {{- end }}
+{{- end }}
+
+{{- define "value_envelope" }}
+    {{ $envelopeType := .Envelope.Type | formatType }}
+        {{- $envelopeType }} {{ $envelopeType | lowerCamelCase }} = new {{ $envelopeType }}();
+    {{- range .Envelope.Values }}
+        {{- $value := include "assignment_value" (dict "Assignment" $.Assignment "IntoType" .Path.Last.Type "Value" .Value) }}
+        {{ $envelopeType | lowerCamelCase }}.{{ (index .Path 0).Identifier | upperCamelCase }} = {{ $value }};
+    {{- end }}
+{{- end }}
+
+{{- /* Final write into the path. `direct` overwrites, `index` writes
+       through a [key]/index slot, `append` calls .Add(...).
+*/ -}}
+{{- define "assignment_method" }}
+        {{ $path := formatAssignmentPath "this.@internal" .Path }}
+        {{- if eq .Method "direct" }}{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "index" }}
+            {{- $index := .Path.Last.Index }}
+            {{- $path = formatAssignmentPath "this.@internal" .Path.RemoveLast }}
+            {{- $path }}[{{ $index | formatPathIndex }}] = {{ .Value }};
+        {{- end }}
+        {{- if and (eq .Method "index") (.Path.Last.Type.IsArray) }}{{ $path }} = {{ .Value }};{{ end }}
+        {{- if eq .Method "append" }}{{ $path }}.Add({{ .Value }});{{ end -}}
+{{- end }}
+
+{{- /* Recursively unfolds builder-typed arrays/maps into their built
+       counterparts so the underlying field can be assigned a plain
+       List<T>/Dictionary<…> rather than a list of builders.
+*/ -}}
+{{- define "unfold_builders" }}
+    {{- if .InputType.IsArray }}
+        foreach ({{ .InputType.AsArray.ValueType | formatBuilderFieldType }} r{{ .Depth }} in {{ .InputVar }})
+        {
+            {{- if .InputType.Array.ValueType.IsArray }}
+                {{ .InputType.Array.ValueType | formatType }} {{ .OriginalInputVar }}Depth{{ .Depth }} = {{ .InputType.Array.ValueType | emptyValueForType }};
+
+                {{- template "unfold_builders" (dict "Depth" (add1 .Depth) "InputType" .InputType.Array.ValueType "OriginalInputVar" .OriginalInputVar "InputVar" (print "r" .Depth) "AssignmentPath" $.AssignmentPath "ResultVar" (print .OriginalInputVar "Depth" .Depth)) }}
+
+                {{ .ResultVar }}.Add({{ .OriginalInputVar }}Depth{{ .Depth }});
+            {{- else }}
+                {{ .InputType.AsArray.ValueType | formatType }} {{ .OriginalInputVar }}Depth{{ .Depth }} = r{{ .Depth }}.Build();
+                {{ .ResultVar }}.Add({{ .OriginalInputVar }}Depth{{ .Depth }});
+            {{- end }}
+        }
+    {{- else if .InputType.IsMap }}
+        foreach (var entry{{ .Depth }} in {{ .InputVar }})
+        {
+            {{- if .InputType.Map.ValueType.IsArray }}
+                {{- template "unfold_builders" (dict "Depth" (add1 .Depth) "InputType" .InputType.Map.ValueType "OriginalInputVar" .OriginalInputVar "InputVar" (print "entry" .Depth) "AssignmentPath" $.AssignmentPath "ResultVar" (print .OriginalInputVar "Depth" .Depth)) }}
+                {{ .ResultVar }}[entry{{ .Depth }}.Key] = entry{{ .Depth }}.Value;
+            {{- else }}
+                {{ .InputType.Map.ValueType | formatType }} {{ .OriginalInputVar }}Depth{{ .Depth }} = entry{{ .Depth }}.Value.Build();
+                {{ .ResultVar }}[entry{{ .Depth }}.Key] = {{ .OriginalInputVar }}Depth{{ .Depth }};
+            {{- end }}
+        }
+    {{- else }}
+        {{ .InputType | formatType }} {{ .ResultVar }} = {{ .InputVar }}.Build();
+    {{- end }}
+{{- end }}

--- a/internal/jennies/csharp/templates/builders/builder.tmpl
+++ b/internal/jennies/csharp/templates/builders/builder.tmpl
@@ -1,0 +1,48 @@
+{{- /* C# fluent builder template — Phase 4.
+
+   Mirrors the Java builders/builder.tmpl shape: a class implementing
+   `Cog.IBuilder<TargetType>` exposes one fluent method per builder
+   option, accumulates state on a protected `internal_` instance, and
+   returns it from `Build()`. The internal field name uses a verbatim
+   identifier (`@internal`) so the generated source reads identically
+   to the Java/TypeScript targets.
+*/ -}}
+namespace {{ .Namespace }};
+{{ if .Imports }}
+{{ .Imports }}
+{{- end }}
+public class {{ .BuilderName }}Builder : Cog.IBuilder<{{ .BuilderSignatureType }}>
+{
+    protected readonly {{ .ObjectName }} @internal;
+
+    {{- range .Properties }}
+    private {{ .Type | formatBuilderFieldType }} {{ .Name | escapeVar | lowerCamelCase }};
+    {{- end }}
+
+    public {{ .BuilderName }}Builder({{- template "args" (dict "Arguments" .Constructor.Args "IsBuilder" true) }})
+    {
+        this.@internal = new {{ .ObjectName }}();
+    {{- range .Constructor.Assignments }}
+        {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" "") }}
+    {{- end }}
+    {{- range .Properties }}
+        this.{{ .Name | escapeVar | lowerCamelCase }} = {{ .Type | emptyValueForType }};
+    {{- end }}
+    }
+
+    {{- range $opt := .Options }}
+
+    public {{ $.BuilderName }}Builder {{ .Name | escapeVar | upperCamelCase }}({{- template "args" (dict "Arguments" .Args "IsBuilder" true) }})
+    {
+        {{- range .Assignments }}
+            {{- template "assignment" (dict "Assignment" . "BuilderName" $.BuilderName "OptionName" $opt.Name) }}
+        {{- end }}
+        return this;
+    }
+    {{- end }}
+
+    public {{ .ObjectName }} Build()
+    {
+        return this.@internal;
+    }
+}

--- a/internal/jennies/csharp/templates/builders/constraints.tmpl
+++ b/internal/jennies/csharp/templates/builders/constraints.tmpl
@@ -1,0 +1,34 @@
+{{- /* Validates a builder option argument before assigning it.
+       Maps the AST constraint vocabulary onto C# expressions; regex
+       constraints lean on System.Text.RegularExpressions.Regex.
+*/ -}}
+{{- define "constraints" }}
+{{- range . }}
+    {{- $leftOperand := .Argument.Name | escapeVar | lowerCamelCase }}
+    {{- $operator := .Op }}
+    {{- if eq .Op "minLength" }}
+        {{- $leftOperand = print $leftOperand ".Length" }}
+        {{- $operator = ">=" }}
+    {{- end }}
+    {{- if eq .Op "maxLength" }}
+        {{- $leftOperand = print $leftOperand ".Length" }}
+        {{- $operator = "<=" }}
+    {{- end }}
+    {{- if eq .Op "=~" }}
+        if (!System.Text.RegularExpressions.Regex.IsMatch({{ $leftOperand }}, "{{ .Parameter }}"))
+        {
+            throw new System.ArgumentException("{{ $leftOperand }} must match regex {{ .Parameter }}");
+        }
+    {{- else if eq .Op "!~" }}
+        if (System.Text.RegularExpressions.Regex.IsMatch({{ $leftOperand }}, "{{ .Parameter }}"))
+        {
+            throw new System.ArgumentException("{{ $leftOperand }} must not match regex {{ .Parameter }}");
+        }
+    {{- else }}
+        if (!({{ $leftOperand }} {{ $operator }} {{ .Parameter }}))
+        {
+            throw new System.ArgumentException("{{ $leftOperand }} must be {{ $operator }} {{ .Parameter }}");
+        }
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/internal/jennies/csharp/templates/builders/nilcheck.tmpl
+++ b/internal/jennies/csharp/templates/builders/nilcheck.tmpl
@@ -1,0 +1,11 @@
+{{- /* Lazily initialises a parent on the assignment path so deeply
+       nested options can be set without forcing the caller to pre-build
+       every intermediary struct.
+*/ -}}
+{{- define "nil_check" }}
+        {{- $path := formatAssignmentPath "this.@internal" .Path }}
+        if ({{ $path }} == null)
+        {
+            {{ $path }} = {{ .EmptyValueType | emptyValueForType }};
+        }
+{{- end }}

--- a/internal/jennies/csharp/templates/marshalling/disjunction_of_refs.tmpl
+++ b/internal/jennies/csharp/templates/marshalling/disjunction_of_refs.tmpl
@@ -1,0 +1,53 @@
+{{- /* C# discriminated disjunction-of-refs JsonConverter.
+       Reads the JSON object once into a JsonDocument, inspects the
+       discriminator field to pick a branch, then deserialises the
+       full object into the matching field.
+*/ -}}
+namespace {{ .Namespace }};
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class {{ .Name }}JsonConverter : JsonConverter<{{ .Name }}>
+{
+    public override {{ .Name }} Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("{{ .Discriminator }}", out var discProp))
+        {
+            throw new JsonException("missing discriminator property '{{ .Discriminator }}' for {{ .Name }}");
+        }
+
+        var result = new {{ .Name }}();
+        var raw = root.GetRawText();
+        switch (discProp.GetString())
+        {
+        {{- range .Cases }}
+        {{- if .CatchAll }}
+            default:
+        {{- else }}
+            case "{{ .Discriminator }}":
+        {{- end }}
+                result.{{ .Field }} = JsonSerializer.Deserialize<{{ .TypeRef }}>(raw, options);
+                break;
+        {{- end }}
+        {{- if not .HasCatchAll }}
+            default:
+                throw new JsonException("unknown discriminator value '" + discProp.GetString() + "' for {{ .Name }}");
+        {{- end }}
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, {{ .Name }} value, JsonSerializerOptions options)
+    {
+        {{- range $i, $c := .Cases }}
+        {{ if $i }}else {{ end }}if (value.{{ $c.Field }} != null) { JsonSerializer.Serialize(writer, value.{{ $c.Field }}, options); }
+        {{- end }}
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/internal/jennies/csharp/templates/marshalling/disjunction_of_scalars.tmpl
+++ b/internal/jennies/csharp/templates/marshalling/disjunction_of_scalars.tmpl
@@ -1,0 +1,52 @@
+{{- /* C# disjunction-of-scalars JsonConverter.
+       For each branch we map a JsonTokenType to one of the struct's
+       fields. Numeric tokens are checked against the int branch
+       (if any) before the float branch.
+*/ -}}
+namespace {{ .Namespace }};
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class {{ .Name }}JsonConverter : JsonConverter<{{ .Name }}>
+{
+    public override {{ .Name }} Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        var result = new {{ .Name }}();
+        switch (reader.TokenType)
+        {
+        {{- range .Branches }}
+        {{- range .Tokens }}
+            case JsonTokenType.{{ . }}:
+        {{- end }}
+        {{- if .IntField }}
+                if (reader.TryGetInt64(out _)) { result.{{ .IntField }} = {{ .IntReadExpr }}; }
+                else { result.{{ .Field }} = {{ .ReadExpr }}; }
+        {{- else }}
+                result.{{ .Field }} = {{ .ReadExpr }};
+        {{- end }}
+                break;
+        {{- end }}
+            default:
+                throw new JsonException("unexpected token while deserialising {{ .Name }}: " + reader.TokenType);
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, {{ .Name }} value, JsonSerializerOptions options)
+    {
+        {{- $first := true }}
+        {{- range .Branches }}
+        {{- if .IntField }}
+        {{ if not $first }}else {{ end }}if (value.{{ .IntField }} != null) { JsonSerializer.Serialize(writer, value.{{ .IntField }}{{ .IntWrite }}, options); }
+        {{- $first = false }}
+        {{- end }}
+        {{ if not $first }}else {{ end }}if (value.{{ .Field }} != null) { JsonSerializer.Serialize(writer, value.{{ .Field }}{{ .WriteAccess }}, options); }
+        {{- $first = false }}
+        {{- end }}
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/internal/jennies/csharp/templates/marshalling/disjunction_of_scalars_and_refs.tmpl
+++ b/internal/jennies/csharp/templates/marshalling/disjunction_of_scalars_and_refs.tmpl
@@ -1,0 +1,92 @@
+{{- /* C# disjunction-of-scalars-and-refs JsonConverter.
+       Reads the input into a JsonDocument so we can inspect its
+       ValueKind. Object payloads are dispatched via try/deserialize
+       attempts against each ref branch (mirrors Java's `couldBe`
+       helper); the first branch that round-trips wins. A trailing
+       `Any`-typed branch, if present, acts as catch-all for objects.
+*/ -}}
+namespace {{ .Namespace }};
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class {{ .Name }}JsonConverter : JsonConverter<{{ .Name }}>
+{
+    public override {{ .Name }} Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+        var raw = root.GetRawText();
+        var result = new {{ .Name }}();
+
+        switch (root.ValueKind)
+        {
+        {{- range .ScalarBranches }}
+        {{- range .ValueKinds }}
+            case JsonValueKind.{{ . }}:
+        {{- end }}
+        {{- if .IntField }}
+                if (root.TryGetInt64(out _)) { result.{{ .IntField }} = root.{{ .IntElementGet }}; }
+                else { result.{{ .Field }} = root.{{ .ElementGet }}; }
+        {{- else if .ElementGet }}
+                result.{{ .Field }} = root.{{ .ElementGet }};
+        {{- else }}
+                result.{{ .Field }} = JsonSerializer.Deserialize<{{ .DeserializeAs }}>(raw, options);
+        {{- end }}
+                break;
+        {{- end }}
+            case JsonValueKind.Object:
+        {{- range .RefBranches }}
+                if (TryDeserialize<{{ .TypeRef }}>(raw, options, out var __{{ .Field }})) { result.{{ .Field }} = __{{ .Field }}; break; }
+        {{- end }}
+        {{- if .HasAnyBranch }}
+                result.{{ .AnyField }} = JsonSerializer.Deserialize<JsonElement>(raw, options);
+        {{- else }}
+                throw new JsonException("no ref branch matched JSON object for {{ .Name }}");
+        {{- end }}
+                break;
+            default:
+                throw new JsonException("unexpected token while deserialising {{ .Name }}: " + root.ValueKind);
+        }
+
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, {{ .Name }} value, JsonSerializerOptions options)
+    {
+        {{- $first := true -}}
+        {{- range .ScalarBranches }}
+        {{- if .IntField }}
+        {{ if not $first }}else {{ end }}if (value.{{ .IntField }} != null) { JsonSerializer.Serialize(writer, value.{{ .IntField }}{{ .IntWrite }}, options); }
+        {{- $first = false }}
+        {{- end }}
+        {{ if not $first }}else {{ end }}if (value.{{ .Field }} != null) { JsonSerializer.Serialize(writer, value.{{ .Field }}{{ .WriteAccess }}, options); }
+        {{- $first = false }}
+        {{- end }}
+        {{- range .RefBranches }}
+        {{ if not $first }}else {{ end }}if (value.{{ .Field }} != null) { JsonSerializer.Serialize(writer, value.{{ .Field }}, options); }
+        {{- $first = false }}
+        {{- end }}
+        {{- if .HasAnyBranch }}
+        {{ if not $first }}else {{ end }}if (value.{{ .AnyField }} != null) { JsonSerializer.Serialize(writer, value.{{ .AnyField }}, options); }
+        {{- end }}
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+
+    private static bool TryDeserialize<T>(string raw, JsonSerializerOptions options, out T? value)
+    {
+        try
+        {
+            value = JsonSerializer.Deserialize<T>(raw, options);
+            return value != null;
+        }
+        catch (JsonException)
+        {
+            value = default;
+            return false;
+        }
+    }
+}

--- a/internal/jennies/csharp/templates/runtime/builder.tmpl
+++ b/internal/jennies/csharp/templates/runtime/builder.tmpl
@@ -1,0 +1,10 @@
+{{- /* Cog runtime — fluent builder interface.
+       Mirrors the cog.Builder<T> Java interface. Lives in
+       Grafana.Foundation.Cog (or whatever NamespaceRoot resolves to).
+*/ -}}
+namespace {{ .Namespace }};
+
+public interface IBuilder<out T>
+{
+    T Build();
+}

--- a/internal/jennies/csharp/templates/types/class.tmpl
+++ b/internal/jennies/csharp/templates/types/class.tmpl
@@ -1,0 +1,39 @@
+{{- /* C# class template — Phase 2 (raw types only).
+       Produces a public class with public fields, a parameterless
+       constructor that assigns defaults, and an all-args constructor.
+       Mirrors the Java class template's basic structure; JSON
+       (de)serializer attributes and Equals/GetHashCode overrides will
+       be added in later phases.
+*/ -}}
+namespace {{ .Namespace }};
+{{ if .Imports }}
+{{ .Imports }}
+{{- end }}
+{{- range .Comments }}
+// {{ . }}
+{{- end }}
+public class {{ .Name }}{{ if .Extends }} : {{ join ", " .Extends }}{{ end }}
+{
+    {{- range .Fields }}
+    {{- range .Comments }}
+    // {{ . }}
+    {{- end }}
+    public {{ .Type }} {{ .Name }};
+    {{- end }}
+
+    public {{ .Name }}()
+    {
+        {{- range .DefaultAssignments }}
+        this.{{ .Name }} = {{ .Value }};
+        {{- end }}
+    }
+    {{- if .HasArgsConstructor }}
+
+    public {{ .Name }}({{- range $i, $a := .Args }}{{ if $i }}, {{ end }}{{ $a.Type }} {{ $a.Name }}{{- end }})
+    {
+        {{- range .ArgAssignments }}
+        this.{{ .Name }} = {{ .ValueFromArg }};
+        {{- end }}
+    }
+    {{- end }}
+}

--- a/internal/jennies/csharp/templates/types/class.tmpl
+++ b/internal/jennies/csharp/templates/types/class.tmpl
@@ -12,11 +12,17 @@ namespace {{ .Namespace }};
 {{- range .Comments }}
 // {{ . }}
 {{- end }}
+{{- range .ClassAttributes }}
+{{ . }}
+{{- end }}
 public class {{ .Name }}{{ if .Extends }} : {{ join ", " .Extends }}{{ end }}
 {
     {{- range .Fields }}
     {{- range .Comments }}
     // {{ . }}
+    {{- end }}
+    {{- range .Attributes }}
+    {{ . }}
     {{- end }}
     public {{ .Type }} {{ .Name }};
     {{- end }}

--- a/internal/jennies/csharp/templates/types/constants.tmpl
+++ b/internal/jennies/csharp/templates/types/constants.tmpl
@@ -1,0 +1,12 @@
+{{- /* C# constants template — Phase 2.
+       Emits each schema-level concrete scalar as a `public const` field
+       on a static class named "Constants" (one per package).
+*/ -}}
+namespace {{ .Namespace }};
+
+public static class {{ .Name }}
+{
+    {{- range .Constants }}
+    public const {{ .Type }} {{ .Name | formatFieldName }} = {{ .Value }};
+    {{- end }}
+}

--- a/internal/jennies/csharp/templates/types/enum.tmpl
+++ b/internal/jennies/csharp/templates/types/enum.tmpl
@@ -1,0 +1,24 @@
+{{- /* C# enum template — Phase 2 (raw types only).
+       Generates a strongly-typed C# enum. For string-valued enums,
+       member names are PascalCased and original values are recorded
+       in [EnumMember] attributes so a JsonStringEnumMemberConverter
+       (added in Phase 3) can round-trip the original strings.
+*/ -}}
+namespace {{ .Namespace }};
+{{ if .NeedsEnumMember }}
+using System.Runtime.Serialization;
+{{ end }}
+{{- range .Comments }}
+// {{ . }}
+{{- end }}
+public enum {{ .Name }}
+{
+    {{- range $i, $val := .Values }}
+    {{- if $.IsString }}
+    [EnumMember(Value = {{ $val.RawValue | printf "%q" }})]
+    {{ $val.Name }}{{- if not (lastValueIndex $i $.Values) }},{{ end }}
+    {{- else }}
+    {{ $val.Name }} = {{ $val.RawValue }}{{- if not (lastValueIndex $i $.Values) }},{{ end }}
+    {{- end }}
+    {{- end }}
+}

--- a/internal/jennies/csharp/templates/types/enum.tmpl
+++ b/internal/jennies/csharp/templates/types/enum.tmpl
@@ -1,21 +1,27 @@
-{{- /* C# enum template — Phase 2 (raw types only).
-       Generates a strongly-typed C# enum. For string-valued enums,
-       member names are PascalCased and original values are recorded
-       in [EnumMember] attributes so a JsonStringEnumMemberConverter
-       (added in Phase 3) can round-trip the original strings.
+{{- /* C# enum template — Phase 2/3.
+       String enums use [JsonStringEnumMemberName("…")] (.NET 9+) on
+       members and rely on [JsonConverter(typeof(
+       JsonStringEnumConverter<T>))] (passed in via EnumAttributes
+       when JSON marshalling is enabled) to round-trip the original
+       string payload. Integer enums use explicit numeric values.
 */ -}}
 namespace {{ .Namespace }};
-{{ if .NeedsEnumMember }}
-using System.Runtime.Serialization;
-{{ end }}
+{{ if .Imports }}
+{{ .Imports }}
+{{- end }}
 {{- range .Comments }}
 // {{ . }}
+{{- end }}
+{{- range .EnumAttributes }}
+{{ . }}
 {{- end }}
 public enum {{ .Name }}
 {
     {{- range $i, $val := .Values }}
-    {{- if $.IsString }}
-    [EnumMember(Value = {{ $val.RawValue | printf "%q" }})]
+    {{- if and $.IsString $.JSONEnabled }}
+    [JsonStringEnumMemberName({{ $val.RawValue | printf "%q" }})]
+    {{ $val.Name }}{{- if not (lastValueIndex $i $.Values) }},{{ end }}
+    {{- else if $.IsString }}
     {{ $val.Name }}{{- if not (lastValueIndex $i $.Values) }},{{ end }}
     {{- else }}
     {{ $val.Name }} = {{ $val.RawValue }}{{- if not (lastValueIndex $i $.Values) }},{{ end }}

--- a/internal/jennies/csharp/tmpl.go
+++ b/internal/jennies/csharp/tmpl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/cog/internal/languages"
 )
 
-//go:embed templates/types/*.tmpl templates/marshalling/*.tmpl
+//go:embed templates/types/*.tmpl templates/marshalling/*.tmpl templates/builders/*.tmpl templates/runtime/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -36,7 +36,18 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 // formattingTemplateFuncs returns helpers that are pure formatting
 // utilities — they don't depend on a typeFormatter and so can be added
 // to the template root without an active jenny.
+//
+// The builder-jenny helpers (formatBuilderFieldType, formatType, …)
+// are registered as panic-stubs so that templates referencing them
+// parse cleanly at init time. Each Builder.Generate call overrides the
+// stubs with real implementations via Template.Funcs(...).
 func formattingTemplateFuncs() template.FuncMap {
+	stub := func(name string) func(...any) string {
+		return func(...any) string {
+			panic(name + "() needs to be overridden by a jenny")
+		}
+	}
+
 	return template.FuncMap{
 		"formatFieldName":   formatFieldName,
 		"formatArgName":     formatArgName,
@@ -46,6 +57,16 @@ func formattingTemplateFuncs() template.FuncMap {
 		"lastValueIndex": func(index int, values []EnumValue) bool {
 			return len(values)-1 == index
 		},
+
+		"formatBuilderFieldType":   stub("formatBuilderFieldType"),
+		"formatType":               stub("formatType"),
+		"formatRefType":            stub("formatRefType"),
+		"formatAssignmentPath":     stub("formatAssignmentPath"),
+		"formatPath":               stub("formatPath"),
+		"formatPathIndex":          stub("formatPathIndex"),
+		"emptyValueForType":        stub("emptyValueForType"),
+		"typeHasBuilder":           func(...any) bool { return false },
+		"resolvesToComposableSlot": func(...any) bool { return false },
 	}
 }
 

--- a/internal/jennies/csharp/tmpl.go
+++ b/internal/jennies/csharp/tmpl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/cog/internal/languages"
 )
 
-//go:embed templates/types/*.tmpl
+//go:embed templates/types/*.tmpl templates/marshalling/*.tmpl
 //nolint:gochecknoglobals
 var templatesFS embed.FS
 
@@ -59,6 +59,9 @@ type classTemplate struct {
 	Name               string
 	Imports            fmt.Stringer
 	Comments           []string
+	// ClassAttributes are emitted on lines preceding the class
+	// declaration (e.g. `[JsonConverter(typeof(FooJsonConverter))]`).
+	ClassAttributes    []string
 	Extends            []string
 	Fields             []classField
 	DefaultAssignments []assignment
@@ -75,6 +78,9 @@ type classField struct {
 	Name     string
 	Type     string
 	Comments []string
+	// Attributes are emitted on lines preceding the field declaration
+	// (e.g. `[JsonPropertyName("origName")]`).
+	Attributes []string
 }
 
 type classArg struct {
@@ -90,12 +96,23 @@ type assignment struct {
 
 // enumTemplate is the model bound to templates/types/enum.tmpl.
 type enumTemplate struct {
-	Namespace       string
-	Name            string
-	Comments        []string
-	IsString        bool
-	NeedsEnumMember bool
-	Values          []EnumValue
+	Namespace string
+	Name      string
+	Comments  []string
+	IsString  bool
+	// Imports is rendered between the namespace declaration and the
+	// enum declaration. Pre-built so we can include the
+	// System.Text.Json.Serialization namespace when JSON-marshalling
+	// is enabled.
+	Imports fmt.Stringer
+	// EnumAttributes are emitted on lines preceding the enum
+	// declaration (e.g. `[JsonConverter(typeof(JsonStringEnumConverter<X>))]`).
+	EnumAttributes []string
+	// JSONEnabled mirrors Config.GenerateJSONConverters and controls
+	// whether per-member [JsonStringEnumMemberName] attributes are
+	// emitted on string enums.
+	JSONEnabled bool
+	Values      []EnumValue
 }
 
 // EnumValue is exported so it can be used by the lastValueIndex helper.
@@ -103,10 +120,10 @@ type EnumValue struct {
 	// Name is the C# member identifier (PascalCase, escaped).
 	Name string
 	// RawValue is the underlying schema value:
-	//   - for integer enums: the int64 itself, formatted as `{n}` in
-	//     templates;
+	//   - for integer enums: a pre-formatted literal string;
 	//   - for string enums: the original string, used inside
-	//     [EnumMember(Value = "…")].
+	//     [JsonStringEnumMemberName("…")] when JSON-marshalling is
+	//     enabled (and as a comment otherwise).
 	RawValue any
 }
 

--- a/internal/jennies/csharp/tmpl.go
+++ b/internal/jennies/csharp/tmpl.go
@@ -1,0 +1,124 @@
+package csharp
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/grafana/cog/internal/jennies/common"
+	"github.com/grafana/cog/internal/jennies/template"
+	"github.com/grafana/cog/internal/languages"
+)
+
+//go:embed templates/types/*.tmpl
+//nolint:gochecknoglobals
+var templatesFS embed.FS
+
+func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector) *template.Template {
+	tmpl, err := template.New(
+		"csharp",
+		template.Funcs(common.TypeResolvingTemplateHelpers(languages.Context{})),
+		template.Funcs(common.TypesTemplateHelpers(languages.Context{})),
+		template.Funcs(common.APIRefTemplateHelpers(apiRefCollector)),
+		template.Funcs(config.OverridesTemplateFuncs),
+		template.Funcs(formattingTemplateFuncs()),
+
+		template.ParseFS(templatesFS, "templates"),
+		template.ParseFS(config.OverridesTemplatesFS, "custom"),
+		template.ParseDirectories(config.OverridesTemplatesDirectories...),
+	)
+	if err != nil {
+		panic(fmt.Errorf("could not initialize templates: %w", err))
+	}
+
+	return tmpl
+}
+
+// formattingTemplateFuncs returns helpers that are pure formatting
+// utilities — they don't depend on a typeFormatter and so can be added
+// to the template root without an active jenny.
+func formattingTemplateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"formatFieldName":   formatFieldName,
+		"formatArgName":     formatArgName,
+		"formatPackageName": formatPackageName,
+		"formatObjectName":  formatObjectName,
+		"escapeVar":         escapeVarName,
+		"lastValueIndex": func(index int, values []EnumValue) bool {
+			return len(values)-1 == index
+		},
+	}
+}
+
+// ---------------------------------------------------------------------
+// Template data structures
+// ---------------------------------------------------------------------
+
+// classTemplate is the model bound to templates/types/class.tmpl.
+type classTemplate struct {
+	Namespace          string
+	Name               string
+	Imports            fmt.Stringer
+	Comments           []string
+	Extends            []string
+	Fields             []classField
+	DefaultAssignments []assignment
+	HasArgsConstructor bool
+	Args               []classArg
+	ArgAssignments     []assignment
+}
+
+// classField mirrors ast.StructField but pre-formats the name and type
+// so the template stays simple and so type formatting (which mutates
+// the importMap as a side-effect) happens before the imports block is
+// rendered.
+type classField struct {
+	Name     string
+	Type     string
+	Comments []string
+}
+
+type classArg struct {
+	Name string
+	Type string
+}
+
+type assignment struct {
+	Name         string // already-formatted field name
+	Value        string // literal expression, used by the parameterless ctor
+	ValueFromArg string // already-formatted arg name, used by the all-args ctor
+}
+
+// enumTemplate is the model bound to templates/types/enum.tmpl.
+type enumTemplate struct {
+	Namespace       string
+	Name            string
+	Comments        []string
+	IsString        bool
+	NeedsEnumMember bool
+	Values          []EnumValue
+}
+
+// EnumValue is exported so it can be used by the lastValueIndex helper.
+type EnumValue struct {
+	// Name is the C# member identifier (PascalCase, escaped).
+	Name string
+	// RawValue is the underlying schema value:
+	//   - for integer enums: the int64 itself, formatted as `{n}` in
+	//     templates;
+	//   - for string enums: the original string, used inside
+	//     [EnumMember(Value = "…")].
+	RawValue any
+}
+
+// constantsTemplate is the model bound to templates/types/constants.tmpl.
+type constantsTemplate struct {
+	Namespace string
+	Name      string
+	Constants []constant
+}
+
+type constant struct {
+	Name  string
+	Type  string
+	Value string
+}

--- a/internal/jennies/csharp/tools.go
+++ b/internal/jennies/csharp/tools.go
@@ -1,0 +1,33 @@
+package csharp
+
+import "strings"
+
+// pascalCase converts a snake_case, kebab-case, or lower-case identifier
+// into PascalCase suitable for C# namespace and type names.
+//
+// Examples:
+//
+//	pascalCase("dashboard")       -> "Dashboard"
+//	pascalCase("library_panel")   -> "LibraryPanel"
+//	pascalCase("library-panel")   -> "LibraryPanel"
+//	pascalCase("HTTPRequest")     -> "HTTPRequest" (already capitalised)
+func pascalCase(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	// Split on common separators used by the schema source identifiers.
+	parts := strings.FieldsFunc(input, func(r rune) bool {
+		return r == '_' || r == '-' || r == '.' || r == ' '
+	})
+
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(part[1:])
+	}
+	return b.String()
+}

--- a/internal/jennies/csharp/tools.go
+++ b/internal/jennies/csharp/tools.go
@@ -1,22 +1,21 @@
 package csharp
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
+)
 
 // pascalCase converts a snake_case, kebab-case, or lower-case identifier
 // into PascalCase suitable for C# namespace and type names.
-//
-// Examples:
-//
-//	pascalCase("dashboard")       -> "Dashboard"
-//	pascalCase("library_panel")   -> "LibraryPanel"
-//	pascalCase("library-panel")   -> "LibraryPanel"
-//	pascalCase("HTTPRequest")     -> "HTTPRequest" (already capitalised)
 func pascalCase(input string) string {
 	if input == "" {
 		return ""
 	}
 
-	// Split on common separators used by the schema source identifiers.
 	parts := strings.FieldsFunc(input, func(r rune) bool {
 		return r == '_' || r == '-' || r == '.' || r == ' '
 	})
@@ -30,4 +29,145 @@ func pascalCase(input string) string {
 		b.WriteString(part[1:])
 	}
 	return b.String()
+}
+
+// formatObjectName produces a PascalCased C# type name.
+func formatObjectName(name string) string {
+	return tools.UpperCamelCase(name)
+}
+
+// formatFieldName produces a PascalCased C# field/property name.
+// (C# convention is PascalCase for public fields and properties.)
+func formatFieldName(name string) string {
+	return escapeVarName(tools.UpperCamelCase(name))
+}
+
+// formatArgName produces a camelCased C# parameter name.
+func formatArgName(name string) string {
+	return escapeVarName(tools.LowerCamelCase(name))
+}
+
+// formatPackageName converts a schema package identifier into the
+// PascalCase segment used in a C# namespace.
+//
+// Example: "library_panel" -> "LibraryPanel".
+func formatPackageName(pkg string) string {
+	rgx := regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+	cleaned := rgx.ReplaceAllString(pkg, "")
+	return pascalCase(cleaned)
+}
+
+// escapeVarName appends a suffix to identifiers that collide with C#
+// reserved keywords.
+func escapeVarName(varName string) string {
+	if isReservedCSharpKeyword(varName) {
+		return varName + "Arg"
+	}
+	return varName
+}
+
+// isReservedCSharpKeyword reports whether the given identifier collides
+// with a C# reserved keyword. Source:
+// https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
+//
+//nolint:gocyclo
+func isReservedCSharpKeyword(input string) bool {
+	switch input {
+	case "abstract", "as", "base", "bool", "break", "byte", "case", "catch",
+		"char", "checked", "class", "const", "continue", "decimal", "default",
+		"delegate", "do", "double", "else", "enum", "event", "explicit",
+		"extern", "false", "finally", "fixed", "float", "for", "foreach",
+		"goto", "if", "implicit", "in", "int", "interface", "internal", "is",
+		"lock", "long", "namespace", "new", "null", "object", "operator",
+		"out", "override", "params", "private", "protected", "public",
+		"readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof",
+		"stackalloc", "static", "string", "struct", "switch", "this", "throw",
+		"true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe",
+		"ushort", "using", "virtual", "void", "volatile", "while":
+		return true
+	}
+	return false
+}
+
+// formatScalarType returns the C# type expression for a scalar AST type.
+//
+// Strings, booleans and numerics map to the matching BCL primitive type.
+// Bytes are rendered as `byte`. `any` becomes `object`.
+func formatScalarType(def ast.ScalarType) string {
+	switch def.ScalarKind {
+	case ast.KindString:
+		return "string"
+	case ast.KindBytes:
+		return "byte"
+	case ast.KindInt8:
+		return "sbyte"
+	case ast.KindUint8:
+		return "byte"
+	case ast.KindInt16:
+		return "short"
+	case ast.KindUint16:
+		return "ushort"
+	case ast.KindInt32:
+		return "int"
+	case ast.KindUint32:
+		return "uint"
+	case ast.KindInt64:
+		return "long"
+	case ast.KindUint64:
+		return "ulong"
+	case ast.KindFloat32:
+		return "float"
+	case ast.KindFloat64:
+		return "double"
+	case ast.KindBool:
+		return "bool"
+	case ast.KindAny:
+		return "object"
+	}
+	return "object"
+}
+
+// formatScalarValue renders a Go value as a C# literal of the given
+// scalar kind. It is used for field defaults and constants.
+func formatScalarValue(t ast.ScalarKind, val any) string {
+	if list, ok := val.([]any); ok {
+		items := make([]string, 0, len(list))
+		for _, item := range list {
+			items = append(items, formatScalarValue(t, item))
+		}
+		return strings.Join(items, ", ")
+	}
+
+	parseFloatVal := func(val any) float64 {
+		if v, ok := val.(int64); ok {
+			return float64(v)
+		}
+		if v, ok := val.(float64); ok {
+			return v
+		}
+		return 0
+	}
+
+	switch t {
+	case ast.KindBool:
+		if b, ok := val.(bool); ok && b {
+			return "true"
+		}
+		return "false"
+	case ast.KindString:
+		s, _ := val.(string)
+		return fmt.Sprintf("%q", s)
+	case ast.KindInt64:
+		return fmt.Sprintf("%dL", tools.AnyToInt64(val))
+	case ast.KindUint64:
+		return fmt.Sprintf("%dUL", tools.AnyToInt64(val))
+	case ast.KindInt8, ast.KindUint8, ast.KindInt16, ast.KindUint16, ast.KindInt32, ast.KindUint32:
+		return fmt.Sprintf("%d", tools.AnyToInt64(val))
+	case ast.KindFloat32:
+		return fmt.Sprintf("%gf", parseFloatVal(val))
+	case ast.KindFloat64:
+		return fmt.Sprintf("%gd", parseFloatVal(val))
+	}
+
+	return fmt.Sprintf("%#v", val)
 }

--- a/internal/jennies/csharp/types.go
+++ b/internal/jennies/csharp/types.go
@@ -1,0 +1,143 @@
+package csharp
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/languages"
+)
+
+// typeFormatter renders an ast.Type as a C# type expression and tracks
+// the namespaces that need to be imported as a side effect.
+type typeFormatter struct {
+	config  Config
+	context languages.Context
+	imports *importMap
+}
+
+func newTypeFormatter(ctx languages.Context, config Config, imports *importMap) *typeFormatter {
+	return &typeFormatter{
+		context: ctx,
+		config:  config,
+		imports: imports,
+	}
+}
+
+// withImports returns a copy of the formatter that records imports on the
+// given map. Used when the formatter is reused across files in the same
+// schema (one importMap per output file).
+func (tf *typeFormatter) withImports(imports *importMap) *typeFormatter {
+	clone := *tf
+	clone.imports = imports
+	return &clone
+}
+
+// formatFieldType renders the C# type expression for a field/property.
+func (tf *typeFormatter) formatFieldType(def ast.Type) string {
+	switch def.Kind {
+	case ast.KindScalar:
+		return formatScalarType(def.AsScalar())
+	case ast.KindRef:
+		return tf.formatReference(def.AsRef())
+	case ast.KindArray:
+		return tf.formatArray(def.AsArray())
+	case ast.KindMap:
+		return tf.formatMap(def.AsMap())
+	case ast.KindStruct:
+		// Anonymous structs should have been lifted by the
+		// AnonymousStructsToNamed compiler pass; if one slips through,
+		// fall back to `object`.
+		return "object"
+	case ast.KindConstantRef:
+		return tf.formatConstantReference(def.AsConstantRef())
+	}
+	return "object"
+}
+
+func (tf *typeFormatter) formatReference(def ast.RefType) string {
+	object, found := tf.context.LocateObjectByRef(def)
+	if found {
+		switch object.Type.Kind {
+		case ast.KindScalar:
+			return formatScalarType(object.Type.AsScalar())
+		case ast.KindMap:
+			return tf.formatMap(object.Type.AsMap())
+		case ast.KindArray:
+			return tf.formatArray(object.Type.AsArray())
+		}
+	}
+	tf.imports.addPackage(def.ReferredPkg)
+	return formatObjectName(def.ReferredType)
+}
+
+func (tf *typeFormatter) formatConstantReference(def ast.ConstantReferenceType) string {
+	object, found := tf.context.LocateObject(def.ReferredPkg, def.ReferredType)
+	if !found {
+		return "object"
+	}
+	if object.Type.IsEnum() {
+		tf.imports.addPackage(def.ReferredPkg)
+		return formatObjectName(def.ReferredType)
+	}
+	if object.Type.IsScalar() {
+		return formatScalarType(object.Type.AsScalar())
+	}
+	return "object"
+}
+
+func (tf *typeFormatter) formatArray(def ast.ArrayType) string {
+	tf.imports.addNamespace("System.Collections.Generic")
+	return fmt.Sprintf("List<%s>", tf.formatFieldType(def.ValueType))
+}
+
+func (tf *typeFormatter) formatMap(def ast.MapType) string {
+	tf.imports.addNamespace("System.Collections.Generic")
+	keyType := formatScalarType(def.IndexType.AsScalar())
+	return fmt.Sprintf("Dictionary<%s, %s>", keyType, tf.formatFieldType(def.ValueType))
+}
+
+// emptyValueForType returns a sensible default-value expression used in
+// the parameterless constructor when no explicit default is provided.
+func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
+	switch def.Kind {
+	case ast.KindArray:
+		tf.imports.addNamespace("System.Collections.Generic")
+		return fmt.Sprintf("new %s()", tf.formatArray(def.AsArray()))
+	case ast.KindMap:
+		tf.imports.addNamespace("System.Collections.Generic")
+		return fmt.Sprintf("new %s()", tf.formatMap(def.AsMap()))
+	case ast.KindRef:
+		referred, found := tf.context.LocateObjectByRef(def.AsRef())
+		if found && referred.Type.IsEnum() {
+			defaultMember := referred.Type.AsEnum().Values[0]
+			tf.imports.addPackage(def.AsRef().ReferredPkg)
+			return fmt.Sprintf("%s.%s", formatObjectName(referred.Name), formatObjectName(defaultMember.Name))
+		}
+		tf.imports.addPackage(def.AsRef().ReferredPkg)
+		return fmt.Sprintf("new %s()", formatObjectName(def.AsRef().ReferredType))
+	case ast.KindStruct:
+		return "new object()"
+	case ast.KindScalar:
+		switch def.AsScalar().ScalarKind {
+		case ast.KindBool:
+			return "false"
+		case ast.KindFloat32:
+			return "0f"
+		case ast.KindFloat64:
+			return "0d"
+		case ast.KindInt8, ast.KindInt16, ast.KindInt32, ast.KindUint8, ast.KindUint16, ast.KindUint32:
+			return "0"
+		case ast.KindInt64:
+			return "0L"
+		case ast.KindUint64:
+			return "0UL"
+		case ast.KindString:
+			return `""`
+		case ast.KindBytes:
+			return "(byte) 0"
+		case ast.KindAny:
+			return "new object()"
+		}
+	}
+	return "default!"
+}

--- a/internal/jennies/csharp/types.go
+++ b/internal/jennies/csharp/types.go
@@ -2,9 +2,11 @@ package csharp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/tools"
 )
 
 // typeFormatter renders an ast.Type as a C# type expression and tracks
@@ -41,6 +43,8 @@ func (tf *typeFormatter) formatFieldType(def ast.Type) string {
 		return tf.formatReference(def.AsRef())
 	case ast.KindArray:
 		return tf.formatArray(def.AsArray())
+	case ast.KindComposableSlot:
+		return tf.formatComposable(def.AsComposableSlot())
 	case ast.KindMap:
 		return tf.formatMap(def.AsMap())
 	case ast.KindStruct:
@@ -52,6 +56,14 @@ func (tf *typeFormatter) formatFieldType(def ast.Type) string {
 		return tf.formatConstantReference(def.AsConstantRef())
 	}
 	return "object"
+}
+
+// formatComposable renders a composable-slot type. Slots resolve to
+// their variant interface (e.g. `Cog.Variants.Dataquery`) which lives
+// under `<NamespaceRoot>.Cog.Variants`. The fully-qualified form is
+// emitted so no extra `using` is required at the call site.
+func (tf *typeFormatter) formatComposable(def ast.ComposableSlotType) string {
+	return fmt.Sprintf("Cog.Variants.%s", formatObjectName(string(def.Variant)))
 }
 
 func (tf *typeFormatter) formatReference(def ast.RefType) string {
@@ -98,7 +110,15 @@ func (tf *typeFormatter) formatMap(def ast.MapType) string {
 
 // emptyValueForType returns a sensible default-value expression used in
 // the parameterless constructor when no explicit default is provided.
+//
+// When useBuilders is true, refs that have a registered builder fall
+// back to invoking the builder's `Build()` method (used by Builder
+// generation when a nested-builder slot needs an empty placeholder).
 func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
+	return tf.emptyValueForTypeOpts(def, false)
+}
+
+func (tf *typeFormatter) emptyValueForTypeOpts(def ast.Type, useBuilders bool) string {
 	switch def.Kind {
 	case ast.KindArray:
 		tf.imports.addNamespace("System.Collections.Generic")
@@ -112,6 +132,10 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 			defaultMember := referred.Type.AsEnum().Values[0]
 			tf.imports.addPackage(def.AsRef().ReferredPkg)
 			return fmt.Sprintf("%s.%s", formatObjectName(referred.Name), formatObjectName(defaultMember.Name))
+		}
+		if useBuilders && tf.typeHasBuilder(def) {
+			tf.imports.addPackage(def.AsRef().ReferredPkg)
+			return fmt.Sprintf("new %sBuilder().Build()", formatObjectName(def.AsRef().ReferredType))
 		}
 		tf.imports.addPackage(def.AsRef().ReferredPkg)
 		return fmt.Sprintf("new %s()", formatObjectName(def.AsRef().ReferredType))
@@ -141,3 +165,160 @@ func (tf *typeFormatter) emptyValueForType(def ast.Type) string {
 	}
 	return "default!"
 }
+
+// ---------------------------------------------------------------------
+// Builder-jenny helpers (used only by the Builder template).
+// ---------------------------------------------------------------------
+
+// typeHasBuilder reports whether a builder is registered for the given
+// type. Used by the Builder template to decide whether option arguments
+// should accept an `IBuilder<T>` instead of the raw `T`.
+func (tf *typeFormatter) typeHasBuilder(def ast.Type) bool {
+	return tf.context.ResolveToBuilder(def)
+}
+
+// resolvesToComposableSlot reports whether the type ultimately resolves
+// to a composable slot (e.g. `Dataquery`). Composable slots are
+// rendered as their variant interface and surfaced via `IBuilder<T>`.
+func (tf *typeFormatter) resolvesToComposableSlot(def ast.Type) bool {
+	_, found := tf.context.ResolveToComposableSlot(def)
+	return found
+}
+
+// formatBuilderFieldType renders the C# type expression used for a
+// builder option's parameter slot. When the underlying type has a
+// builder (or resolves to a composable slot), it is wrapped in
+// `Cog.IBuilder<T>` (or `List<…>` / `Dictionary<string, …>` for
+// collections of builders).
+func (tf *typeFormatter) formatBuilderFieldType(def ast.Type) string {
+	if tf.resolvesToComposableSlot(def) || tf.typeHasBuilder(def) {
+		switch def.Kind {
+		case ast.KindArray:
+			return tf.formatBuilderCollectionFields(def.AsArray().ValueType, "List", "List<")
+		case ast.KindMap:
+			keyType := formatScalarType(def.AsMap().IndexType.AsScalar())
+			return tf.formatBuilderCollectionFields(def.AsMap().ValueType, "Dictionary", fmt.Sprintf("Dictionary<%s, ", keyType))
+		default:
+			tf.imports.addPackage("cog")
+			return fmt.Sprintf("Cog.IBuilder<%s>", tf.formatFieldType(def))
+		}
+	}
+
+	return tf.formatFieldType(def)
+}
+
+func (tf *typeFormatter) formatBuilderCollectionFields(def ast.Type, collection string, prefix string) string {
+	tf.imports.addNamespace("System.Collections.Generic")
+	_ = collection
+	if def.Kind == ast.KindArray || def.Kind == ast.KindMap {
+		return fmt.Sprintf("%s%s>", prefix, tf.formatBuilderFieldType(def))
+	}
+
+	tf.imports.addPackage("cog")
+	return fmt.Sprintf("%sCog.IBuilder<%s>>", prefix, tf.formatFieldType(def))
+}
+
+// formatFieldPath renders a dotted field-access expression for read
+// positions (e.g. `parent.child.field`). Path elements after an `any`
+// boundary are dropped because the value beyond that point is opaque.
+func (tf *typeFormatter) formatFieldPath(fieldPath ast.Path) string {
+	parts := make([]string, 0)
+	for i, part := range fieldPath {
+		output := formatFieldName(part.Identifier)
+
+		if i > 0 && fieldPath[i-1].Type.IsAny() {
+			return output
+		}
+
+		parts = append(parts, output)
+	}
+
+	return strings.Join(parts, ".")
+}
+
+// formatPathIndex renders a map/array indexing expression (the value
+// inside the `[…]`). Constants become C# literals; argument-driven
+// indices reference the formatted argument name.
+func (tf *typeFormatter) formatPathIndex(pathIndex *ast.PathIndex) string {
+	if pathIndex.Constant != nil {
+		switch v := pathIndex.Constant.(type) {
+		case string:
+			return fmt.Sprintf("%q", v)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return formatArgName(pathIndex.Argument.Name)
+}
+
+// formatAssignmentPath renders the LHS of an assignment, walking the
+// AST path from the resource root (typically `this.@internal`) down to
+// the field being assigned. Map indexing nodes produce `[key]` access;
+// the trailing element keeps its dot syntax even when annotated as
+// `any` so Phase 4 stays out of the cast-emission business.
+func (tf *typeFormatter) formatAssignmentPath(resourceRoot string, fieldPath ast.Path) string {
+	path := resourceRoot
+
+	for i := range fieldPath {
+		output := fieldPath[i].Identifier
+		if !fieldPath[i].Root {
+			output = formatFieldName(output)
+		}
+
+		if fieldPath[i].Index != nil {
+			path += output + "[" + tf.formatPathIndex(fieldPath[i].Index) + "]"
+			continue
+		}
+
+		// Without a TypeHint (or as the trailing element) we just
+		// append the field; the cast path used by Java to navigate
+		// `any` values isn't needed for the C# scenarios we currently
+		// support and would obscure generated code.
+		if !fieldPath[i].Type.IsAny() || fieldPath[i].TypeHint == nil || i == len(fieldPath)-1 {
+			path += "." + output
+			continue
+		}
+
+		path = fmt.Sprintf("((%s) %s.%s)", tf.formatReference(fieldPath[i].TypeHint.AsRef()), path, output)
+	}
+
+	return path
+}
+
+// formatRefType renders a literal value of the destination type. It is
+// used by constant assignments (e.g. discriminator fields). For enum
+// destinations the corresponding member is emitted; otherwise we fall
+// back to a Go-style %#v rendering.
+func (tf *typeFormatter) formatRefType(destinationType ast.Type, value any) string {
+	if !destinationType.IsRef() {
+		if value == nil {
+			return "null"
+		}
+		switch v := value.(type) {
+		case string:
+			return fmt.Sprintf("%q", v)
+		case bool:
+			if v {
+				return "true"
+			}
+			return "false"
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+
+	referred, found := tf.context.LocateObjectByRef(destinationType.AsRef())
+	if !found {
+		return fmt.Sprintf("%#v", value)
+	}
+	if referred.Type.IsEnum() {
+		member, _ := referred.Type.AsEnum().MemberForValue(value)
+		tf.imports.addPackage(referred.SelfRef.ReferredPkg)
+		return fmt.Sprintf("%s.%s", formatObjectName(referred.Name), formatEnumMemberName(member.Name))
+	}
+	return fmt.Sprintf("%#v", value)
+}
+
+// _unused keeps the tools import alive when the file is trimmed during
+// edits.
+var _ = tools.UpperCamelCase

--- a/scripts/ci/build-csharp.sh
+++ b/scripts/ci/build-csharp.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Exit on error. Append "|| true" if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+
+dotnet build --nologo generated/csharp

--- a/testdata/generated/src/Grafana/Foundation/Defaults/BoolOrString.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/BoolOrString.cs
@@ -1,0 +1,24 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Text.Json.Serialization;
+
+[JsonConverter(typeof(BoolOrStringJsonConverter))]
+public class BoolOrString
+{
+    [JsonPropertyName("Bool")]
+    public bool? Bool;
+    [JsonPropertyName("String")]
+    public string String;
+
+    public BoolOrString()
+    {
+    }
+
+    public BoolOrString(bool? boolArg, string stringArg)
+    {
+        this.Bool = boolArg;
+        this.String = stringArg;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Defaults/BoolOrStringJsonConverter.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/BoolOrStringJsonConverter.cs
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class BoolOrStringJsonConverter : JsonConverter<BoolOrString>
+{
+    public override BoolOrString Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        var result = new BoolOrString();
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.True:
+            case JsonTokenType.False:
+                result.Bool = reader.GetBoolean();
+                break;
+            case JsonTokenType.String:
+                result.String = reader.GetString();
+                break;
+            default:
+                throw new JsonException("unexpected token while deserialising BoolOrString: " + reader.TokenType);
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, BoolOrString value, JsonSerializerOptions options)
+    {
+        if (value.Bool != null) { JsonSerializer.Serialize(writer, value.Bool.Value, options); }
+        else if (value.String != null) { JsonSerializer.Serialize(writer, value.String, options); }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Defaults/StringOrArrayOfString.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/StringOrArrayOfString.cs
@@ -1,0 +1,25 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+[JsonConverter(typeof(StringOrArrayOfStringJsonConverter))]
+public class StringOrArrayOfString
+{
+    [JsonPropertyName("String")]
+    public string String;
+    [JsonPropertyName("ArrayOfString")]
+    public List<string> ArrayOfString;
+
+    public StringOrArrayOfString()
+    {
+    }
+
+    public StringOrArrayOfString(string stringArg, List<string> arrayOfString)
+    {
+        this.String = stringArg;
+        this.ArrayOfString = arrayOfString;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Defaults/StringOrArrayOfStringJsonConverter.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/StringOrArrayOfStringJsonConverter.cs
@@ -1,0 +1,36 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class StringOrArrayOfStringJsonConverter : JsonConverter<StringOrArrayOfString>
+{
+    public override StringOrArrayOfString Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        var result = new StringOrArrayOfString();
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                result.String = reader.GetString();
+                break;
+            case JsonTokenType.StartArray:
+                result.ArrayOfString = JsonSerializer.Deserialize<List<string>>(ref reader, options);
+                break;
+            default:
+                throw new JsonException("unexpected token while deserialising StringOrArrayOfString: " + reader.TokenType);
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, StringOrArrayOfString value, JsonSerializerOptions options)
+    {
+        if (value.String != null) { JsonSerializer.Serialize(writer, value.String, options); }
+        else if (value.ArrayOfString != null) { JsonSerializer.Serialize(writer, value.ArrayOfString, options); }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Defaults/TextVariable.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/TextVariable.cs
@@ -1,0 +1,29 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Text.Json.Serialization;
+
+public class TextVariable
+{
+    [JsonPropertyName("name")]
+    public string Name;
+    [JsonPropertyName("current")]
+    public VariableOption Current;
+    [JsonPropertyName("skipUrlSync")]
+    public bool SkipUrlSync;
+
+    public TextVariable()
+    {
+        this.Name = "";
+        this.Current = new VariableOption();
+        this.SkipUrlSync = false;
+    }
+
+    public TextVariable(string name, VariableOption current, bool skipUrlSync)
+    {
+        this.Name = name;
+        this.Current = current;
+        this.SkipUrlSync = skipUrlSync;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Defaults/VariableOption.cs
+++ b/testdata/generated/src/Grafana/Foundation/Defaults/VariableOption.cs
@@ -1,0 +1,28 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Defaults;
+
+using System.Text.Json.Serialization;
+
+public class VariableOption
+{
+    [JsonPropertyName("selected")]
+    public BoolOrString Selected;
+    [JsonPropertyName("text")]
+    public StringOrArrayOfString Text;
+    [JsonPropertyName("value")]
+    public StringOrArrayOfString Value;
+
+    public VariableOption()
+    {
+        this.Text = new StringOrArrayOfString();
+        this.Value = new StringOrArrayOfString();
+    }
+
+    public VariableOption(BoolOrString selected, StringOrArrayOfString text, StringOrArrayOfString value)
+    {
+        this.Selected = selected;
+        this.Text = text;
+        this.Value = value;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Arrays.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Arrays.cs
@@ -1,0 +1,42 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class Arrays
+{
+    [JsonPropertyName("ints")]
+    public List<long> Ints;
+    [JsonPropertyName("strings")]
+    public List<string> Strings;
+    [JsonPropertyName("arrayOfArray")]
+    public List<List<string>> ArrayOfArray;
+    [JsonPropertyName("refs")]
+    public List<Variable> Refs;
+    [JsonPropertyName("anonymousStructs")]
+    public List<EqualityArraysAnonymousStructs> AnonymousStructs;
+    [JsonPropertyName("arrayOfAny")]
+    public List<object> ArrayOfAny;
+
+    public Arrays()
+    {
+        this.Ints = new List<long>();
+        this.Strings = new List<string>();
+        this.ArrayOfArray = new List<List<string>>();
+        this.Refs = new List<Variable>();
+        this.AnonymousStructs = new List<EqualityArraysAnonymousStructs>();
+        this.ArrayOfAny = new List<object>();
+    }
+
+    public Arrays(List<long> ints, List<string> strings, List<List<string>> arrayOfArray, List<Variable> refs, List<EqualityArraysAnonymousStructs> anonymousStructs, List<object> arrayOfAny)
+    {
+        this.Ints = ints;
+        this.Strings = strings;
+        this.ArrayOfArray = arrayOfArray;
+        this.Refs = refs;
+        this.AnonymousStructs = anonymousStructs;
+        this.ArrayOfAny = arrayOfAny;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Container.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Container.cs
@@ -1,0 +1,33 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+public class Container
+{
+    [JsonPropertyName("stringField")]
+    public string StringField;
+    [JsonPropertyName("intField")]
+    public long IntField;
+    [JsonPropertyName("enumField")]
+    public Direction EnumField;
+    [JsonPropertyName("refField")]
+    public Variable RefField;
+
+    public Container()
+    {
+        this.StringField = "";
+        this.IntField = 0L;
+        this.EnumField = Direction.Top;
+        this.RefField = new Variable();
+    }
+
+    public Container(string stringField, long intField, Direction enumField, Variable refField)
+    {
+        this.StringField = stringField;
+        this.IntField = intField;
+        this.EnumField = enumField;
+        this.RefField = refField;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Direction.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Direction.cs
@@ -1,0 +1,18 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+[JsonConverter(typeof(JsonStringEnumConverter<Direction>))]
+public enum Direction
+{
+    [JsonStringEnumMemberName("top")]
+    Top,
+    [JsonStringEnumMemberName("bottom")]
+    Bottom,
+    [JsonStringEnumMemberName("left")]
+    Left,
+    [JsonStringEnumMemberName("right")]
+    Right
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/EqualityArraysAnonymousStructs.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/EqualityArraysAnonymousStructs.cs
@@ -1,0 +1,21 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+public class EqualityArraysAnonymousStructs
+{
+    [JsonPropertyName("inner")]
+    public string Inner;
+
+    public EqualityArraysAnonymousStructs()
+    {
+        this.Inner = "";
+    }
+
+    public EqualityArraysAnonymousStructs(string inner)
+    {
+        this.Inner = inner;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/EqualityMapsAnonymousStructs.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/EqualityMapsAnonymousStructs.cs
@@ -1,0 +1,21 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+public class EqualityMapsAnonymousStructs
+{
+    [JsonPropertyName("inner")]
+    public string Inner;
+
+    public EqualityMapsAnonymousStructs()
+    {
+        this.Inner = "";
+    }
+
+    public EqualityMapsAnonymousStructs(string inner)
+    {
+        this.Inner = inner;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Maps.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Maps.cs
@@ -1,0 +1,38 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class Maps
+{
+    [JsonPropertyName("ints")]
+    public Dictionary<string, long> Ints;
+    [JsonPropertyName("strings")]
+    public Dictionary<string, string> Strings;
+    [JsonPropertyName("refs")]
+    public Dictionary<string, Variable> Refs;
+    [JsonPropertyName("anonymousStructs")]
+    public Dictionary<string, EqualityMapsAnonymousStructs> AnonymousStructs;
+    [JsonPropertyName("stringToAny")]
+    public Dictionary<string, object> StringToAny;
+
+    public Maps()
+    {
+        this.Ints = new Dictionary<string, long>();
+        this.Strings = new Dictionary<string, string>();
+        this.Refs = new Dictionary<string, Variable>();
+        this.AnonymousStructs = new Dictionary<string, EqualityMapsAnonymousStructs>();
+        this.StringToAny = new Dictionary<string, object>();
+    }
+
+    public Maps(Dictionary<string, long> ints, Dictionary<string, string> strings, Dictionary<string, Variable> refs, Dictionary<string, EqualityMapsAnonymousStructs> anonymousStructs, Dictionary<string, object> stringToAny)
+    {
+        this.Ints = ints;
+        this.Strings = strings;
+        this.Refs = refs;
+        this.AnonymousStructs = anonymousStructs;
+        this.StringToAny = stringToAny;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Optionals.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Optionals.cs
@@ -1,0 +1,29 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+public class Optionals
+{
+    [JsonPropertyName("stringField")]
+    public string StringField;
+    [JsonPropertyName("enumField")]
+    public Direction EnumField;
+    [JsonPropertyName("refField")]
+    public Variable RefField;
+    [JsonPropertyName("byteField")]
+    public byte ByteField;
+
+    public Optionals()
+    {
+    }
+
+    public Optionals(string stringField, Direction enumField, Variable refField, byte byteField)
+    {
+        this.StringField = stringField;
+        this.EnumField = enumField;
+        this.RefField = refField;
+        this.ByteField = byteField;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Equality/Variable.cs
+++ b/testdata/generated/src/Grafana/Foundation/Equality/Variable.cs
@@ -1,0 +1,21 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Equality;
+
+using System.Text.Json.Serialization;
+
+public class Variable
+{
+    [JsonPropertyName("name")]
+    public string Name;
+
+    public Variable()
+    {
+        this.Name = "";
+    }
+
+    public Variable(string name)
+    {
+        this.Name = name;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Validation/Dashboard.cs
+++ b/testdata/generated/src/Grafana/Foundation/Validation/Dashboard.cs
@@ -1,0 +1,40 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Validation;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class Dashboard
+{
+    [JsonPropertyName("uid")]
+    public string Uid;
+    [JsonPropertyName("id")]
+    public long Id;
+    [JsonPropertyName("title")]
+    public string Title;
+    [JsonPropertyName("tags")]
+    public List<string> Tags;
+    [JsonPropertyName("labels")]
+    public Dictionary<string, string> Labels;
+    [JsonPropertyName("panels")]
+    public List<Panel> Panels;
+
+    public Dashboard()
+    {
+        this.Title = "";
+        this.Tags = new List<string>();
+        this.Labels = new Dictionary<string, string>();
+        this.Panels = new List<Panel>();
+    }
+
+    public Dashboard(string uid, long id, string title, List<string> tags, Dictionary<string, string> labels, List<Panel> panels)
+    {
+        this.Uid = uid;
+        this.Id = id;
+        this.Title = title;
+        this.Tags = tags;
+        this.Labels = labels;
+        this.Panels = panels;
+    }
+}

--- a/testdata/generated/src/Grafana/Foundation/Validation/Panel.cs
+++ b/testdata/generated/src/Grafana/Foundation/Validation/Panel.cs
@@ -1,0 +1,21 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+namespace Grafana.Foundation.Validation;
+
+using System.Text.Json.Serialization;
+
+public class Panel
+{
+    [JsonPropertyName("title")]
+    public string Title;
+
+    public Panel()
+    {
+        this.Title = "";
+    }
+
+    public Panel(string title)
+    {
+        this.Title = title;
+    }
+}

--- a/testdata/jennies/builders/anonymous_struct/CSharpBuilder/src/Grafana/Foundation/AnonymousStruct/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/anonymous_struct/CSharpBuilder/src/Grafana/Foundation/AnonymousStruct/SomeStructBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.AnonymousStruct;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Time(object time)
+    {
+        this.@internal.Time = time;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/array_append/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/array_append/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
@@ -1,0 +1,27 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Tags(string tags)
+    {
+        if (this.@internal.Tags == null)
+        {
+            this.@internal.Tags = new List<string>();
+        }
+        this.@internal.Tags.Add(tags);
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/basic_struct/CSharpBuilder/src/Grafana/Foundation/BasicStruct/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/basic_struct/CSharpBuilder/src/Grafana/Foundation/BasicStruct/SomeStructBuilder.cs
@@ -1,0 +1,41 @@
+namespace Grafana.Foundation.BasicStruct;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Id(long id)
+    {
+        this.@internal.Id = id;
+        return this;
+    }
+
+    public SomeStructBuilder Uid(string uid)
+    {
+        this.@internal.Uid = uid;
+        return this;
+    }
+
+    public SomeStructBuilder Tags(List<string> tags)
+    {
+        this.@internal.Tags = tags;
+        return this;
+    }
+
+    public SomeStructBuilder LiveNow(bool liveNow)
+    {
+        this.@internal.LiveNow = liveNow;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/basic_struct_defaults/CSharpBuilder/src/Grafana/Foundation/BasicStructDefaults/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/basic_struct_defaults/CSharpBuilder/src/Grafana/Foundation/BasicStructDefaults/SomeStructBuilder.cs
@@ -1,0 +1,41 @@
+namespace Grafana.Foundation.BasicStructDefaults;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Id(long id)
+    {
+        this.@internal.Id = id;
+        return this;
+    }
+
+    public SomeStructBuilder Uid(string uid)
+    {
+        this.@internal.Uid = uid;
+        return this;
+    }
+
+    public SomeStructBuilder Tags(List<string> tags)
+    {
+        this.@internal.Tags = tags;
+        return this;
+    }
+
+    public SomeStructBuilder LiveNow(bool liveNow)
+    {
+        this.@internal.LiveNow = liveNow;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation/CSharpBuilder/src/Grafana/Foundation/BuilderDelegation/DashboardBuilder.cs
+++ b/testdata/jennies/builders/builder_delegation/CSharpBuilder/src/Grafana/Foundation/BuilderDelegation/DashboardBuilder.cs
@@ -1,0 +1,66 @@
+namespace Grafana.Foundation.BuilderDelegation;
+
+
+public class DashboardBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public DashboardBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public DashboardBuilder Id(long id)
+    {
+        this.@internal.Id = id;
+        return this;
+    }
+
+    public DashboardBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public DashboardBuilder Links(List<Cog.IBuilder<DashboardLink>> links)
+    {
+        List<DashboardLink> linksResources = new List<DashboardLink>();
+        foreach (Cog.IBuilder<DashboardLink> r1 in links)
+        {
+                DashboardLink linksDepth1 = r1.Build();
+                linksResources.Add(linksDepth1);
+        }
+        this.@internal.Links = linksResources;
+        return this;
+    }
+
+    public DashboardBuilder LinksOfLinks(List<List<Cog.IBuilder<DashboardLink>>> linksOfLinks)
+    {
+        List<List<DashboardLink>> linksOfLinksResources = new List<List<DashboardLink>>();
+        foreach (List<Cog.IBuilder<DashboardLink>> r1 in linksOfLinks)
+        {
+                List<DashboardLink> linksOfLinksDepth1 = new List<DashboardLink>();
+        foreach (Cog.IBuilder<DashboardLink> r2 in r1)
+        {
+                DashboardLink linksOfLinksDepth2 = r2.Build();
+                linksOfLinksDepth1.Add(linksOfLinksDepth2);
+        }
+
+                linksOfLinksResources.Add(linksOfLinksDepth1);
+        }
+        this.@internal.LinksOfLinks = linksOfLinksResources;
+        return this;
+    }
+
+    public DashboardBuilder SingleLink(Cog.IBuilder<DashboardLink> singleLink)
+    {
+        DashboardLink singleLinkResource = singleLink.Build();
+        this.@internal.SingleLink = singleLinkResource;
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation/CSharpBuilder/src/Grafana/Foundation/BuilderDelegation/DashboardLinkBuilder.cs
+++ b/testdata/jennies/builders/builder_delegation/CSharpBuilder/src/Grafana/Foundation/BuilderDelegation/DashboardLinkBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.BuilderDelegation;
+
+
+public class DashboardLinkBuilder : Cog.IBuilder<DashboardLink>
+{
+    protected readonly DashboardLink @internal;
+
+    public DashboardLinkBuilder()
+    {
+        this.@internal = new DashboardLink();
+    }
+
+    public DashboardLinkBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public DashboardLinkBuilder Url(string url)
+    {
+        this.@internal.Url = url;
+        return this;
+    }
+
+    public DashboardLink Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/DashboardBuilder.cs
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/DashboardBuilder.cs
@@ -1,0 +1,43 @@
+namespace Grafana.Foundation.BuilderDelegationInDisjunction;
+
+
+public class DashboardBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public DashboardBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public DashboardBuilder SingleLinkOrString(Cog.IBuilder<object> singleLinkOrString)
+    {
+        object singleLinkOrStringResource = singleLinkOrString.Build();
+        this.@internal.SingleLinkOrString = singleLinkOrStringResource;
+        return this;
+    }
+
+    public DashboardBuilder LinksOrStrings(List<Cog.IBuilder<object>> linksOrStrings)
+    {
+        List<object> linksOrStringsResources = new List<object>();
+        foreach (Cog.IBuilder<object> r1 in linksOrStrings)
+        {
+                object linksOrStringsDepth1 = r1.Build();
+                linksOrStringsResources.Add(linksOrStringsDepth1);
+        }
+        this.@internal.LinksOrStrings = linksOrStringsResources;
+        return this;
+    }
+
+    public DashboardBuilder DisjunctionOfBuilders(Cog.IBuilder<object> disjunctionOfBuilders)
+    {
+        object disjunctionOfBuildersResource = disjunctionOfBuilders.Build();
+        this.@internal.DisjunctionOfBuilders = disjunctionOfBuildersResource;
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/DashboardLinkBuilder.cs
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/DashboardLinkBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.BuilderDelegationInDisjunction;
+
+
+public class DashboardLinkBuilder : Cog.IBuilder<DashboardLink>
+{
+    protected readonly DashboardLink @internal;
+
+    public DashboardLinkBuilder()
+    {
+        this.@internal = new DashboardLink();
+    }
+
+    public DashboardLinkBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public DashboardLinkBuilder Url(string url)
+    {
+        this.@internal.Url = url;
+        return this;
+    }
+
+    public DashboardLink Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/ExternalLinkBuilder.cs
+++ b/testdata/jennies/builders/builder_delegation_in_disjunction/CSharpBuilder/src/Grafana/Foundation/BuilderDelegationInDisjunction/ExternalLinkBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.BuilderDelegationInDisjunction;
+
+
+public class ExternalLinkBuilder : Cog.IBuilder<ExternalLink>
+{
+    protected readonly ExternalLink @internal;
+
+    public ExternalLinkBuilder()
+    {
+        this.@internal = new ExternalLink();
+    }
+
+    public ExternalLinkBuilder Url(string url)
+    {
+        this.@internal.Url = url;
+        return this;
+    }
+
+    public ExternalLink Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/composable_slot/CSharpBuilder/src/Grafana/Foundation/ComposableSlot/LokiBuilderBuilder.cs
+++ b/testdata/jennies/builders/composable_slot/CSharpBuilder/src/Grafana/Foundation/ComposableSlot/LokiBuilderBuilder.cs
@@ -1,0 +1,36 @@
+namespace Grafana.Foundation.ComposableSlot;
+
+
+public class LokiBuilderBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public LokiBuilderBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public LokiBuilderBuilder Target(Cog.IBuilder<Cog.Variants.Dataquery> target)
+    {
+        Cog.Variants.Dataquery targetResource = target.Build();
+        this.@internal.Target = targetResource;
+        return this;
+    }
+
+    public LokiBuilderBuilder Targets(List<Cog.IBuilder<Cog.Variants.Dataquery>> targets)
+    {
+        List<Cog.Variants.Dataquery> targetsResources = new List<Cog.Variants.Dataquery>();
+        foreach (Cog.IBuilder<Cog.Variants.Dataquery> r1 in targets)
+        {
+                Cog.Variants.Dataquery targetsDepth1 = r1.Build();
+                targetsResources.Add(targetsDepth1);
+        }
+        this.@internal.Targets = targetsResources;
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/constant_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/constant_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
@@ -1,0 +1,41 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Editable()
+    {
+        this.@internal.Editable = true;
+        return this;
+    }
+
+    public SomeStructBuilder ReadonlyArg()
+    {
+        this.@internal.Editable = false;
+        return this;
+    }
+
+    public SomeStructBuilder AutoRefresh()
+    {
+        this.@internal.AutoRefresh = true;
+        return this;
+    }
+
+    public SomeStructBuilder NoAutoRefresh()
+    {
+        this.@internal.AutoRefresh = false;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/constraints/CSharpBuilder/src/Grafana/Foundation/Constraints/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/constraints/CSharpBuilder/src/Grafana/Foundation/Constraints/SomeStructBuilder.cs
@@ -1,0 +1,41 @@
+namespace Grafana.Foundation.Constraints;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Id(ulong id)
+    {
+        if (!(id >= 5))
+        {
+            throw new System.ArgumentException("id must be >= 5");
+        }
+        if (!(id < 10))
+        {
+            throw new System.ArgumentException("id must be < 10");
+        }
+        this.@internal.Id = id;
+        return this;
+    }
+
+    public SomeStructBuilder Title(string title)
+    {
+        if (!(title.Length >= 1))
+        {
+            throw new System.ArgumentException("title.Length must be >= 1");
+        }
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/constructor_argument/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/constructor_argument/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder(string title)
+    {
+        this.@internal = new SomeStruct();
+        this.@internal.Title = title;
+    }
+
+    public SomeStructBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/constructor_initializations/CSharpBuilder/src/Grafana/Foundation/ConstructorInitializations/SomePanelBuilder.cs
+++ b/testdata/jennies/builders/constructor_initializations/CSharpBuilder/src/Grafana/Foundation/ConstructorInitializations/SomePanelBuilder.cs
@@ -1,0 +1,25 @@
+namespace Grafana.Foundation.ConstructorInitializations;
+
+
+public class SomePanelBuilder : Cog.IBuilder<SomePanel>
+{
+    protected readonly SomePanel @internal;
+
+    public SomePanelBuilder()
+    {
+        this.@internal = new SomePanel();
+        this.@internal.Type = "panel_type";
+        this.@internal.Cursor = CursorMode.Tooltip;
+    }
+
+    public SomePanelBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomePanel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/dashboard_panel/CSharpBuilder/src/Grafana/Foundation/Dashboard/PanelBuilder.cs
+++ b/testdata/jennies/builders/dashboard_panel/CSharpBuilder/src/Grafana/Foundation/Dashboard/PanelBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.Dashboard;
+
+
+public class PanelBuilder : Cog.IBuilder<Panel>
+{
+    protected readonly Panel @internal;
+
+    public PanelBuilder()
+    {
+        this.@internal = new Panel();
+    }
+
+    public PanelBuilder OnlyFromThisDashboard(bool onlyFromThisDashboard)
+    {
+        this.@internal.OnlyFromThisDashboard = onlyFromThisDashboard;
+        return this;
+    }
+
+    public Panel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/dataquery_variant_builder/CSharpBuilder/src/Grafana/Foundation/DataqueryVariantBuilder/LokiBuilderBuilder.cs
+++ b/testdata/jennies/builders/dataquery_variant_builder/CSharpBuilder/src/Grafana/Foundation/DataqueryVariantBuilder/LokiBuilderBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.DataqueryVariantBuilder;
+
+
+public class LokiBuilderBuilder : Cog.IBuilder<Cog.Variants.Dataquery>
+{
+    protected readonly Loki @internal;
+
+    public LokiBuilderBuilder()
+    {
+        this.@internal = new Loki();
+    }
+
+    public LokiBuilderBuilder Expr(string expr)
+    {
+        this.@internal.Expr = expr;
+        return this;
+    }
+
+    public Loki Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/discriminator_without_option/CSharpBuilder/src/Grafana/Foundation/DiscriminatorWithoutOption/NoShowFieldOptionBuilder.cs
+++ b/testdata/jennies/builders/discriminator_without_option/CSharpBuilder/src/Grafana/Foundation/DiscriminatorWithoutOption/NoShowFieldOptionBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.DiscriminatorWithoutOption;
+
+
+public class NoShowFieldOptionBuilder : Cog.IBuilder<NoShowFieldOption>
+{
+    protected readonly NoShowFieldOption @internal;
+
+    public NoShowFieldOptionBuilder()
+    {
+        this.@internal = new NoShowFieldOption();
+    }
+
+    public NoShowFieldOptionBuilder Text(string text)
+    {
+        this.@internal.Text = text;
+        return this;
+    }
+
+    public NoShowFieldOption Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/discriminator_without_option/CSharpBuilder/src/Grafana/Foundation/DiscriminatorWithoutOption/ShowFieldOptionBuilder.cs
+++ b/testdata/jennies/builders/discriminator_without_option/CSharpBuilder/src/Grafana/Foundation/DiscriminatorWithoutOption/ShowFieldOptionBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.DiscriminatorWithoutOption;
+
+
+public class ShowFieldOptionBuilder : Cog.IBuilder<ShowFieldOption>
+{
+    protected readonly ShowFieldOption @internal;
+
+    public ShowFieldOptionBuilder()
+    {
+        this.@internal = new ShowFieldOption();
+    }
+
+    public ShowFieldOptionBuilder Field(AnEnum field)
+    {
+        this.@internal.Field = field;
+        return this;
+    }
+
+    public ShowFieldOptionBuilder Text(string text)
+    {
+        this.@internal.Text = text;
+        return this;
+    }
+
+    public ShowFieldOption Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/envelope_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/DashboardBuilder.cs
+++ b/testdata/jennies/builders/envelope_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/DashboardBuilder.cs
@@ -1,0 +1,30 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class DashboardBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public DashboardBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public DashboardBuilder WithVariable(string name,string value)
+    {
+        if (this.@internal.Variables == null)
+        {
+            this.@internal.Variables = new List<Variable>();
+        }
+    Variable variable = new Variable();
+        variable.Name = name;
+        variable.Value = value;
+        this.@internal.Variables.Add(variable);
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/factories/CSharpBuilder/src/Grafana/Foundation/Promql/FuncCallExprBuilder.cs
+++ b/testdata/jennies/builders/factories/CSharpBuilder/src/Grafana/Foundation/Promql/FuncCallExprBuilder.cs
@@ -1,0 +1,51 @@
+namespace Grafana.Foundation.Promql;
+
+
+public class FuncCallExprBuilder : Cog.IBuilder<FuncCallExpr>
+{
+    protected readonly FuncCallExpr @internal;
+
+    public FuncCallExprBuilder()
+    {
+        this.@internal = new FuncCallExpr();
+        this.@internal.Type = "funcCallExpr";
+    }
+
+    public FuncCallExprBuilder Function(string function)
+    {
+        if (!(function.Length >= 1))
+        {
+            throw new System.ArgumentException("function.Length must be >= 1");
+        }
+        this.@internal.Function = function;
+        return this;
+    }
+
+    public FuncCallExprBuilder Args(List<Cog.IBuilder<Expr>> args)
+    {
+        List<Expr> argsResources = new List<Expr>();
+        foreach (Cog.IBuilder<Expr> r1 in args)
+        {
+                Expr argsDepth1 = r1.Build();
+                argsResources.Add(argsDepth1);
+        }
+        this.@internal.Args = argsResources;
+        return this;
+    }
+
+    public FuncCallExprBuilder Arg(Cog.IBuilder<Expr> arg)
+    {
+        if (this.@internal.Args == null)
+        {
+            this.@internal.Args = new List<Expr>();
+        }
+        Expr argResource = arg.Build();
+        this.@internal.Args.Add(argResource);
+        return this;
+    }
+
+    public FuncCallExpr Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/foreign_builder/CSharpBuilder/src/Grafana/Foundation/BuilderPkg/BuilderPkgSomeNiceBuilderBuilder.cs
+++ b/testdata/jennies/builders/foreign_builder/CSharpBuilder/src/Grafana/Foundation/BuilderPkg/BuilderPkgSomeNiceBuilderBuilder.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.BuilderPkg;
+
+using Grafana.Foundation.SomePkg;
+
+public class BuilderPkgSomeNiceBuilderBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public BuilderPkgSomeNiceBuilderBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public BuilderPkgSomeNiceBuilderBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/initialization_safeguards/CSharpBuilder/src/Grafana/Foundation/InitializationSafeguards/SomePanelBuilder.cs
+++ b/testdata/jennies/builders/initialization_safeguards/CSharpBuilder/src/Grafana/Foundation/InitializationSafeguards/SomePanelBuilder.cs
@@ -1,0 +1,37 @@
+namespace Grafana.Foundation.InitializationSafeguards;
+
+
+public class SomePanelBuilder : Cog.IBuilder<SomePanel>
+{
+    protected readonly SomePanel @internal;
+
+    public SomePanelBuilder()
+    {
+        this.@internal = new SomePanel();
+    }
+
+    public SomePanelBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomePanelBuilder ShowLegend(bool show)
+    {
+        if (this.@internal.Options == null)
+        {
+            this.@internal.Options = new Options();
+        }
+        if (this.@internal.Options.Legend == null)
+        {
+            this.@internal.Options.Legend = new LegendOptions();
+        }
+        this.@internal.Options.Legend.Show = show;
+        return this;
+    }
+
+    public SomePanel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/known_any/CSharpBuilder/src/Grafana/Foundation/KnownAny/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/known_any/CSharpBuilder/src/Grafana/Foundation/KnownAny/SomeStructBuilder.cs
@@ -1,0 +1,27 @@
+namespace Grafana.Foundation.KnownAny;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Title(string title)
+    {
+        if (this.@internal.Config == null)
+        {
+            this.@internal.Config = new Config();
+        }
+        ((Config) this.@internal.Config).Title = title;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_index_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/map_index_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
@@ -1,0 +1,27 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Annotations(string key,string value)
+    {
+        if (this.@internal.Annotations == null)
+        {
+            this.@internal.Annotations = new Dictionary<string, string>();
+        }
+        this.@internal.Annotations[key] = value;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/CSharpBuilder/src/Grafana/Foundation/MapOfBuilders/DashboardBuilder.cs
+++ b/testdata/jennies/builders/map_of_builders/CSharpBuilder/src/Grafana/Foundation/MapOfBuilders/DashboardBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.MapOfBuilders;
+
+
+public class DashboardBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public DashboardBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public DashboardBuilder Panels(Dictionary<string, Cog.IBuilder<Panel>> panels)
+    {
+        Dictionary<string, Panel> panelsResources = new Dictionary<string, Panel>();
+        foreach (var entry1 in panels)
+        {
+                Panel panelsDepth1 = entry1.Value.Build();
+                panelsResources[entry1.Key] = panelsDepth1;
+        }
+        this.@internal.Panels = panelsResources;
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_builders/CSharpBuilder/src/Grafana/Foundation/MapOfBuilders/PanelBuilder.cs
+++ b/testdata/jennies/builders/map_of_builders/CSharpBuilder/src/Grafana/Foundation/MapOfBuilders/PanelBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.MapOfBuilders;
+
+
+public class PanelBuilder : Cog.IBuilder<Panel>
+{
+    protected readonly Panel @internal;
+
+    public PanelBuilder()
+    {
+        this.@internal = new Panel();
+    }
+
+    public PanelBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public Panel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/DashboardBuilder.cs
+++ b/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/DashboardBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.MapOfDisjunctions;
+
+
+public class DashboardBuilder : Cog.IBuilder<Dashboard>
+{
+    protected readonly Dashboard @internal;
+
+    public DashboardBuilder()
+    {
+        this.@internal = new Dashboard();
+    }
+
+    public DashboardBuilder Panels(Dictionary<string, Cog.IBuilder<Element>> panels)
+    {
+        Dictionary<string, Element> panelsResources = new Dictionary<string, Element>();
+        foreach (var entry1 in panels)
+        {
+                Element panelsDepth1 = entry1.Value.Build();
+                panelsResources[entry1.Key] = panelsDepth1;
+        }
+        this.@internal.Panels = panelsResources;
+        return this;
+    }
+
+    public Dashboard Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/ElementBuilder.cs
+++ b/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/ElementBuilder.cs
@@ -1,0 +1,31 @@
+namespace Grafana.Foundation.MapOfDisjunctions;
+
+
+public class ElementBuilder : Cog.IBuilder<Element>
+{
+    protected readonly Element @internal;
+
+    public ElementBuilder()
+    {
+        this.@internal = new Element();
+    }
+
+    public ElementBuilder Panel(Cog.IBuilder<Panel> panel)
+    {
+        Panel panelResource = panel.Build();
+        this.@internal.Panel = panelResource;
+        return this;
+    }
+
+    public ElementBuilder LibraryPanel(Cog.IBuilder<LibraryPanel> libraryPanel)
+    {
+        LibraryPanel libraryPanelResource = libraryPanel.Build();
+        this.@internal.LibraryPanel = libraryPanelResource;
+        return this;
+    }
+
+    public Element Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/LibraryPanelBuilder.cs
+++ b/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/LibraryPanelBuilder.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.MapOfDisjunctions;
+
+
+public class LibraryPanelBuilder : Cog.IBuilder<LibraryPanel>
+{
+    protected readonly LibraryPanel @internal;
+
+    public LibraryPanelBuilder()
+    {
+        this.@internal = new LibraryPanel();
+        this.@internal.Kind = "Library";
+    }
+
+    public LibraryPanelBuilder Text(string text)
+    {
+        this.@internal.Text = text;
+        return this;
+    }
+
+    public LibraryPanel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/PanelBuilder.cs
+++ b/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/PanelBuilder.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.MapOfDisjunctions;
+
+
+public class PanelBuilder : Cog.IBuilder<Panel>
+{
+    protected readonly Panel @internal;
+
+    public PanelBuilder()
+    {
+        this.@internal = new Panel();
+        this.@internal.Kind = "Panel";
+    }
+
+    public PanelBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public Panel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/PanelOrLibraryPanelBuilder.cs
+++ b/testdata/jennies/builders/map_of_disjunctions/CSharpBuilder/src/Grafana/Foundation/MapOfDisjunctions/PanelOrLibraryPanelBuilder.cs
@@ -1,0 +1,31 @@
+namespace Grafana.Foundation.MapOfDisjunctions;
+
+
+public class PanelOrLibraryPanelBuilder : Cog.IBuilder<PanelOrLibraryPanel>
+{
+    protected readonly PanelOrLibraryPanel @internal;
+
+    public PanelOrLibraryPanelBuilder()
+    {
+        this.@internal = new PanelOrLibraryPanel();
+    }
+
+    public PanelOrLibraryPanelBuilder Panel(Cog.IBuilder<Panel> panel)
+    {
+        Panel panelResource = panel.Build();
+        this.@internal.Panel = panelResource;
+        return this;
+    }
+
+    public PanelOrLibraryPanelBuilder LibraryPanel(Cog.IBuilder<LibraryPanel> libraryPanel)
+    {
+        LibraryPanel libraryPanelResource = libraryPanel.Build();
+        this.@internal.LibraryPanel = libraryPanelResource;
+        return this;
+    }
+
+    public PanelOrLibraryPanel Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/nullable_map_assignment/CSharpBuilder/src/Grafana/Foundation/NullableMapAssignment/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/nullable_map_assignment/CSharpBuilder/src/Grafana/Foundation/NullableMapAssignment/SomeStructBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.NullableMapAssignment;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Config(Dictionary<string, string> config)
+    {
+        this.@internal.Config = config;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/package-with-dashes/CSharpBuilder/src/Grafana/Foundation/BuilderPkg/BuilderPkgSomeNiceBuilderBuilder.cs
+++ b/testdata/jennies/builders/package-with-dashes/CSharpBuilder/src/Grafana/Foundation/BuilderPkg/BuilderPkgSomeNiceBuilderBuilder.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.BuilderPkg;
+
+using Grafana.Foundation.WithDashes;
+
+public class BuilderPkgSomeNiceBuilderBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public BuilderPkgSomeNiceBuilderBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public BuilderPkgSomeNiceBuilderBuilder Title(string title)
+    {
+        this.@internal.Title = title;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/panel_builders/CSharpBuilder/src/Grafana/Foundation/Panelbuilder/PanelBuilder.cs
+++ b/testdata/jennies/builders/panel_builders/CSharpBuilder/src/Grafana/Foundation/Panelbuilder/PanelBuilder.cs
@@ -1,0 +1,77 @@
+namespace Grafana.Foundation.Panelbuilder;
+
+
+public class PanelBuilder : Cog.IBuilder<Options>
+{
+    protected readonly Options @internal;
+
+    public PanelBuilder()
+    {
+        this.@internal = new Options();
+    }
+
+    public PanelBuilder OnlyFromThisDashboard(bool onlyFromThisDashboard)
+    {
+        this.@internal.OnlyFromThisDashboard = onlyFromThisDashboard;
+        return this;
+    }
+
+    public PanelBuilder OnlyInTimeRange(bool onlyInTimeRange)
+    {
+        this.@internal.OnlyInTimeRange = onlyInTimeRange;
+        return this;
+    }
+
+    public PanelBuilder Tags(List<string> tags)
+    {
+        this.@internal.Tags = tags;
+        return this;
+    }
+
+    public PanelBuilder Limit(uint limit)
+    {
+        this.@internal.Limit = limit;
+        return this;
+    }
+
+    public PanelBuilder ShowUser(bool showUser)
+    {
+        this.@internal.ShowUser = showUser;
+        return this;
+    }
+
+    public PanelBuilder ShowTime(bool showTime)
+    {
+        this.@internal.ShowTime = showTime;
+        return this;
+    }
+
+    public PanelBuilder ShowTags(bool showTags)
+    {
+        this.@internal.ShowTags = showTags;
+        return this;
+    }
+
+    public PanelBuilder NavigateToPanel(bool navigateToPanel)
+    {
+        this.@internal.NavigateToPanel = navigateToPanel;
+        return this;
+    }
+
+    public PanelBuilder NavigateBefore(string navigateBefore)
+    {
+        this.@internal.NavigateBefore = navigateBefore;
+        return this;
+    }
+
+    public PanelBuilder NavigateAfter(string navigateAfter)
+    {
+        this.@internal.NavigateAfter = navigateAfter;
+        return this;
+    }
+
+    public Options Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/properties/CSharpBuilder/src/Grafana/Foundation/Properties/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/properties/CSharpBuilder/src/Grafana/Foundation/Properties/SomeStructBuilder.cs
@@ -1,0 +1,25 @@
+namespace Grafana.Foundation.Properties;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+    private string someBuilderProperty;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+        this.someBuilderProperty = "";
+    }
+
+    public SomeStructBuilder Id(long id)
+    {
+        this.@internal.Id = id;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/references/CSharpBuilder/src/Grafana/Foundation/SomePkg/PersonBuilder.cs
+++ b/testdata/jennies/builders/references/CSharpBuilder/src/Grafana/Foundation/SomePkg/PersonBuilder.cs
@@ -1,0 +1,23 @@
+namespace Grafana.Foundation.SomePkg;
+
+
+public class PersonBuilder : Cog.IBuilder<Person>
+{
+    protected readonly Person @internal;
+
+    public PersonBuilder()
+    {
+        this.@internal = new Person();
+    }
+
+    public PersonBuilder Name(Name name)
+    {
+        this.@internal.Name = name;
+        return this;
+    }
+
+    public Person Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/struct_fields_as_args_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
+++ b/testdata/jennies/builders/struct_fields_as_args_assignment/CSharpBuilder/src/Grafana/Foundation/Sandbox/SomeStructBuilder.cs
@@ -1,0 +1,28 @@
+namespace Grafana.Foundation.Sandbox;
+
+
+public class SomeStructBuilder : Cog.IBuilder<SomeStruct>
+{
+    protected readonly SomeStruct @internal;
+
+    public SomeStructBuilder()
+    {
+        this.@internal = new SomeStruct();
+    }
+
+    public SomeStructBuilder Time(string from,string to)
+    {
+        if (this.@internal.Time == null)
+        {
+            this.@internal.Time = new object();
+        }
+        this.@internal.Time.From = from;
+        this.@internal.Time.To = to;
+        return this;
+    }
+
+    public SomeStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/struct_with_defaults/CSharpBuilder/src/Grafana/Foundation/StructWithDefaults/NestedStructBuilder.cs
+++ b/testdata/jennies/builders/struct_with_defaults/CSharpBuilder/src/Grafana/Foundation/StructWithDefaults/NestedStructBuilder.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.StructWithDefaults;
+
+
+public class NestedStructBuilder : Cog.IBuilder<NestedStruct>
+{
+    protected readonly NestedStruct @internal;
+
+    public NestedStructBuilder()
+    {
+        this.@internal = new NestedStruct();
+    }
+
+    public NestedStructBuilder StringVal(string stringVal)
+    {
+        this.@internal.StringVal = stringVal;
+        return this;
+    }
+
+    public NestedStructBuilder IntVal(long intVal)
+    {
+        this.@internal.IntVal = intVal;
+        return this;
+    }
+
+    public NestedStruct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/builders/struct_with_defaults/CSharpBuilder/src/Grafana/Foundation/StructWithDefaults/StructBuilder.cs
+++ b/testdata/jennies/builders/struct_with_defaults/CSharpBuilder/src/Grafana/Foundation/StructWithDefaults/StructBuilder.cs
@@ -1,0 +1,50 @@
+namespace Grafana.Foundation.StructWithDefaults;
+
+
+public class StructBuilder : Cog.IBuilder<Struct>
+{
+    protected readonly Struct @internal;
+
+    public StructBuilder()
+    {
+        this.@internal = new Struct();
+    }
+
+    public StructBuilder AllFields(Cog.IBuilder<NestedStruct> allFields)
+    {
+        NestedStruct allFieldsResource = allFields.Build();
+        this.@internal.AllFields = allFieldsResource;
+        return this;
+    }
+
+    public StructBuilder PartialFields(Cog.IBuilder<NestedStruct> partialFields)
+    {
+        NestedStruct partialFieldsResource = partialFields.Build();
+        this.@internal.PartialFields = partialFieldsResource;
+        return this;
+    }
+
+    public StructBuilder EmptyFields(Cog.IBuilder<NestedStruct> emptyFields)
+    {
+        NestedStruct emptyFieldsResource = emptyFields.Build();
+        this.@internal.EmptyFields = emptyFieldsResource;
+        return this;
+    }
+
+    public StructBuilder ComplexField(object complexField)
+    {
+        this.@internal.ComplexField = complexField;
+        return this;
+    }
+
+    public StructBuilder PartialComplexField(object partialComplexField)
+    {
+        this.@internal.PartialComplexField = partialComplexField;
+        return this;
+    }
+
+    public Struct Build()
+    {
+        return this.@internal;
+    }
+}

--- a/testdata/jennies/rawtypes/arrays/CSharpRawTypes/src/Grafana/Foundation/Arrays/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/arrays/CSharpRawTypes/src/Grafana/Foundation/Arrays/SomeStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.Arrays;
+
+
+public class SomeStruct
+{
+    public object FieldAny;
+
+    public SomeStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public SomeStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceAsDefault/Constants.cs
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceAsDefault/Constants.cs
@@ -1,0 +1,6 @@
+namespace Grafana.Foundation.ConstantReferenceAsDefault;
+
+public static class Constants
+{
+    public const string ConstantRefString = "AString";
+}

--- a/testdata/jennies/rawtypes/constant_reference_as_default/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceAsDefault/MyStruct.cs
+++ b/testdata/jennies/rawtypes/constant_reference_as_default/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceAsDefault/MyStruct.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.ConstantReferenceAsDefault;
+
+
+public class MyStruct
+{
+    public string AString;
+    public string OptString;
+
+    public MyStruct()
+    {
+        this.AString = default!;
+    }
+
+    public MyStruct(string aString, string optString)
+    {
+        this.AString = aString;
+        this.OptString = optString;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/Constants.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/Constants.cs
@@ -1,0 +1,7 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+public static class Constants
+{
+    public const string GridLayoutKindType = "GridLayout";
+    public const string RowsLayoutKindType = "RowsLayout";
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/GridLayoutUsingValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/GridLayoutUsingValue.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class GridLayoutUsingValue
+{
+    public string Kind;
+    public string GridLayoutProperty;
+
+    public GridLayoutUsingValue()
+    {
+        this.Kind = default!;
+        this.GridLayoutProperty = "";
+    }
+
+    public GridLayoutUsingValue(string kind, string gridLayoutProperty)
+    {
+        this.Kind = kind;
+        this.GridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/GridLayoutWithoutValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/GridLayoutWithoutValue.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class GridLayoutWithoutValue
+{
+    public string Kind;
+    public string GridLayoutProperty;
+
+    public GridLayoutWithoutValue()
+    {
+        this.Kind = default!;
+        this.GridLayoutProperty = "";
+    }
+
+    public GridLayoutWithoutValue(string kind, string gridLayoutProperty)
+    {
+        this.Kind = kind;
+        this.GridLayoutProperty = gridLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/LayoutWithValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/LayoutWithValue.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class LayoutWithValue
+{
+    public GridLayoutUsingValue GridLayoutUsingValue;
+    public RowsLayoutUsingValue RowsLayoutUsingValue;
+
+    public LayoutWithValue()
+    {
+    }
+
+    public LayoutWithValue(GridLayoutUsingValue gridLayoutUsingValue, RowsLayoutUsingValue rowsLayoutUsingValue)
+    {
+        this.GridLayoutUsingValue = gridLayoutUsingValue;
+        this.RowsLayoutUsingValue = rowsLayoutUsingValue;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/LayoutWithoutValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/LayoutWithoutValue.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class LayoutWithoutValue
+{
+    public GridLayoutWithoutValue GridLayoutWithoutValue;
+    public RowsLayoutWithoutValue RowsLayoutWithoutValue;
+
+    public LayoutWithoutValue()
+    {
+    }
+
+    public LayoutWithoutValue(GridLayoutWithoutValue gridLayoutWithoutValue, RowsLayoutWithoutValue rowsLayoutWithoutValue)
+    {
+        this.GridLayoutWithoutValue = gridLayoutWithoutValue;
+        this.RowsLayoutWithoutValue = rowsLayoutWithoutValue;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/RowsLayoutUsingValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/RowsLayoutUsingValue.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class RowsLayoutUsingValue
+{
+    public string Kind;
+    public string RowsLayoutProperty;
+
+    public RowsLayoutUsingValue()
+    {
+        this.Kind = default!;
+        this.RowsLayoutProperty = "";
+    }
+
+    public RowsLayoutUsingValue(string kind, string rowsLayoutProperty)
+    {
+        this.Kind = kind;
+        this.RowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.cs
+++ b/testdata/jennies/rawtypes/constant_reference_discriminator/CSharpRawTypes/src/Grafana/Foundation/ConstantReferenceDiscriminator/RowsLayoutWithoutValue.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferenceDiscriminator;
+
+
+public class RowsLayoutWithoutValue
+{
+    public string Kind;
+    public string RowsLayoutProperty;
+
+    public RowsLayoutWithoutValue()
+    {
+        this.Kind = default!;
+        this.RowsLayoutProperty = "";
+    }
+
+    public RowsLayoutWithoutValue(string kind, string rowsLayoutProperty)
+    {
+        this.Kind = kind;
+        this.RowsLayoutProperty = rowsLayoutProperty;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Enum.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Enum.cs
@@ -1,13 +1,8 @@
 namespace Grafana.Foundation.ConstantReferences;
 
-using System.Runtime.Serialization;
-
 public enum Enum
 {
-    [EnumMember(Value = "ValueA")]
     ValueA,
-    [EnumMember(Value = "ValueB")]
     ValueB,
-    [EnumMember(Value = "ValueC")]
     ValueC
 }

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Enum.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Enum.cs
@@ -1,0 +1,13 @@
+namespace Grafana.Foundation.ConstantReferences;
+
+using System.Runtime.Serialization;
+
+public enum Enum
+{
+    [EnumMember(Value = "ValueA")]
+    ValueA,
+    [EnumMember(Value = "ValueB")]
+    ValueB,
+    [EnumMember(Value = "ValueC")]
+    ValueC
+}

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/ParentStruct.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/ParentStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.ConstantReferences;
+
+
+public class ParentStruct
+{
+    public Enum MyEnum;
+
+    public ParentStruct()
+    {
+        this.MyEnum = Enum.ValueA;
+    }
+
+    public ParentStruct(Enum myEnum)
+    {
+        this.MyEnum = myEnum;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Struct.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/Struct.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferences;
+
+
+public class Struct
+{
+    public string MyValue;
+    public Enum MyEnum;
+
+    public Struct()
+    {
+        this.MyValue = "";
+        this.MyEnum = Enum.ValueA;
+    }
+
+    public Struct(string myValue, Enum myEnum)
+    {
+        this.MyValue = myValue;
+        this.MyEnum = myEnum;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/StructA.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/StructA.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.ConstantReferences;
+
+
+public class StructA
+{
+    public Enum MyEnum;
+    public Enum Other;
+
+    public StructA()
+    {
+        this.MyEnum = default!;
+    }
+
+    public StructA(Enum myEnum, Enum other)
+    {
+        this.MyEnum = myEnum;
+        this.Other = other;
+    }
+}

--- a/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/StructB.cs
+++ b/testdata/jennies/rawtypes/constant_references/CSharpRawTypes/src/Grafana/Foundation/ConstantReferences/StructB.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.ConstantReferences;
+
+
+public class StructB
+{
+    public Enum MyEnum;
+    public string MyValue;
+
+    public StructB()
+    {
+        this.MyEnum = default!;
+        this.MyValue = "";
+    }
+
+    public StructB(Enum myEnum, string myValue)
+    {
+        this.MyEnum = myEnum;
+        this.MyValue = myValue;
+    }
+}

--- a/testdata/jennies/rawtypes/constraints/CSharpRawTypes/src/Grafana/Foundation/Constraints/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/constraints/CSharpRawTypes/src/Grafana/Foundation/Constraints/SomeStruct.cs
@@ -1,0 +1,50 @@
+namespace Grafana.Foundation.Constraints;
+
+using System.Collections.Generic;
+
+public class SomeStruct
+{
+    public ulong Id;
+    public ulong MaybeId;
+    public ulong GreaterThanZero;
+    public long Negative;
+    public string Title;
+    public Dictionary<string, string> Labels;
+    public List<string> Tags;
+    public string Regex;
+    public string NegativeRegex;
+    public List<string> MinMaxList;
+    public List<string> UniqueList;
+    public List<long> FullConstraintList;
+
+    public SomeStruct()
+    {
+        this.Id = 0UL;
+        this.GreaterThanZero = 0UL;
+        this.Negative = 0L;
+        this.Title = "";
+        this.Labels = new Dictionary<string, string>();
+        this.Tags = new List<string>();
+        this.Regex = "";
+        this.NegativeRegex = "";
+        this.MinMaxList = new List<string>();
+        this.UniqueList = new List<string>();
+        this.FullConstraintList = new List<long>();
+    }
+
+    public SomeStruct(ulong id, ulong maybeId, ulong greaterThanZero, long negative, string title, Dictionary<string, string> labels, List<string> tags, string regex, string negativeRegex, List<string> minMaxList, List<string> uniqueList, List<long> fullConstraintList)
+    {
+        this.Id = id;
+        this.MaybeId = maybeId;
+        this.GreaterThanZero = greaterThanZero;
+        this.Negative = negative;
+        this.Title = title;
+        this.Labels = labels;
+        this.Tags = tags;
+        this.Regex = regex;
+        this.NegativeRegex = negativeRegex;
+        this.MinMaxList = minMaxList;
+        this.UniqueList = uniqueList;
+        this.FullConstraintList = fullConstraintList;
+    }
+}

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Dashboard.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Dashboard.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Dashboard;
+
+using System.Collections.Generic;
+
+public class Dashboard
+{
+    public string Title;
+    public List<Panel> Panels;
+
+    public Dashboard()
+    {
+        this.Title = "";
+    }
+
+    public Dashboard(string title, List<Panel> panels)
+    {
+        this.Title = title;
+        this.Panels = panels;
+    }
+}

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/DataSourceRef.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/DataSourceRef.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.Dashboard;
+
+
+public class DataSourceRef
+{
+    public string Type;
+    public string Uid;
+
+    public DataSourceRef()
+    {
+    }
+
+    public DataSourceRef(string type, string uid)
+    {
+        this.Type = type;
+        this.Uid = uid;
+    }
+}

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/FieldConfig.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/FieldConfig.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.Dashboard;
+
+
+public class FieldConfig
+{
+    public string Unit;
+    public object Custom;
+
+    public FieldConfig()
+    {
+    }
+
+    public FieldConfig(string unit, object custom)
+    {
+        this.Unit = unit;
+        this.Custom = custom;
+    }
+}

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/FieldConfigSource.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/FieldConfigSource.cs
@@ -1,0 +1,16 @@
+namespace Grafana.Foundation.Dashboard;
+
+
+public class FieldConfigSource
+{
+    public FieldConfig Defaults;
+
+    public FieldConfigSource()
+    {
+    }
+
+    public FieldConfigSource(FieldConfig defaults)
+    {
+        this.Defaults = defaults;
+    }
+}

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Panel.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Panel.cs
@@ -8,7 +8,7 @@ public class Panel
     public string Type;
     public DataSourceRef Datasource;
     public object Options;
-    public List<object> Targets;
+    public List<Cog.Variants.Dataquery> Targets;
     public FieldConfigSource FieldConfig;
 
     public Panel()
@@ -17,7 +17,7 @@ public class Panel
         this.Type = "";
     }
 
-    public Panel(string title, string type, DataSourceRef datasource, object options, List<object> targets, FieldConfigSource fieldConfig)
+    public Panel(string title, string type, DataSourceRef datasource, object options, List<Cog.Variants.Dataquery> targets, FieldConfigSource fieldConfig)
     {
         this.Title = title;
         this.Type = type;

--- a/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Panel.cs
+++ b/testdata/jennies/rawtypes/dashboard/CSharpRawTypes/src/Grafana/Foundation/Dashboard/Panel.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.Dashboard;
+
+using System.Collections.Generic;
+
+public class Panel
+{
+    public string Title;
+    public string Type;
+    public DataSourceRef Datasource;
+    public object Options;
+    public List<object> Targets;
+    public FieldConfigSource FieldConfig;
+
+    public Panel()
+    {
+        this.Title = "";
+        this.Type = "";
+    }
+
+    public Panel(string title, string type, DataSourceRef datasource, object options, List<object> targets, FieldConfigSource fieldConfig)
+    {
+        this.Title = title;
+        this.Type = type;
+        this.Datasource = datasource;
+        this.Options = options;
+        this.Targets = targets;
+        this.FieldConfig = fieldConfig;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunction_of_numbers/CSharpRawTypes/src/Grafana/Foundation/DisjunctionOfNumbers/Numbers.cs
+++ b/testdata/jennies/rawtypes/disjunction_of_numbers/CSharpRawTypes/src/Grafana/Foundation/DisjunctionOfNumbers/Numbers.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.DisjunctionOfNumbers;
+
+
+public class Numbers
+{
+    public long Int64;
+    public double Float64;
+    public float Float32;
+
+    public Numbers()
+    {
+    }
+
+    public Numbers(long int64, double float64, float float32)
+    {
+        this.Int64 = int64;
+        this.Float64 = float64;
+        this.Float32 = float32;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/BoolOrRef.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/BoolOrRef.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+public class BoolOrRef
+{
+    public bool Bool;
+    public SomeStruct SomeStruct;
+
+    public BoolOrRef()
+    {
+    }
+
+    public BoolOrRef(bool boolArg, SomeStruct someStruct)
+    {
+        this.Bool = boolArg;
+        this.SomeStruct = someStruct;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/RefreshRate.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/RefreshRate.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+// Refresh rate or disabled.
+public class RefreshRate
+{
+    public string String;
+    public bool Bool;
+
+    public RefreshRate()
+    {
+    }
+
+    public RefreshRate(string stringArg, bool boolArg)
+    {
+        this.String = stringArg;
+        this.Bool = boolArg;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SeveralRefs.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SeveralRefs.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+public class SeveralRefs
+{
+    public SomeStruct SomeStruct;
+    public SomeOtherStruct SomeOtherStruct;
+    public YetAnotherStruct YetAnotherStruct;
+
+    public SeveralRefs()
+    {
+    }
+
+    public SeveralRefs(SomeStruct someStruct, SomeOtherStruct someOtherStruct, YetAnotherStruct yetAnotherStruct)
+    {
+        this.SomeStruct = someStruct;
+        this.SomeOtherStruct = someOtherStruct;
+        this.YetAnotherStruct = yetAnotherStruct;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SomeOtherStruct.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SomeOtherStruct.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+public class SomeOtherStruct
+{
+    public string Type;
+    public byte Foo;
+
+    public SomeOtherStruct()
+    {
+        this.Type = "";
+        this.Foo = (byte) 0;
+    }
+
+    public SomeOtherStruct(string type, byte foo)
+    {
+        this.Type = type;
+        this.Foo = foo;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/SomeStruct.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+public class SomeStruct
+{
+    public string Type;
+    public object FieldAny;
+
+    public SomeStruct()
+    {
+        this.Type = "";
+        this.FieldAny = new object();
+    }
+
+    public SomeStruct(string type, object fieldAny)
+    {
+        this.Type = type;
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/YetAnotherStruct.cs
+++ b/testdata/jennies/rawtypes/disjunctions/CSharpRawTypes/src/Grafana/Foundation/Disjunctions/YetAnotherStruct.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Disjunctions;
+
+
+public class YetAnotherStruct
+{
+    public string Type;
+    public byte Bar;
+
+    public YetAnotherStruct()
+    {
+        this.Type = "";
+        this.Bar = 0;
+    }
+
+    public YetAnotherStruct(string type, byte bar)
+    {
+        this.Type = type;
+        this.Bar = bar;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions_of_refs_without_discriminator/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfRefsWithoutDiscriminator/TypeA.cs
+++ b/testdata/jennies/rawtypes/disjunctions_of_refs_without_discriminator/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfRefsWithoutDiscriminator/TypeA.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.DisjunctionsOfRefsWithoutDiscriminator;
+
+
+public class TypeA
+{
+    public string FieldA;
+
+    public TypeA()
+    {
+        this.FieldA = "";
+    }
+
+    public TypeA(string fieldA)
+    {
+        this.FieldA = fieldA;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions_of_refs_without_discriminator/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfRefsWithoutDiscriminator/TypeB.cs
+++ b/testdata/jennies/rawtypes/disjunctions_of_refs_without_discriminator/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfRefsWithoutDiscriminator/TypeB.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.DisjunctionsOfRefsWithoutDiscriminator;
+
+
+public class TypeB
+{
+    public long FieldB;
+
+    public TypeB()
+    {
+        this.FieldB = 0L;
+    }
+
+    public TypeB(long fieldB)
+    {
+        this.FieldB = fieldB;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/DisjunctionOfScalarsAndRefs.cs
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/DisjunctionOfScalarsAndRefs.cs
@@ -1,0 +1,25 @@
+namespace Grafana.Foundation.DisjunctionsOfScalarsAndRefs;
+
+using System.Collections.Generic;
+
+public class DisjunctionOfScalarsAndRefs
+{
+    public string String;
+    public bool Bool;
+    public List<string> ArrayOfString;
+    public MyRefA MyRefA;
+    public MyRefB MyRefB;
+
+    public DisjunctionOfScalarsAndRefs()
+    {
+    }
+
+    public DisjunctionOfScalarsAndRefs(string stringArg, bool boolArg, List<string> arrayOfString, MyRefA myRefA, MyRefB myRefB)
+    {
+        this.String = stringArg;
+        this.Bool = boolArg;
+        this.ArrayOfString = arrayOfString;
+        this.MyRefA = myRefA;
+        this.MyRefB = myRefB;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/MyRefA.cs
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/MyRefA.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.DisjunctionsOfScalarsAndRefs;
+
+
+public class MyRefA
+{
+    public string Foo;
+
+    public MyRefA()
+    {
+        this.Foo = "";
+    }
+
+    public MyRefA(string foo)
+    {
+        this.Foo = foo;
+    }
+}

--- a/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/MyRefB.cs
+++ b/testdata/jennies/rawtypes/disjunctions_of_scalars_and_refs/CSharpRawTypes/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/MyRefB.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.DisjunctionsOfScalarsAndRefs;
+
+
+public class MyRefB
+{
+    public long Bar;
+
+    public MyRefB()
+    {
+        this.Bar = 0L;
+    }
+
+    public MyRefB(long bar)
+    {
+        this.Bar = bar;
+    }
+}

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/DashboardCursorSync.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/DashboardCursorSync.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Enums;
+
+// 0 for no shared crosshair or tooltip (default).
+// 1 for shared crosshair.
+// 2 for shared crosshair AND shared tooltip.
+public enum DashboardCursorSync
+{
+    Off = 0,
+    Crosshair = 1,
+    Tooltip = 2
+}

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/LogsSortOrder.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/LogsSortOrder.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Enums;
+
+using System.Runtime.Serialization;
+
+public enum LogsSortOrder
+{
+    [EnumMember(Value = "time_asc")]
+    Asc,
+    [EnumMember(Value = "time_desc")]
+    Desc
+}

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/LogsSortOrder.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/LogsSortOrder.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.Enums;
 
-using System.Runtime.Serialization;
-
 public enum LogsSortOrder
 {
-    [EnumMember(Value = "time_asc")]
     Asc,
-    [EnumMember(Value = "time_desc")]
     Desc
 }

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/Operator.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/Operator.cs
@@ -1,0 +1,12 @@
+namespace Grafana.Foundation.Enums;
+
+using System.Runtime.Serialization;
+
+// This is a very interesting string enum.
+public enum Operator
+{
+    [EnumMember(Value = ">")]
+    GreaterThan,
+    [EnumMember(Value = "<")]
+    LessThan
+}

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/Operator.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/Operator.cs
@@ -1,12 +1,8 @@
 namespace Grafana.Foundation.Enums;
 
-using System.Runtime.Serialization;
-
 // This is a very interesting string enum.
 public enum Operator
 {
-    [EnumMember(Value = ">")]
     GreaterThan,
-    [EnumMember(Value = "<")]
     LessThan
 }

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/TableSortOrder.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/TableSortOrder.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Enums;
+
+using System.Runtime.Serialization;
+
+public enum TableSortOrder
+{
+    [EnumMember(Value = "asc")]
+    Asc,
+    [EnumMember(Value = "desc")]
+    Desc
+}

--- a/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/TableSortOrder.cs
+++ b/testdata/jennies/rawtypes/enums/CSharpRawTypes/src/Grafana/Foundation/Enums/TableSortOrder.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.Enums;
 
-using System.Runtime.Serialization;
-
 public enum TableSortOrder
 {
-    [EnumMember(Value = "asc")]
     Asc,
-    [EnumMember(Value = "desc")]
     Desc
 }

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructComplexField.cs
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructComplexField.cs
@@ -1,0 +1,24 @@
+namespace Grafana.Foundation.Defaults;
+
+using System.Collections.Generic;
+
+public class DefaultsStructComplexField
+{
+    public string Uid;
+    public DefaultsStructComplexFieldNested Nested;
+    public List<string> Array;
+
+    public DefaultsStructComplexField()
+    {
+        this.Uid = "";
+        this.Nested = new DefaultsStructComplexFieldNested();
+        this.Array = new List<string>();
+    }
+
+    public DefaultsStructComplexField(string uid, DefaultsStructComplexFieldNested nested, List<string> array)
+    {
+        this.Uid = uid;
+        this.Nested = nested;
+        this.Array = array;
+    }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructComplexFieldNested.cs
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructComplexFieldNested.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.Defaults;
+
+
+public class DefaultsStructComplexFieldNested
+{
+    public string NestedVal;
+
+    public DefaultsStructComplexFieldNested()
+    {
+        this.NestedVal = "";
+    }
+
+    public DefaultsStructComplexFieldNested(string nestedVal)
+    {
+        this.NestedVal = nestedVal;
+    }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructPartialComplexField.cs
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/DefaultsStructPartialComplexField.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Defaults;
+
+
+public class DefaultsStructPartialComplexField
+{
+    public string Uid;
+    public long IntVal;
+
+    public DefaultsStructPartialComplexField()
+    {
+        this.Uid = "";
+        this.IntVal = 0L;
+    }
+
+    public DefaultsStructPartialComplexField(string uid, long intVal)
+    {
+        this.Uid = uid;
+        this.IntVal = intVal;
+    }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/NestedStruct.cs
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/NestedStruct.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.Defaults;
+
+
+public class NestedStruct
+{
+    public string StringVal;
+    public long IntVal;
+
+    public NestedStruct()
+    {
+        this.StringVal = "";
+        this.IntVal = 0L;
+    }
+
+    public NestedStruct(string stringVal, long intVal)
+    {
+        this.StringVal = stringVal;
+        this.IntVal = intVal;
+    }
+}

--- a/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/Struct.cs
+++ b/testdata/jennies/rawtypes/field_with_struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/Struct.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.Defaults;
+
+
+public class Struct
+{
+    public NestedStruct AllFields;
+    public NestedStruct PartialFields;
+    public NestedStruct EmptyFields;
+    public DefaultsStructComplexField ComplexField;
+    public DefaultsStructPartialComplexField PartialComplexField;
+
+    public Struct()
+    {
+        this.AllFields = new NestedStruct();
+        this.PartialFields = new NestedStruct();
+        this.EmptyFields = new NestedStruct();
+        this.ComplexField = new DefaultsStructComplexField();
+        this.PartialComplexField = new DefaultsStructPartialComplexField();
+    }
+
+    public Struct(NestedStruct allFields, NestedStruct partialFields, NestedStruct emptyFields, DefaultsStructComplexField complexField, DefaultsStructPartialComplexField partialComplexField)
+    {
+        this.AllFields = allFields;
+        this.PartialFields = partialFields;
+        this.EmptyFields = emptyFields;
+        this.ComplexField = complexField;
+        this.PartialComplexField = partialComplexField;
+    }
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Common.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Common.cs
@@ -1,0 +1,27 @@
+namespace Grafana.Foundation.Intersections;
+
+
+// Base properties for all metrics
+public class Common
+{
+    // The metric name
+    public string Name;
+    // The metric type
+    public CommonType Type;
+    // The type of data the metric contains
+    public CommonContains Contains;
+
+    public Common()
+    {
+        this.Name = "";
+        this.Type = CommonType.Counter;
+        this.Contains = CommonContains.Default;
+    }
+
+    public Common(string name, CommonType type, CommonContains contains)
+    {
+        this.Name = name;
+        this.Type = type;
+        this.Contains = contains;
+    }
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonContains.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonContains.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Intersections;
+
+using System.Runtime.Serialization;
+
+public enum CommonContains
+{
+    [EnumMember(Value = "default")]
+    Default,
+    [EnumMember(Value = "time")]
+    Time
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonContains.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonContains.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.Intersections;
 
-using System.Runtime.Serialization;
-
 public enum CommonContains
 {
-    [EnumMember(Value = "default")]
     Default,
-    [EnumMember(Value = "time")]
     Time
 }

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonType.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonType.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.Intersections;
 
-using System.Runtime.Serialization;
-
 public enum CommonType
 {
-    [EnumMember(Value = "counter")]
     Counter,
-    [EnumMember(Value = "gauge")]
     Gauge
 }

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonType.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/CommonType.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Intersections;
+
+using System.Runtime.Serialization;
+
+public enum CommonType
+{
+    [EnumMember(Value = "counter")]
+    Counter,
+    [EnumMember(Value = "gauge")]
+    Gauge
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Counter.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Counter.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.Intersections;
+
+
+// Counter metric combining common properties with specific values
+public class Counter : Common
+{
+    // Counter metric values
+    public object Values;
+
+    public Counter()
+    {
+        this.Values = new object();
+    }
+
+    public Counter(object values)
+    {
+        this.Values = values;
+    }
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Intersections.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/Intersections.cs
@@ -1,0 +1,21 @@
+namespace Grafana.Foundation.Intersections;
+
+using Grafana.Foundation.ExternalPkg;
+
+public class Intersections : SomeStruct, AnotherStruct
+{
+    public string FieldString;
+    public int FieldInteger;
+
+    public Intersections()
+    {
+        this.FieldString = "hello";
+        this.FieldInteger = 32;
+    }
+
+    public Intersections(string fieldString, int fieldInteger)
+    {
+        this.FieldString = fieldString;
+        this.FieldInteger = fieldInteger;
+    }
+}

--- a/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/intersections/CSharpRawTypes/src/Grafana/Foundation/Intersections/SomeStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.Intersections;
+
+
+public class SomeStruct
+{
+    public bool FieldBool;
+
+    public SomeStruct()
+    {
+        this.FieldBool = true;
+    }
+
+    public SomeStruct(bool fieldBool)
+    {
+        this.FieldBool = fieldBool;
+    }
+}

--- a/testdata/jennies/rawtypes/maps/CSharpRawTypes/src/Grafana/Foundation/Maps/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/maps/CSharpRawTypes/src/Grafana/Foundation/Maps/SomeStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.Maps;
+
+
+public class SomeStruct
+{
+    public object FieldAny;
+
+    public SomeStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public SomeStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/Constants.cs
+++ b/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/Constants.cs
@@ -1,0 +1,6 @@
+namespace Grafana.Foundation.NullableFields;
+
+public static class Constants
+{
+    public const string ConstantRef = "hey";
+}

--- a/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/MyObject.cs
+++ b/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/MyObject.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.NullableFields;
+
+
+public class MyObject
+{
+    public string Field;
+
+    public MyObject()
+    {
+        this.Field = "";
+    }
+
+    public MyObject(string field)
+    {
+        this.Field = field;
+    }
+}

--- a/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/NullableFieldsStructF.cs
+++ b/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/NullableFieldsStructF.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.NullableFields;
+
+
+public class NullableFieldsStructF
+{
+    public string A;
+
+    public NullableFieldsStructF()
+    {
+        this.A = "";
+    }
+
+    public NullableFieldsStructF(string a)
+    {
+        this.A = a;
+    }
+}

--- a/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/Struct.cs
+++ b/testdata/jennies/rawtypes/nullable_fields/CSharpRawTypes/src/Grafana/Foundation/NullableFields/Struct.cs
@@ -1,0 +1,30 @@
+namespace Grafana.Foundation.NullableFields;
+
+using System.Collections.Generic;
+
+public class Struct
+{
+    public MyObject A;
+    public MyObject B;
+    public string C;
+    public List<string> D;
+    public Dictionary<string, string> E;
+    public NullableFieldsStructF F;
+    public string G;
+
+    public Struct()
+    {
+        this.E = new Dictionary<string, string>();
+    }
+
+    public Struct(MyObject a, MyObject b, string c, List<string> d, Dictionary<string, string> e, NullableFieldsStructF f, string g)
+    {
+        this.A = a;
+        this.B = b;
+        this.C = c;
+        this.D = d;
+        this.E = e;
+        this.F = f;
+        this.G = g;
+    }
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/CSharpRawTypes/src/Grafana/Foundation/WithDashes/RefreshRate.cs
+++ b/testdata/jennies/rawtypes/package-with-dashes/CSharpRawTypes/src/Grafana/Foundation/WithDashes/RefreshRate.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.WithDashes;
+
+
+// Refresh rate or disabled.
+public class RefreshRate
+{
+    public string String;
+    public bool Bool;
+
+    public RefreshRate()
+    {
+    }
+
+    public RefreshRate(string stringArg, bool boolArg)
+    {
+        this.String = stringArg;
+        this.Bool = boolArg;
+    }
+}

--- a/testdata/jennies/rawtypes/package-with-dashes/CSharpRawTypes/src/Grafana/Foundation/WithDashes/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/package-with-dashes/CSharpRawTypes/src/Grafana/Foundation/WithDashes/SomeStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.WithDashes;
+
+
+public class SomeStruct
+{
+    public object FieldAny;
+
+    public SomeStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public SomeStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/reference_of_reference/CSharpRawTypes/src/Grafana/Foundation/ReferenceOfReference/MyStruct.cs
+++ b/testdata/jennies/rawtypes/reference_of_reference/CSharpRawTypes/src/Grafana/Foundation/ReferenceOfReference/MyStruct.cs
@@ -1,0 +1,16 @@
+namespace Grafana.Foundation.ReferenceOfReference;
+
+
+public class MyStruct
+{
+    public OtherStruct Field;
+
+    public MyStruct()
+    {
+    }
+
+    public MyStruct(OtherStruct field)
+    {
+        this.Field = field;
+    }
+}

--- a/testdata/jennies/rawtypes/reference_of_reference/CSharpRawTypes/src/Grafana/Foundation/ReferenceOfReference/OtherStruct.cs
+++ b/testdata/jennies/rawtypes/reference_of_reference/CSharpRawTypes/src/Grafana/Foundation/ReferenceOfReference/OtherStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.ReferenceOfReference;
+
+
+public class OtherStruct
+{
+    public string A;
+
+    public OtherStruct()
+    {
+        this.A = "";
+    }
+
+    public OtherStruct(string a)
+    {
+        this.A = a;
+    }
+}

--- a/testdata/jennies/rawtypes/refs/CSharpRawTypes/src/Grafana/Foundation/Refs/RefToSomeStruct.cs
+++ b/testdata/jennies/rawtypes/refs/CSharpRawTypes/src/Grafana/Foundation/Refs/RefToSomeStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.Refs;
+
+
+public class RefToSomeStruct
+{
+    public object FieldAny;
+
+    public RefToSomeStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public RefToSomeStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/refs/CSharpRawTypes/src/Grafana/Foundation/Refs/RefToSomeStructFromOtherPackage.cs
+++ b/testdata/jennies/rawtypes/refs/CSharpRawTypes/src/Grafana/Foundation/Refs/RefToSomeStructFromOtherPackage.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.Refs;
+
+using Grafana.Foundation.Otherpkg;
+
+public class RefToSomeStructFromOtherPackage : SomeDistantStruct
+{
+
+    public RefToSomeStructFromOtherPackage()
+    {
+    }
+}

--- a/testdata/jennies/rawtypes/scalars/CSharpRawTypes/src/Grafana/Foundation/Scalars/Constants.cs
+++ b/testdata/jennies/rawtypes/scalars/CSharpRawTypes/src/Grafana/Foundation/Scalars/Constants.cs
@@ -1,0 +1,6 @@
+namespace Grafana.Foundation.Scalars;
+
+public static class Constants
+{
+    public const string ConstTypeString = "foo";
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/Constants.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/Constants.cs
@@ -1,0 +1,6 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+public static class Constants
+{
+    public const string ConnectionPath = "straight";
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeOtherStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeOtherStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+
+public class SomeOtherStruct
+{
+    public object FieldAny;
+
+    public SomeOtherStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public SomeOtherStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStruct.cs
@@ -1,0 +1,42 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+using System.Collections.Generic;
+
+// This struct does things.
+public class SomeStruct
+{
+    public SomeOtherStruct FieldRef;
+    public StringOrBool FieldDisjunctionOfScalars;
+    public StringOrSomeOtherStruct FieldMixedDisjunction;
+    public string FieldDisjunctionWithNull;
+    public SomeStructOperator Operator;
+    public List<string> FieldArrayOfStrings;
+    public Dictionary<string, string> FieldMapOfStringToString;
+    public StructComplexFieldsSomeStructFieldAnonymousStruct FieldAnonymousStruct;
+    public string FieldRefToConstant;
+
+    public SomeStruct()
+    {
+        this.FieldRef = new SomeOtherStruct();
+        this.FieldDisjunctionOfScalars = new StringOrBool();
+        this.FieldMixedDisjunction = new StringOrSomeOtherStruct();
+        this.Operator = SomeStructOperator.GreaterThan;
+        this.FieldArrayOfStrings = new List<string>();
+        this.FieldMapOfStringToString = new Dictionary<string, string>();
+        this.FieldAnonymousStruct = new StructComplexFieldsSomeStructFieldAnonymousStruct();
+        this.FieldRefToConstant = new ConnectionPath();
+    }
+
+    public SomeStruct(SomeOtherStruct fieldRef, StringOrBool fieldDisjunctionOfScalars, StringOrSomeOtherStruct fieldMixedDisjunction, string fieldDisjunctionWithNull, SomeStructOperator operatorArg, List<string> fieldArrayOfStrings, Dictionary<string, string> fieldMapOfStringToString, StructComplexFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct, string fieldRefToConstant)
+    {
+        this.FieldRef = fieldRef;
+        this.FieldDisjunctionOfScalars = fieldDisjunctionOfScalars;
+        this.FieldMixedDisjunction = fieldMixedDisjunction;
+        this.FieldDisjunctionWithNull = fieldDisjunctionWithNull;
+        this.Operator = operatorArg;
+        this.FieldArrayOfStrings = fieldArrayOfStrings;
+        this.FieldMapOfStringToString = fieldMapOfStringToString;
+        this.FieldAnonymousStruct = fieldAnonymousStruct;
+        this.FieldRefToConstant = fieldRefToConstant;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStructOperator.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStructOperator.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.StructComplexFields;
 
-using System.Runtime.Serialization;
-
 public enum SomeStructOperator
 {
-    [EnumMember(Value = ">")]
     GreaterThan,
-    [EnumMember(Value = "<")]
     LessThan
 }

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStructOperator.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/SomeStructOperator.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+using System.Runtime.Serialization;
+
+public enum SomeStructOperator
+{
+    [EnumMember(Value = ">")]
+    GreaterThan,
+    [EnumMember(Value = "<")]
+    LessThan
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StringOrBool.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StringOrBool.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+
+public class StringOrBool
+{
+    public string String;
+    public bool Bool;
+
+    public StringOrBool()
+    {
+    }
+
+    public StringOrBool(string stringArg, bool boolArg)
+    {
+        this.String = stringArg;
+        this.Bool = boolArg;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StringOrSomeOtherStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StringOrSomeOtherStruct.cs
@@ -1,0 +1,18 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+
+public class StringOrSomeOtherStruct
+{
+    public string String;
+    public SomeOtherStruct SomeOtherStruct;
+
+    public StringOrSomeOtherStruct()
+    {
+    }
+
+    public StringOrSomeOtherStruct(string stringArg, SomeOtherStruct someOtherStruct)
+    {
+        this.String = stringArg;
+        this.SomeOtherStruct = someOtherStruct;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StructComplexFieldsSomeStructFieldAnonymousStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_complex_fields/CSharpRawTypes/src/Grafana/Foundation/StructComplexFields/StructComplexFieldsSomeStructFieldAnonymousStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.StructComplexFields;
+
+
+public class StructComplexFieldsSomeStructFieldAnonymousStruct
+{
+    public object FieldAny;
+
+    public StructComplexFieldsSomeStructFieldAnonymousStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public StructComplexFieldsSomeStructFieldAnonymousStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_defaults/CSharpRawTypes/src/Grafana/Foundation/Defaults/SomeStruct.cs
@@ -1,0 +1,29 @@
+namespace Grafana.Foundation.Defaults;
+
+
+public class SomeStruct
+{
+    public bool FieldBool;
+    public string FieldString;
+    public string FieldStringWithConstantValue;
+    public float FieldFloat32;
+    public int FieldInt32;
+
+    public SomeStruct()
+    {
+        this.FieldBool = true;
+        this.FieldString = "foo";
+        this.FieldStringWithConstantValue = "";
+        this.FieldFloat32 = 42.42f;
+        this.FieldInt32 = 42;
+    }
+
+    public SomeStruct(bool fieldBool, string fieldString, string fieldStringWithConstantValue, float fieldFloat32, int fieldInt32)
+    {
+        this.FieldBool = fieldBool;
+        this.FieldString = fieldString;
+        this.FieldStringWithConstantValue = fieldStringWithConstantValue;
+        this.FieldFloat32 = fieldFloat32;
+        this.FieldInt32 = fieldInt32;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeOtherStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeOtherStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.StructOptionalFields;
+
+
+public class SomeOtherStruct
+{
+    public object FieldAny;
+
+    public SomeOtherStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public SomeOtherStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStruct.cs
@@ -1,0 +1,25 @@
+namespace Grafana.Foundation.StructOptionalFields;
+
+using System.Collections.Generic;
+
+public class SomeStruct
+{
+    public SomeOtherStruct FieldRef;
+    public string FieldString;
+    public SomeStructOperator Operator;
+    public List<string> FieldArrayOfStrings;
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct FieldAnonymousStruct;
+
+    public SomeStruct()
+    {
+    }
+
+    public SomeStruct(SomeOtherStruct fieldRef, string fieldString, SomeStructOperator operatorArg, List<string> fieldArrayOfStrings, StructOptionalFieldsSomeStructFieldAnonymousStruct fieldAnonymousStruct)
+    {
+        this.FieldRef = fieldRef;
+        this.FieldString = fieldString;
+        this.Operator = operatorArg;
+        this.FieldArrayOfStrings = fieldArrayOfStrings;
+        this.FieldAnonymousStruct = fieldAnonymousStruct;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStructOperator.cs
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStructOperator.cs
@@ -1,0 +1,11 @@
+namespace Grafana.Foundation.StructOptionalFields;
+
+using System.Runtime.Serialization;
+
+public enum SomeStructOperator
+{
+    [EnumMember(Value = ">")]
+    GreaterThan,
+    [EnumMember(Value = "<")]
+    LessThan
+}

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStructOperator.cs
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/SomeStructOperator.cs
@@ -1,11 +1,7 @@
 namespace Grafana.Foundation.StructOptionalFields;
 
-using System.Runtime.Serialization;
-
 public enum SomeStructOperator
 {
-    [EnumMember(Value = ">")]
     GreaterThan,
-    [EnumMember(Value = "<")]
     LessThan
 }

--- a/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/StructOptionalFieldsSomeStructFieldAnonymousStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_optional_fields/CSharpRawTypes/src/Grafana/Foundation/StructOptionalFields/StructOptionalFieldsSomeStructFieldAnonymousStruct.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.StructOptionalFields;
+
+
+public class StructOptionalFieldsSomeStructFieldAnonymousStruct
+{
+    public object FieldAny;
+
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct()
+    {
+        this.FieldAny = new object();
+    }
+
+    public StructOptionalFieldsSomeStructFieldAnonymousStruct(object fieldAny)
+    {
+        this.FieldAny = fieldAny;
+    }
+}

--- a/testdata/jennies/rawtypes/struct_with_scalar_fields/CSharpRawTypes/src/Grafana/Foundation/Basic/SomeStruct.cs
+++ b/testdata/jennies/rawtypes/struct_with_scalar_fields/CSharpRawTypes/src/Grafana/Foundation/Basic/SomeStruct.cs
@@ -1,0 +1,65 @@
+namespace Grafana.Foundation.Basic;
+
+
+// This
+// is
+// a
+// comment
+public class SomeStruct
+{
+    // Anything can go in there.
+    // Really, anything.
+    public object FieldAny;
+    public bool FieldBool;
+    public byte FieldBytes;
+    public string FieldString;
+    public string FieldStringWithConstantValue;
+    public float FieldFloat32;
+    public double FieldFloat64;
+    public byte FieldUint8;
+    public ushort FieldUint16;
+    public uint FieldUint32;
+    public ulong FieldUint64;
+    public sbyte FieldInt8;
+    public short FieldInt16;
+    public int FieldInt32;
+    public long FieldInt64;
+
+    public SomeStruct()
+    {
+        this.FieldAny = new object();
+        this.FieldBool = false;
+        this.FieldBytes = (byte) 0;
+        this.FieldString = "";
+        this.FieldStringWithConstantValue = "";
+        this.FieldFloat32 = 0f;
+        this.FieldFloat64 = 0d;
+        this.FieldUint8 = 0;
+        this.FieldUint16 = 0;
+        this.FieldUint32 = 0;
+        this.FieldUint64 = 0UL;
+        this.FieldInt8 = 0;
+        this.FieldInt16 = 0;
+        this.FieldInt32 = 0;
+        this.FieldInt64 = 0L;
+    }
+
+    public SomeStruct(object fieldAny, bool fieldBool, byte fieldBytes, string fieldString, string fieldStringWithConstantValue, float fieldFloat32, double fieldFloat64, byte fieldUint8, ushort fieldUint16, uint fieldUint32, ulong fieldUint64, sbyte fieldInt8, short fieldInt16, int fieldInt32, long fieldInt64)
+    {
+        this.FieldAny = fieldAny;
+        this.FieldBool = fieldBool;
+        this.FieldBytes = fieldBytes;
+        this.FieldString = fieldString;
+        this.FieldStringWithConstantValue = fieldStringWithConstantValue;
+        this.FieldFloat32 = fieldFloat32;
+        this.FieldFloat64 = fieldFloat64;
+        this.FieldUint8 = fieldUint8;
+        this.FieldUint16 = fieldUint16;
+        this.FieldUint32 = fieldUint32;
+        this.FieldUint64 = fieldUint64;
+        this.FieldInt8 = fieldInt8;
+        this.FieldInt16 = fieldInt16;
+        this.FieldInt32 = fieldInt32;
+        this.FieldInt64 = fieldInt64;
+    }
+}

--- a/testdata/jennies/rawtypes/time_hint/CSharpRawTypes/src/Grafana/Foundation/TimeHint/ObjWithTimeField.cs
+++ b/testdata/jennies/rawtypes/time_hint/CSharpRawTypes/src/Grafana/Foundation/TimeHint/ObjWithTimeField.cs
@@ -1,0 +1,20 @@
+namespace Grafana.Foundation.TimeHint;
+
+
+public class ObjWithTimeField
+{
+    public string RegisteredAt;
+    public string Duration;
+
+    public ObjWithTimeField()
+    {
+        this.RegisteredAt = "";
+        this.Duration = "";
+    }
+
+    public ObjWithTimeField(string registeredAt, string duration)
+    {
+        this.RegisteredAt = registeredAt;
+        this.Duration = duration;
+    }
+}

--- a/testdata/jennies/rawtypes/variant_dataquery/CSharpRawTypes/src/Grafana/Foundation/VariantDataquery/Query.cs
+++ b/testdata/jennies/rawtypes/variant_dataquery/CSharpRawTypes/src/Grafana/Foundation/VariantDataquery/Query.cs
@@ -1,0 +1,19 @@
+namespace Grafana.Foundation.VariantDataquery;
+
+
+public class Query
+{
+    public string Expr;
+    public bool Instant;
+
+    public Query()
+    {
+        this.Expr = "";
+    }
+
+    public Query(string expr, bool instant)
+    {
+        this.Expr = expr;
+        this.Instant = instant;
+    }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgFull/FieldConfig.cs
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgFull/FieldConfig.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.VariantPanelcfgFull;
+
+
+public class FieldConfig
+{
+    public string TimeseriesFieldConfigOption;
+
+    public FieldConfig()
+    {
+        this.TimeseriesFieldConfigOption = "";
+    }
+
+    public FieldConfig(string timeseriesFieldConfigOption)
+    {
+        this.TimeseriesFieldConfigOption = timeseriesFieldConfigOption;
+    }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_full/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgFull/Options.cs
+++ b/testdata/jennies/rawtypes/variant_panelcfg_full/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgFull/Options.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.VariantPanelcfgFull;
+
+
+public class Options
+{
+    public string TimeseriesOption;
+
+    public Options()
+    {
+        this.TimeseriesOption = "";
+    }
+
+    public Options(string timeseriesOption)
+    {
+        this.TimeseriesOption = timeseriesOption;
+    }
+}

--- a/testdata/jennies/rawtypes/variant_panelcfg_only_options/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgOnlyOptions/Options.cs
+++ b/testdata/jennies/rawtypes/variant_panelcfg_only_options/CSharpRawTypes/src/Grafana/Foundation/VariantPanelcfgOnlyOptions/Options.cs
@@ -1,0 +1,17 @@
+namespace Grafana.Foundation.VariantPanelcfgOnlyOptions;
+
+
+public class Options
+{
+    public string Content;
+
+    public Options()
+    {
+        this.Content = "";
+    }
+
+    public Options(string content)
+    {
+        this.Content = content;
+    }
+}

--- a/testdata/jennies/serializers/disjunctions_of_refs/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfRefs/DisjunctionOfRefsJsonConverter.cs
+++ b/testdata/jennies/serializers/disjunctions_of_refs/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfRefs/DisjunctionOfRefsJsonConverter.cs
@@ -1,0 +1,42 @@
+namespace Grafana.Foundation.DisjunctionsOfRefs;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class DisjunctionOfRefsJsonConverter : JsonConverter<DisjunctionOfRefs>
+{
+    public override DisjunctionOfRefs Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("type", out var discProp))
+        {
+            throw new JsonException("missing discriminator property 'type' for DisjunctionOfRefs");
+        }
+
+        var result = new DisjunctionOfRefs();
+        var raw = root.GetRawText();
+        switch (discProp.GetString())
+        {
+            case "A":
+                result.MyRefA = JsonSerializer.Deserialize<MyRefA>(raw, options);
+                break;
+            case "B":
+                result.MyRefB = JsonSerializer.Deserialize<MyRefB>(raw, options);
+                break;
+            default:
+                throw new JsonException("unknown discriminator value '" + discProp.GetString() + "' for DisjunctionOfRefs");
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DisjunctionOfRefs value, JsonSerializerOptions options)
+    {
+        if (value.MyRefA != null) { JsonSerializer.Serialize(writer, value.MyRefA, options); }
+        else if (value.MyRefB != null) { JsonSerializer.Serialize(writer, value.MyRefB, options); }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/testdata/jennies/serializers/disjunctions_of_scalars/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfScalars/DisjunctionOfScalarsJsonConverter.cs
+++ b/testdata/jennies/serializers/disjunctions_of_scalars/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfScalars/DisjunctionOfScalarsJsonConverter.cs
@@ -1,0 +1,45 @@
+namespace Grafana.Foundation.DisjunctionsOfScalars;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class DisjunctionOfScalarsJsonConverter : JsonConverter<DisjunctionOfScalars>
+{
+    public override DisjunctionOfScalars Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        var result = new DisjunctionOfScalars();
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                result.String = reader.GetString();
+                break;
+            case JsonTokenType.True:
+            case JsonTokenType.False:
+                result.Bool = reader.GetBoolean();
+                break;
+            case JsonTokenType.StartArray:
+                result.ArrayOfString = JsonSerializer.Deserialize<List<string>>(ref reader, options);
+                break;
+            case JsonTokenType.Number:
+                if (reader.TryGetInt64(out _)) { result.Int64 = reader.GetInt64(); }
+                else { result.Float32 = reader.GetSingle(); }
+                break;
+            default:
+                throw new JsonException("unexpected token while deserialising DisjunctionOfScalars: " + reader.TokenType);
+        }
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DisjunctionOfScalars value, JsonSerializerOptions options)
+    {
+        if (value.String != null) { JsonSerializer.Serialize(writer, value.String, options); }
+        else if (value.Bool != null) { JsonSerializer.Serialize(writer, value.Bool.Value, options); }
+        else if (value.ArrayOfString != null) { JsonSerializer.Serialize(writer, value.ArrayOfString, options); }
+        else if (value.Int64 != null) { JsonSerializer.Serialize(writer, value.Int64.Value, options); }
+        else if (value.Float32 != null) { JsonSerializer.Serialize(writer, value.Float32.Value, options); }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/testdata/jennies/serializers/disjunctions_of_scalars_and_refs/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/DisjunctionOfScalarsAndRefsJsonConverter.cs
+++ b/testdata/jennies/serializers/disjunctions_of_scalars_and_refs/CSharpJsonConverters/src/Grafana/Foundation/DisjunctionsOfScalarsAndRefs/DisjunctionOfScalarsAndRefsJsonConverter.cs
@@ -1,0 +1,66 @@
+namespace Grafana.Foundation.DisjunctionsOfScalarsAndRefs;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public sealed class DisjunctionOfScalarsAndRefsJsonConverter : JsonConverter<DisjunctionOfScalarsAndRefs>
+{
+    public override DisjunctionOfScalarsAndRefs Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+        var raw = root.GetRawText();
+        var result = new DisjunctionOfScalarsAndRefs();
+
+        switch (root.ValueKind)
+        {
+            case JsonValueKind.String:
+                result.String = root.GetString();
+                break;
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                result.Bool = root.GetBoolean();
+                break;
+            case JsonValueKind.Array:
+                result.ArrayOfString = JsonSerializer.Deserialize<List<string>>(raw, options);
+                break;
+            case JsonValueKind.Object:
+                if (TryDeserialize<MyRefA>(raw, options, out var __MyRefA)) { result.MyRefA = __MyRefA; break; }
+                if (TryDeserialize<MyRefB>(raw, options, out var __MyRefB)) { result.MyRefB = __MyRefB; break; }
+                result.Any = JsonSerializer.Deserialize<JsonElement>(raw, options);
+                break;
+            default:
+                throw new JsonException("unexpected token while deserialising DisjunctionOfScalarsAndRefs: " + root.ValueKind);
+        }
+
+        return result;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DisjunctionOfScalarsAndRefs value, JsonSerializerOptions options)
+    {
+        if (value.String != null) { JsonSerializer.Serialize(writer, value.String, options); }
+        else if (value.Bool != null) { JsonSerializer.Serialize(writer, value.Bool.Value, options); }
+        else if (value.ArrayOfString != null) { JsonSerializer.Serialize(writer, value.ArrayOfString, options); }
+        else if (value.MyRefA != null) { JsonSerializer.Serialize(writer, value.MyRefA, options); }
+        else if (value.MyRefB != null) { JsonSerializer.Serialize(writer, value.MyRefB, options); }
+        else if (value.Any != null) { JsonSerializer.Serialize(writer, value.Any, options); }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+
+    private static bool TryDeserialize<T>(string raw, JsonSerializerOptions options, out T? value)
+    {
+        try
+        {
+            value = JsonSerializer.Deserialize<T>(raw, options);
+            return value != null;
+        }
+        catch (JsonException)
+        {
+            value = default;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **C#** as a new code-generation target to `cog`, sitting alongside Go, Java, PHP, Python, TypeScript, Terraform, JSON Schema and OpenAPI. The implementation closely mirrors the Java jenny — the closest existing OO/strongly-typed analogue — and produces idiomatic .NET 10 C# code with nullable reference types enabled.

This is the foundational work to enable a future C# Grafana Foundation SDK.

## What's generated

For each schema, the new jenny emits:

- **Raw types** — `class`, `enum` and constant declarations under `src/<NamespaceRoot>/<Package>/<Type>.cs`. Default namespace root is `Grafana.Foundation`, configurable via `namespace_root`.
- **`System.Text.Json` converters** (opt-in via `generate_json_converters: true`) — per-field `[JsonPropertyName]`, per-class `[JsonConverter(typeof(<T>JsonConverter))]`, per-string-enum `[JsonConverter(typeof(JsonStringEnumConverter<T>))]` + `[JsonStringEnumMemberName(...)]`. Disjunction shapes (refs/scalars/mixed) get bespoke `JsonConverter<T>` classes mirroring Java's `couldBe` semantics.
- **Fluent builders** (gated on the global `output.builders` flag) — `public class <Name>Builder : Cog.IBuilder<TargetType>` with chainable PascalCase option methods, constructor + property fields, nil-checks for nested parents, builder-typed args via `Cog.IBuilder<T>` / `List<Cog.IBuilder<T>>` / `Dictionary<string, Cog.IBuilder<T>>` unfolded into plain collections via `foreach + .Build()`. Constraints (`>=`, `<=`, regex) throw `System.ArgumentException`.
- **Cog runtime** — single `Cog/IBuilder.cs` with `public interface IBuilder<out T> { T Build(); }`. Skippable via `skip_runtime: true` (mutually exclusive with builders).

Composable slots render as `Cog.Variants.<Variant>` (the variants interface itself is a follow-up). The C# `internal` keyword is sidestepped via the verbatim identifier `@internal` for the wrapped instance field.

## Pipeline config

```yaml
output:
  languages:
    - csharp:
        namespace_root: 'Grafana.Foundation'   # default
        generate_json_converters: true
        generate_equality: false               # not yet implemented
        skip_runtime: false
```

The C# output is wired into `config/foundation_sdk.tests.yaml` so `make tests` / `gen-tests` exercises the full pipeline (16 generated `.cs` files committed under `testdata/generated/src/`).

## Implementation notes

- **Layout**: `internal/jennies/csharp/` mirrors `internal/jennies/java/`. Templates live under `templates/{types,marshalling,builders,runtime}/`.
- **Type formatter**: pre-formats every field/arg type in Go before rendering so the import map is fully populated when `{{ .Imports }}` is rendered. This is a deliberate deviation from Java (where `formatType` is called at render time and imports may be stale).
- **Cog references**: written as `Cog.X` and resolved via parent-namespace lookup — no `using Grafana.Foundation.Cog;` is emitted.
- **Source layout**: `src/Grafana/Foundation/<Package>/<Type>.cs` with a single `.csproj` for v1; per-package projects can be introduced later without touching paths or namespaces.

Each phase landed as a separate commit on this branch:

1. `371db9ad` — skeleton & wiring (`Language` interface, `OutputLanguage.CSharp`, pipeline switch)
2. `8326264d` — raw types jenny (89 golden files across 28 fixtures)
3. `3fa01876` — System.Text.Json marshalling
4. `909db276` — fluent builders + `Cog.IBuilder<T>` runtime (28 builder fixtures + smoke test)
5. `b092023d` — SDK test pipeline wiring + docs

## What's *not* in this PR (deferred)

- **Option converters** (Java-style object-to-builder-source codegen, used for "dashboards as code" import). Disabled by default in Java too; will be a follow-up.
- **`Equals` / `GetHashCode` jenny** behind `generate_equality`.
- **`Cog.Variants.<X>` interface generation** — currently referenced but not emitted.
- **Generic-panel hierarchy** (Java's `<T extends FooBuilder<T>>` for `Dashboard.Panel` / `VizConfigKind` / `DataQueryKind`).
- **Foundation-SDK sibling-repo wiring** (`examples/csharp`, `prepare-release.sh` hooks). `scripts/ci/build-csharp.sh` is added as a placeholder.

## Testing

- `go test ./...` is green.
- `internal/jennies/csharp/{rawtypes,converters,builder,runtime}_test.go` cover all jennies with golden files under `testdata/jennies/{rawtypes,builders,serializers,deserializers}/`.
- End-to-end `make gen-tests` produces a clean `testdata/generated/src/` tree (committed).
- The generated C# has not been compiled with `dotnet build` in this repo (no .NET toolchain in CI yet); spot-check by hand looks good. A real `csproj` + `dotnet build` step belongs in the foundation-sdk CI alongside `scripts/ci/build-csharp.sh`.
