### PR TITLE
QoL improvements

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -89,6 +89,9 @@ func doInspect(ctx context.Context, logger *slog.Logger, opts options) error {
 		return err
 	}
 
+	// To ensure we won't build bother with builder-related things when building the context.
+	pipeline.Output.Builders = opts.IRType == "builders"
+
 	language, err := inspectedLanguage(pipeline, opts)
 	if err != nil {
 		return err

--- a/internal/ast/compiler/schema_set_entrypoint.go
+++ b/internal/ast/compiler/schema_set_entrypoint.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -15,6 +17,10 @@ func (pass *SchemaSetEntrypoint) Process(schemas []*ast.Schema) ([]*ast.Schema, 
 	for _, schema := range schemas {
 		if schema.Package != pass.Package {
 			continue
+		}
+
+		if !schema.HasObject(pass.EntryPoint) {
+			return nil, fmt.Errorf("can not use %s as entrypoint for schema %s: object not found", pass.EntryPoint, pass.Package)
 		}
 
 		schema.EntryPoint = pass.EntryPoint


### PR DESCRIPTION
A couple of nice-to-have improvements that I needed when debugging some stuff:
* the first commit makes sure that the `cog inspect` command doesn't initialize builder-related transforms when builders aren't being inspected
* the second commit makes the SchemaSetEntrypoint fail explicitly when we're trying to set an entrypoint that doesn't exist