### PR TITLE
Support initializing fields when composing builders

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -7,8 +7,7 @@
     "php83Packages.phpstan@2.1.1",
     "python@3.14",
     "golangci-lint@2.9.0",
-    "nodejs-slim_18@18.20.8",
-    "nodePackages.ts-node@10.9.2",
+    "yarn@1.22",
     "gradle@8.14.4",
     "goreleaser@2.16.0"
   ],

--- a/devbox.lock
+++ b/devbox.lock
@@ -197,135 +197,6 @@
         }
       }
     },
-    "nodePackages.ts-node@10.9.2": {
-      "last_modified": "2025-02-26T05:29:08Z",
-      "resolved": "github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a#nodePackages.ts-node",
-      "source": "devbox-search",
-      "version": "10.9.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/sy0hq2153kr5xppb7k5clx7lfbxnm9xn-ts-node-10.9.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/sy0hq2153kr5xppb7k5clx7lfbxnm9xn-ts-node-10.9.2"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/2bjvqlfmis3p3nw8i8k607znq9wvfpia-ts-node-10.9.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/2bjvqlfmis3p3nw8i8k607znq9wvfpia-ts-node-10.9.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/5617lzmjjkc1kbq4vqn68v2nj4phqlpl-ts-node-10.9.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/5617lzmjjkc1kbq4vqn68v2nj4phqlpl-ts-node-10.9.2"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/0w72g1f20xx14sqhfqr7wkh7x8j48j0r-ts-node-10.9.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/0w72g1f20xx14sqhfqr7wkh7x8j48j0r-ts-node-10.9.2"
-        }
-      }
-    },
-    "nodejs-slim_18@18.20.8": {
-      "last_modified": "2025-04-17T05:47:26Z",
-      "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c#nodejs-slim_18",
-      "source": "devbox-search",
-      "version": "18.20.8",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/sn1vm9ax1cgjslbr5gkgxyscaccc5nq9-nodejs-slim-18.20.8",
-              "default": true
-            },
-            {
-              "name": "libv8",
-              "path": "/nix/store/3w031xpjzd77ald8d8zp3mn7fg99kgs7-nodejs-slim-18.20.8-libv8"
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/ny97a1afbpnwjc1j4nfglpkrls19a9jn-nodejs-slim-18.20.8-dev"
-            }
-          ],
-          "store_path": "/nix/store/sn1vm9ax1cgjslbr5gkgxyscaccc5nq9-nodejs-slim-18.20.8"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/1d6ac8mr9pqrq4iw7dqyfnx28my39sqb-nodejs-slim-18.20.8",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/xvl22s047bnygnibf9qq57y6660khd9q-nodejs-slim-18.20.8-dev"
-            },
-            {
-              "name": "libv8",
-              "path": "/nix/store/dl6g5vy6axkjqmy52az44q69gric20hg-nodejs-slim-18.20.8-libv8"
-            }
-          ],
-          "store_path": "/nix/store/1d6ac8mr9pqrq4iw7dqyfnx28my39sqb-nodejs-slim-18.20.8"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/imh0dmszccvxqqh2d676zijplvryfdpr-nodejs-slim-18.20.8",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/gv2m3bfm9ygd62a3pkah2yrxr8rwh5n7-nodejs-slim-18.20.8-dev"
-            },
-            {
-              "name": "libv8",
-              "path": "/nix/store/3jm0dhpfbg4hmamjd4rn2fh2a1mgph7v-nodejs-slim-18.20.8-libv8"
-            }
-          ],
-          "store_path": "/nix/store/imh0dmszccvxqqh2d676zijplvryfdpr-nodejs-slim-18.20.8"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/6qxbirspbc3781wfnbj4cwl1ci8bwgb2-nodejs-slim-18.20.8",
-              "default": true
-            },
-            {
-              "name": "libv8",
-              "path": "/nix/store/n4q6bqnlbp48dx3gvq3kqh5l2cbm8d0q-nodejs-slim-18.20.8-libv8"
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/i8n79nfy9dqfgcwfqv9ih122paijh2n9-nodejs-slim-18.20.8-dev"
-            }
-          ],
-          "store_path": "/nix/store/6qxbirspbc3781wfnbj4cwl1ci8bwgb2-nodejs-slim-18.20.8"
-        }
-      }
-    },
     "php83Packages.composer@2.9.8": {
       "last_modified": "2026-05-14T12:36:40Z",
       "resolved": "github:NixOS/nixpkgs/27198194e52129ccd8e845e7d5911911e7fea7d7#php83Packages.composer",
@@ -525,6 +396,54 @@
             }
           ],
           "store_path": "/nix/store/hd3h6gjpy7pf5himwf8sfqb3108pz5ld-python3-3.14.2"
+        }
+      }
+    },
+    "yarn@1.22": {
+      "last_modified": "2026-05-21T08:15:18Z",
+      "resolved": "github:NixOS/nixpkgs/4a29d733e8a7d5b824c3d8c958a946a9867b3eb2#yarn",
+      "source": "devbox-search",
+      "version": "1.22.22",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lqy5dclc9x809r5hd474sa8pr904205b-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lqy5dclc9x809r5hd474sa8pr904205b-yarn-1.22.22"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/q12qjvf4g8zxpw2dd0pbw2cxv2bk608q-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/q12qjvf4g8zxpw2dd0pbw2cxv2bk608q-yarn-1.22.22"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y972fn9z79dhgmv1zwl6zahjh2x80vl6-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y972fn9z79dhgmv1zwl6zahjh2x80vl6-yarn-1.22.22"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ih3inzyxsw3ls23zs2zcrjnn1k1jvygm-yarn-1.22.22",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ih3inzyxsw3ls23zs2zcrjnn1k1jvygm-yarn-1.22.22"
         }
       }
     }

--- a/docs/reference/builders_transformations.md
+++ b/docs/reference/builders_transformations.md
@@ -50,6 +50,7 @@ compose:
   plugin_discriminator_field: string
   exclude_options: []string
   composition_map: map[string]string
+  initialize_composition_map: bool
   composed_builder_name: string
   preserve_original_builders: bool
   rename_options: map[string]string

--- a/internal/ast/builder.go
+++ b/internal/ast/builder.go
@@ -380,9 +380,10 @@ func (envelope *AssignmentEnvelope) DeepCopy() AssignmentEnvelope {
 }
 
 type AssignmentValue struct {
-	Argument *Argument           `json:",omitempty"`
-	Constant any                 `json:",omitempty"`
-	Envelope *AssignmentEnvelope `json:",omitempty"`
+	Argument       *Argument           `json:",omitempty"`
+	Constant       any                 `json:",omitempty"`
+	Envelope       *AssignmentEnvelope `json:",omitempty"`
+	ConstructorFor *RefType            `json:",omitempty"`
 }
 
 func (value *AssignmentValue) DeepCopy() AssignmentValue {
@@ -398,6 +399,11 @@ func (value *AssignmentValue) DeepCopy() AssignmentValue {
 	if value.Envelope != nil {
 		envelope := value.Envelope.DeepCopy()
 		clone.Envelope = &envelope
+	}
+
+	if value.ConstructorFor != nil {
+		ref := value.ConstructorFor.DeepCopy()
+		clone.ConstructorFor = &ref
 	}
 
 	return clone

--- a/internal/jennies/golang/builder.go
+++ b/internal/jennies/golang/builder.go
@@ -67,12 +67,6 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 		buildObjectSignature = jenny.typeFormatter.variantInterface(builder.For.Type.ImplementedVariant())
 	}
 
-	constructorName := "New" + formatObjectName(builder.For.SelfRef.ReferredType)
-	constructorPkg := jenny.typeImportMapper(builder.For.SelfRef.ReferredPkg)
-	if constructorPkg != "" {
-		constructorName = constructorPkg + "." + constructorName
-	}
-
 	jenny.apiRefCollector.BuilderMethod(builder, common.MethodReference{
 		Name: "Build",
 		Comments: []string{
@@ -93,6 +87,16 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 			}),
 			Return: "*" + builder.Name + "Builder",
 		})
+	}
+
+	constructorFor := func(ref *ast.RefType) string {
+		constructorName := "New" + formatObjectName(ref.ReferredType)
+		constructorPkg := jenny.typeImportMapper(ref.ReferredPkg)
+		if constructorPkg != "" {
+			constructorName = constructorPkg + "." + constructorName
+		}
+
+		return constructorName
 	}
 
 	return jenny.Tmpl.
@@ -128,13 +132,14 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 
 				return formatted
 			},
+			"constructorFor": constructorFor,
 		}).
 		RenderAsBytes("builders/builder.tmpl", map[string]any{
 			"Builder":              builder,
 			"BuilderSignatureType": buildObjectSignature,
 			"Imports":              imports,
 			"ObjectName":           fullObjectName,
-			"ConstructorName":      constructorName,
+			"ConstructorName":      constructorFor(&builder.For.SelfRef),
 		})
 }
 

--- a/internal/jennies/golang/templates/builders/assignment.tmpl
+++ b/internal/jennies/golang/templates/builders/assignment.tmpl
@@ -31,6 +31,8 @@
         {{- with .Value.Envelope }}
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
         {{- end }}
+    {{- else if .Value.ConstructorFor }}
+        {{- .Value.ConstructorFor|constructorFor }}()
     {{- else }}
         {{- if isNullableNonArray .Assignment.Path.Last.Type }}
             {{- print "&val" (.Assignment.Path.Last.Identifier | upperCamelCase) }}

--- a/internal/jennies/golang/tmpl.go
+++ b/internal/jennies/golang/tmpl.go
@@ -67,6 +67,9 @@ func initTemplates(config Config, apiRefCollector *common.APIReferenceCollector)
 			"toGoIdent": func(_ string) string {
 				panic("toGoIdent() needs to be overridden by a jenny")
 			},
+			"constructorFor": func(ref *ast.RefType) string {
+				panic("constructorFor() needs to be overridden by a jenny")
+			},
 			"formatValue": func(destinationType ast.Type, value any) string {
 				panic("formatValue() needs to be overridden by a jenny")
 			},

--- a/internal/jennies/java/templates/builders/assigments.tmpl
+++ b/internal/jennies/java/templates/builders/assigments.tmpl
@@ -56,6 +56,8 @@
         {{- with .Value.Envelope }}
         {{- .Type | formatType | lowerCamelCase }}
         {{- end }}
+    {{- else if .Value.ConstructorFor }}
+        {{- .Value.ConstructorFor.AsType|emptyValueForType}}
     {{- else }}
         {{- formatRefType .IntoType .Value.Constant }}
     {{- end }}

--- a/internal/jennies/php/rawtypes.go
+++ b/internal/jennies/php/rawtypes.go
@@ -148,7 +148,7 @@ func (jenny RawTypes) formatObject(context languages.Context, schema *ast.Schema
 
 		buffer.WriteString(enum)
 	case ast.KindRef:
-		buffer.WriteString(fmt.Sprintf("class %s extends %s {}", defName, jenny.typeFormatter.formatType(def.Type)))
+		fmt.Fprintf(&buffer, "class %s extends %s {}", defName, jenny.typeFormatter.formatType(def.Type))
 	case ast.KindStruct:
 		structDef, err := jenny.formatStructDef(context, schema, def)
 		if err != nil {
@@ -182,11 +182,11 @@ func (jenny RawTypes) formatStructDef(context languages.Context, schema *ast.Sch
 		variant = ", " + jenny.config.fullNamespaceRef("Cog\\"+formatObjectName(object.Type.ImplementedVariant()))
 	}
 
-	buffer.WriteString(fmt.Sprintf("class %s", formatObjectName(object.Name)))
+	fmt.Fprintf(&buffer, "class %s", formatObjectName(object.Name))
 	if jenny.config.GenerateJSONMarshaller {
 		buffer.WriteString(" implements \\JsonSerializable")
 	}
-	buffer.WriteString(fmt.Sprintf("%s\n{\n", variant))
+	fmt.Fprintf(&buffer, "%s\n{\n", variant)
 
 	for _, fieldDef := range object.Type.Struct.Fields {
 		buffer.WriteString(tools.Indent(jenny.typeFormatter.formatField(fieldDef), 4))
@@ -352,7 +352,7 @@ func (jenny RawTypes) generateConstructor(context languages.Context, def ast.Obj
 		buffer.WriteString(formatCommentsBlock(typeAnnotations))
 	}
 
-	buffer.WriteString(fmt.Sprintf("public function __construct(%s)\n", strings.Join(args, ", ")))
+	fmt.Fprintf(&buffer, "public function __construct(%s)\n", strings.Join(args, ", "))
 	buffer.WriteString("{\n")
 
 	buffer.WriteString(strings.Join(assignments, "\n"))
@@ -398,7 +398,7 @@ func (jenny RawTypes) generateFromJSON(context languages.Context, def ast.Object
 	buffer.WriteString("public static function fromArray(array $inputData): self\n")
 	buffer.WriteString("{\n")
 	if len(constructorArgs) != 0 {
-		buffer.WriteString(fmt.Sprintf("    /** @var %s $inputData */\n", jenny.shaper.typeShape(def.Type)))
+		fmt.Fprintf(&buffer, "    /** @var %s $inputData */\n", jenny.shaper.typeShape(def.Type))
 		buffer.WriteString("    $data = $inputData;\n")
 	}
 	buffer.WriteString("    return new self(\n")
@@ -491,7 +491,7 @@ func (jenny RawTypes) unmarshalRefFunc(context languages.Context, refDef ast.Typ
 	case found && referredObject.Type.IsEnum():
 		return fmt.Sprintf(`(function($input) { return %[1]s::fromValue($input); })`, formattedRef)
 	case found && referredObject.Type.IsRef():
-		assignment := fmt.Sprintf("/** @var array<string, mixed> */\n")
+		assignment := "/** @var array<string, mixed> */\n"
 		assignment += "$val = $input;"
 
 		return fmt.Sprintf(`(function($input) {
@@ -647,7 +647,7 @@ func (jenny RawTypes) generateJSONSerialize(def ast.Object) string {
 			continue
 		}
 
-		buffer.WriteString(fmt.Sprintf(`    $data->%s = $this->%s;`+"\n", field.Name, formatFieldName(field.Name)))
+		fmt.Fprintf(&buffer, `    $data->%s = $this->%s;`+"\n", field.Name, formatFieldName(field.Name))
 	}
 
 	for _, field := range def.Type.AsStruct().Fields {
@@ -657,8 +657,8 @@ func (jenny RawTypes) generateJSONSerialize(def ast.Object) string {
 
 		fieldName := formatFieldName(field.Name)
 
-		buffer.WriteString(fmt.Sprintf("    if (isset($this->%s)) {\n", fieldName))
-		buffer.WriteString(fmt.Sprintf(`        $data->%s = $this->%s;`+"\n", field.Name, fieldName))
+		fmt.Fprintf(&buffer, "    if (isset($this->%s)) {\n", fieldName)
+		fmt.Fprintf(&buffer, `        $data->%s = $this->%s;`+"\n", field.Name, fieldName)
 		buffer.WriteString("    }\n")
 	}
 

--- a/internal/jennies/php/templates/builders/assignment.tmpl
+++ b/internal/jennies/php/templates/builders/assignment.tmpl
@@ -32,6 +32,8 @@
         {{- with .Value.Envelope }}
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
         {{- end }}
+    {{- else if .Value.ConstructorFor -}}
+        new {{ .Value.ConstructorFor.AsType|formatRawType }}()
     {{- else }}
         {{- formatValue .IntoType .Value.Constant }}
     {{- end }}

--- a/internal/jennies/python/builder.go
+++ b/internal/jennies/python/builder.go
@@ -74,7 +74,6 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 	jenny.importModule("cogbuilder", "..cog", "builder")
 
 	fullObjectName := jenny.typeFormatter.formatRef(builder.For.SelfRef)
-	buildObjectSignature := fullObjectName
 
 	jenny.apiRefCollector.BuilderMethod(builder, common.MethodReference{
 		Name: "build",
@@ -132,8 +131,7 @@ func (jenny *Builder) generateBuilder(context languages.Context, builder ast.Bui
 			},
 		}).
 		RenderAsBytes("builders/builder.tmpl", map[string]any{
-			"Builder":              builder,
-			"BuilderSignatureType": buildObjectSignature,
-			"ObjectName":           fullObjectName,
+			"Builder":    builder,
+			"ObjectName": fullObjectName,
 		})
 }

--- a/internal/jennies/python/equality.go
+++ b/internal/jennies/python/equality.go
@@ -24,13 +24,13 @@ func (jenny equalityMethods) generateForObject(object ast.Object) string {
 	objectName := formatObjectName(object.Name)
 	var buffer strings.Builder
 
-	buffer.WriteString(fmt.Sprintf("    def __eq__(self, other: object) -> bool:\n"))
-	buffer.WriteString(fmt.Sprintf("        if not isinstance(other, %s):\n", objectName))
+	fmt.Fprintf(&buffer, "    def __eq__(self, other: object) -> bool:\n")
+	fmt.Fprintf(&buffer, "        if not isinstance(other, %s):\n", objectName)
 	buffer.WriteString("            return False\n")
 
 	for _, field := range object.Type.AsStruct().Fields {
 		fieldName := formatIdentifier(field.Name)
-		buffer.WriteString(fmt.Sprintf("        if self.%s != other.%s:\n", fieldName, fieldName))
+		fmt.Fprintf(&buffer, "        if self.%s != other.%s:\n", fieldName, fieldName)
 		buffer.WriteString("            return False\n")
 	}
 

--- a/internal/jennies/python/templates/builders/assignment.tmpl
+++ b/internal/jennies/python/templates/builders/assignment.tmpl
@@ -61,6 +61,8 @@ assert {{ range $i, $branch := .Type.Disjunction.Branches }}isinstance({{ $name 
 {{- with .Value.Envelope }}
 {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
 {{- end }}
+{{- else if .Value.ConstructorFor }}
+{{- .Value.ConstructorFor.AsType|formatRawType }}()
 {{- else }}
 {{- formatValue .IntoType .Value.Constant }}
 {{- end }}

--- a/internal/jennies/python/templates/builders/builder.tmpl
+++ b/internal/jennies/python/templates/builders/builder.tmpl
@@ -1,6 +1,6 @@
-class {{ .Builder.Name|formatObjectName }}(cogbuilder.Builder[{{ .BuilderSignatureType }}]):
+class {{ .Builder.Name|formatObjectName }}(cogbuilder.Builder[{{ .ObjectName }}]):
     {{- include "comments" (dict "Comments" .Builder.For.Comments) | indent 4 }}
-    _internal: {{ .BuilderSignatureType }}
+    _internal: {{ .ObjectName }}
     {{- range .Builder.Properties }}
     __{{ .Name|formatIdentifier }}: {{ .Type | formatType }} = {{ defaultForType .Type }}
     {{- end }}

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -117,22 +117,22 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 
 	tmpl := initTemplates(language.config, language.apiRefCollector)
 
-	jenny := codejen.JennyListWithNamer[languages.Context](func(_ languages.Context) string {
+	jenny := codejen.JennyListWithNamer(func(_ languages.Context) string {
 		return LanguageRef
 	})
 	jenny.AppendOneToMany(
-		common.If[languages.Context](!language.config.SkipRuntime, Runtime{config: language.config}),
+		common.If(!language.config.SkipRuntime, Runtime{config: language.config}),
 
-		common.If[languages.Context](globalConfig.Types, RawTypes{config: language.config, tmpl: tmpl}),
-		common.If[languages.Context](!language.config.SkipRuntime && globalConfig.Builders, &Builder{
+		common.If(globalConfig.Types, RawTypes{config: language.config, tmpl: tmpl}),
+		common.If(!language.config.SkipRuntime && globalConfig.Builders, &Builder{
 			config:          language.config,
 			tmpl:            tmpl,
 			apiRefCollector: language.apiRefCollector,
 		}),
 
-		common.If[languages.Context](!language.config.SkipIndex, Index{config: language.config, Targets: globalConfig}),
+		common.If(!language.config.SkipIndex, Index{config: language.config, Targets: globalConfig}),
 
-		common.If[languages.Context](globalConfig.APIReference, common.APIReference{
+		common.If(globalConfig.APIReference, common.APIReference{
 			Collector: language.apiRefCollector,
 			Language:  LanguageRef,
 			Formatter: apiReferenceFormatter(language.config),

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -94,6 +94,8 @@ export class {{ .Builder.Name|upperCamelCase }}Builder implements cog.Builder<{{
         {{- with .Value.Envelope }}
         {{- template "value_envelope" (dict "Assignment" $.Assignment "Envelope" .) }}
         {{- end }}
+    {{- else if .Value.ConstructorFor }}
+        {{- .Value.ConstructorFor.AsType | defaultValueForType }}
     {{- else }}
         {{- formatValue .Assignment.Path.Last.Type .Value.Constant }}
     {{- end }}

--- a/internal/jennies/typescript/templates/builder.tmpl
+++ b/internal/jennies/typescript/templates/builder.tmpl
@@ -13,8 +13,7 @@ export class {{ .Builder.Name|upperCamelCase }}Builder implements cog.Builder<{{
     constructor({{ template "args" .Builder.Constructor.Args }}) {
         this.internal = {{ .ImportAlias }}.default{{ .ObjectName | upperCamelCase }}();
         {{- range $arg := .Builder.Constructor.Assignments }}
-        {{- template "constraints" $arg.Constraints }}
-        this.internal.{{ $arg.Path }} = {{ template "assignment_value" (dict "Assignment" $arg "Value" $arg.Value) }};
+        {{- template "assignment" (dict "Assignment" . "Builder" $.Builder "Option" (dict "Name" "")) }}
         {{- end }}
     }
 

--- a/internal/veneers/builder/actions.go
+++ b/internal/veneers/builder/actions.go
@@ -158,6 +158,16 @@ func composeBuilderForType(schemas ast.Schemas, config CompositionConfig, typeDi
 			return nil, err
 		}
 
+		if config.InitializeCompositionMap {
+			newBuilder.Constructor.Assignments = append(newBuilder.Constructor.Assignments, ast.Assignment{
+				Path:   newRoot,
+				Method: ast.DirectAssignment,
+				Value: ast.AssignmentValue{
+					ConstructorFor: refType.Ref,
+				},
+			})
+		}
+
 		// we do this to ensure that the same builder can be composed more than once
 		// ie: dashboard and dashboardv2 packages
 		if config.PreserveOriginalBuilders {
@@ -261,6 +271,17 @@ type CompositionConfig struct {
 	// }
 	// ```
 	CompositionMap map[string]string
+
+	// InitializeCompositionMap indicates that each path in the composition map
+	// must be initialized with a call to the constructor of the type associated
+	// to it.
+	//
+	// Example:
+	// ```go
+	// builder.internal.Spec.Options = NewOptions()
+	// builder.internal.Spec.FieldConfig.Defaults.Custom = NewFieldConfig()
+	// ```
+	InitializeCompositionMap bool
 
 	// ExcludeOptions lists option names to exclude in the resulting
 	// composed builders.

--- a/internal/yaml/builder.go
+++ b/internal/yaml/builder.go
@@ -133,6 +133,7 @@ type ComposeBuilders struct {
 	PluginDiscriminatorField string            `yaml:"plugin_discriminator_field"`
 	ExcludeOptions           []string          `yaml:"exclude_options"`
 	CompositionMap           map[string]string `yaml:"composition_map"`
+	InitializeCompositionMap bool              `yaml:"initialize_composition_map"`
 	ComposedBuilderName      string            `yaml:"composed_builder_name"`
 	PreserveOriginalBuilders bool              `yaml:"preserve_original_builders"`
 	RenameOptions            map[string]string `yaml:"rename_options"`
@@ -149,6 +150,7 @@ func (rule ComposeBuilders) AsRule(pkg string) (*builder.Rule, error) {
 		PluginDiscriminatorField: rule.PluginDiscriminatorField,
 		ExcludeOptions:           rule.ExcludeOptions,
 		CompositionMap:           rule.CompositionMap,
+		InitializeCompositionMap: rule.InitializeCompositionMap,
 		ComposedBuilderName:      rule.ComposedBuilderName,
 		PreserveOriginalBuilders: rule.PreserveOriginalBuilders,
 		RenameOptions:            rule.RenameOptions,

--- a/schemas/veneers.json
+++ b/schemas/veneers.json
@@ -693,6 +693,9 @@
           },
           "type": "object"
         },
+        "initialize_composition_map": {
+          "type": "boolean"
+        },
         "composed_builder_name": {
           "type": "string"
         },

--- a/scripts/ci/build-ts.sh
+++ b/scripts/ci/build-ts.sh
@@ -9,4 +9,6 @@ set -o nounset
 # Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
 set -o pipefail
 
-tsc generated/typescript/src/*/*.ts
+cd generated/typescript 
+
+yarn install && yarn build


### PR DESCRIPTION
When composing builders, it can be useful to initialize the fields being composed with a default value.

Think dashboard panels and options/fieldConfig needing to be initialized with values coming from table/timeseries/...

Concretely, we want to go from:

```go
func NewVisualizationBuilder() *VisualizationBuilder {
	resource := dashboardv2beta1.NewVizConfigKind()
	builder := &VisualizationBuilder{
		internal: resource,
		errors:   make(cog.BuildErrors, 0),
	}
	builder.internal.Kind = "VizConfig"
	builder.internal.Group = "timeseries"

	return builder
}
```

To:

```go
func NewVisualizationBuilder() *VisualizationBuilder {
	resource := dashboardv2beta1.NewVizConfigKind()
	builder := &VisualizationBuilder{
		internal: resource,
		errors:   make(cog.BuildErrors, 0),
	}
	builder.internal.Kind = "VizConfig"
	builder.internal.Group = "timeseries"
	builder.internal.Spec.Options = NewOptions() // this is added by this PR
	builder.internal.Spec.FieldConfig.Defaults.Custom = NewFieldConfig() // this is added by this PR

	return builder
}
```