### PR TITLE
Converters: Skip empty maps or slices as defaults

### DIFF
--- a/internal/languages/converter.go
+++ b/internal/languages/converter.go
@@ -581,14 +581,20 @@ func (generator *ConverterGenerator) guardForAssignments(valuesRootPath ast.Path
 			guards.Set(guard.String(), guard)
 		}
 
-		// For scalar values, add a guard against assignments equal to the default value for that path
+		// For scalar values, add a guard against assignments equal to the default value for that path.
+		// Map and slice defaults are skipped: they can't be compared with != in Go (compile error
+		// for concrete map types, runtime panic for interface types).
 		if assignmentType.IsScalar() && assignmentType.Default != nil {
-			guard := MappingGuard{
-				Path:  valuesRootPath.Append(assignment.Path),
-				Op:    ast.NotEqualOp,
-				Value: assignmentType.Default,
+			_, defaultIsMap := assignmentType.Default.(map[string]interface{})
+			_, defaultIsSlice := assignmentType.Default.([]interface{})
+			if !defaultIsMap && !defaultIsSlice {
+				guard := MappingGuard{
+					Path:  valuesRootPath.Append(assignment.Path),
+					Op:    ast.NotEqualOp,
+					Value: assignmentType.Default,
+				}
+				guards.Set(guard.String(), guard)
 			}
-			guards.Set(guard.String(), guard)
 		}
 
 		// TODO: is that correct/needed?


### PR DESCRIPTION
Contributes to: https://github.com/grafana/grafana-foundation-sdk/issues/1203

When we set an empty slice or map as default, the converters generating a wrong change doing the code to fail.

For example:

```yaml
  - fields_set_default:
      defaults:
        dashboardv2.VizConfigSpec.options: {}
```

it was generating:

```go
if input.Spec.Options != nil && *input.Spec.Options != map[string]interface{}{} {
}
```

This change detects these defaults omitting them from the generation.