### PR TITLE
Veneers: Create set_as_generic action

### DIFF
--- a/cmd/veneers-docs/main.go
+++ b/cmd/veneers-docs/main.go
@@ -16,10 +16,10 @@ import (
 )
 
 const builderRulesSource = "./internal/veneers/builder/rules.go"
-const builderRulesOuputFile = "./docs/reference/builders_transformations.md"
+const builderRulesOutputFile = "./docs/reference/builders_transformations.md"
 
 const optionRulesSource = "./internal/veneers/option/rules.go"
-const optionRulesOuputFile = "./docs/reference/options_transformations.md"
+const optionRulesOutputFile = "./docs/reference/options_transformations.md"
 
 type Rule struct {
 	Name string
@@ -291,7 +291,7 @@ func main() {
 	}
 
 	builderDocEntries := parseYamlRules(reflect.TypeFor[yaml.BuilderRule](), builderRules)
-	if err := os.WriteFile(builderRulesOuputFile, builderDocEntriesToMarkdown(builderDocEntries), 0600); err != nil {
+	if err := os.WriteFile(builderRulesOutputFile, builderDocEntriesToMarkdown(builderDocEntries), 0600); err != nil {
 		panic(err)
 	}
 
@@ -301,7 +301,7 @@ func main() {
 	}
 
 	optionDocEntries := parseYamlRules(reflect.TypeFor[yaml.OptionRule](), optionRules)
-	if err := os.WriteFile(optionRulesOuputFile, optionDocEntriesToMarkdown(optionDocEntries), 0600); err != nil {
+	if err := os.WriteFile(optionRulesOutputFile, optionDocEntriesToMarkdown(optionDocEntries), 0600); err != nil {
 		panic(err)
 	}
 }

--- a/docs/reference/builders_transformations.md
+++ b/docs/reference/builders_transformations.md
@@ -145,3 +145,13 @@ rename:
   as: string
 ```
 
+## `set_as_generic`
+
+N/A
+
+### Usage
+
+```yaml
+set_as_generic: {}
+```
+

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -26,6 +26,10 @@ type Builder struct {
 	// root path defined at composition time.
 	// e.g.: under `spec`
 	AssignmentsPreferredRoot Path
+
+	// IsGeneric is used by some languages as Java to be able to generate the builder as generic to simplify
+	// the extension of the builder.
+	IsGeneric bool `json:",omitempty"`
 }
 
 func (builder *Builder) OptionByName(name string) (Option, bool) {

--- a/internal/jennies/java/builder.go
+++ b/internal/jennies/java/builder.go
@@ -66,7 +66,7 @@ func (jenny Builder) genBuilder(context languages.Context, builder ast.Builder) 
 		Options:              builder.Options,
 		Properties:           builder.Properties,
 		ImportAlias:          jenny.config.PackagePath,
-		IsGenericPanel:       jenny.isGenericPanel(builder),
+		IsGenericPanel:       builder.IsGeneric,
 	}
 
 	jenny.apiRefCollector.BuilderMethod(builder, common.MethodReference{
@@ -110,16 +110,4 @@ func (jenny Builder) getBuilderSignature(pkg string, obj ast.Object) string {
 	}
 
 	return fmt.Sprintf("%s.%s", jenny.config.formatPackage("cog.variants"), tools.UpperCamelCase(obj.Type.ImplementedVariant()))
-}
-
-func (jenny Builder) isGenericPanel(builder ast.Builder) bool {
-	if builder.Package != builder.For.SelfRef.ReferredPkg {
-		return false
-	}
-
-	// TODO: remove this once we have a better way to identify generic builders
-	dashboardLegacy := builder.Package == "dashboard" && builder.Name == "Panel"
-	dashboardv2VizConfig := builder.Package == "dashboardv2beta1" && builder.Name == "VizConfigKind"
-	dashboardv2DataQueryKind := builder.Package == "dashboardv2beta1" && builder.Name == "DataQueryKind"
-	return dashboardLegacy || dashboardv2VizConfig || dashboardv2DataQueryKind
 }

--- a/internal/veneers/builder/actions.go
+++ b/internal/veneers/builder/actions.go
@@ -499,3 +499,15 @@ func DebugAction() ActionRunner {
 		return builders, nil
 	}
 }
+
+func GenericAction(selector *Selector) ActionRunner {
+	return func(ctx RuleCtx, builders ast.Builders) (ast.Builders, error) {
+		for i := range builders {
+			if selector.Matches(ctx.Schemas, builders[i]) {
+				builders[i].IsGeneric = true
+				builders[i].AddToVeneerTrail(fmt.Sprintf("Generic[selector=%s.%s]", builders[i].For.SelfRef.ReferredPkg, builders[i].For.SelfRef.ReferredType))
+			}
+		}
+		return builders, nil
+	}
+}

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -196,6 +196,8 @@ func Debug(selector *Selector) *Rule {
 	}
 }
 
+// Generic sets a builder as generic. Useful when a language needs special generation
+// when a builder has to be extensible.
 func Generic(selector *Selector) *Rule {
 	return &Rule{
 		Selector: selector,

--- a/internal/veneers/builder/rules.go
+++ b/internal/veneers/builder/rules.go
@@ -195,3 +195,13 @@ func Debug(selector *Selector) *Rule {
 		},
 	}
 }
+
+func Generic(selector *Selector) *Rule {
+	return &Rule{
+		Selector: selector,
+		Action: &Action{
+			description: "generic",
+			run:         GenericAction(selector),
+		},
+	}
+}

--- a/internal/veneers/builder/rules_test.go
+++ b/internal/veneers/builder/rules_test.go
@@ -138,3 +138,40 @@ func TestPromoteOptionsToConstructor(t *testing.T) {
 	req.Equal(expectedArgs, updatedBuilders[0].Constructor.Args)
 	req.Equal(expectedAssignments, updatedBuilders[0].Constructor.Assignments)
 }
+
+func TestGenericAction(t *testing.T) {
+	req := require.New(t)
+
+	originalObject := ast.NewObject("generic", "Panel", ast.NewStruct(
+		ast.NewStructField("uid", ast.String()),
+		ast.NewStructField("name", ast.String()),
+	))
+
+	schemas := ast.Schemas{
+		&ast.Schema{
+			Package: "generic",
+			Objects: testutils.ObjectsMap(originalObject),
+		},
+	}
+	originalBuilders := ast.Builders{
+		{
+			For:     originalObject,
+			Package: "generic",
+		},
+	}
+
+	expectedBuilders := ast.Builders{
+		{
+			For:         originalObject,
+			Package:     "generic",
+			IsGeneric:   true,
+			VeneerTrail: []string{"Generic[selector=generic.Panel]"},
+		},
+	}
+
+	action := GenericAction(ByObjectName("generic", "Panel"))
+	updatedBuilders, err := action(RuleCtx{Schemas: schemas, Builders: originalBuilders}, originalBuilders)
+	req.NoError(err)
+
+	req.Equal(expectedBuilders, updatedBuilders)
+}

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -25,6 +25,7 @@ type BuilderRule struct {
 	AddOption                *AddOption                `yaml:"add_option"`
 	AddFactory               *AddFactory               `yaml:"add_factory"`
 	Debug                    *DebugBuilder             `yaml:"debug" rule_name:"Debug"`
+	SetAsGeneric             *SetAsGeneric             `yaml:"set_as_generic"`
 }
 
 func (rule BuilderRule) AsRule(pkg string) (*builder.Rule, error) {
@@ -70,6 +71,10 @@ func (rule BuilderRule) AsRule(pkg string) (*builder.Rule, error) {
 
 	if rule.Debug != nil {
 		return rule.Debug.AsRule(pkg)
+	}
+
+	if rule.SetAsGeneric != nil {
+		return rule.SetAsGeneric.AsRule(pkg)
 	}
 
 	return nil, fmt.Errorf("empty rule")
@@ -262,6 +267,19 @@ func (rule DebugBuilder) AsRule(pkg string) (*builder.Rule, error) {
 	}
 
 	return builder.Debug(selector), nil
+}
+
+type SetAsGeneric struct {
+	BuilderSelector `yaml:",inline"`
+}
+
+func (rule SetAsGeneric) AsRule(pkg string) (*builder.Rule, error) {
+	selector, err := rule.AsSelector(pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.Generic(selector), nil
 }
 
 /******************************************************************************

--- a/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
+++ b/testdata/jennies/builders/dashboard_panel/JavaBuilder/dashboard/PanelBuilder.java
@@ -1,15 +1,15 @@
 package dashboard;
 
 
-public class PanelBuilder<T extends PanelBuilder<T>> implements cog.Builder<Panel> {
+public class PanelBuilder implements cog.Builder<Panel> {
     protected final Panel internal;
     
     public PanelBuilder() {
         this.internal = new Panel();
     }
-    public T onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
+    public PanelBuilder onlyFromThisDashboard(Boolean onlyFromThisDashboard) {
         this.internal.onlyFromThisDashboard = onlyFromThisDashboard;
-        return (T) this;
+        return this;
     }
     public Panel build() {
         return this.internal;


### PR DESCRIPTION
Closes: https://github.com/grafana/cog/issues/1096

It allows to set a builder as generic and use it in the languages that we need. It's useful for Java because allows to make `dashboard.Panel` or `dashboardv2.VizConfigKind` builders extensibles for third party objects.

This information was hardcoded in cog since we didn't have an action to allow to do it. It needs update in Foundation-SDK in the next cog update.