### PR TITLE
Don't skip builder generation for objects implementing a variant

### DIFF
--- a/internal/ast/compiler/disjunction_propagate_variant.go
+++ b/internal/ast/compiler/disjunction_propagate_variant.go
@@ -1,0 +1,49 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/grafana/cog/internal/ast"
+)
+
+var _ Pass = (*DisjunctionPropagateVariant)(nil)
+
+type DisjunctionPropagateVariant struct {
+	schemas ast.Schemas
+}
+
+func (pass *DisjunctionPropagateVariant) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.schemas = schemas
+
+	visitor := &Visitor{
+		OnObject: pass.processObject,
+	}
+
+	return visitor.VisitSchemas(schemas)
+}
+
+func (pass *DisjunctionPropagateVariant) processObject(_ *Visitor, schema *ast.Schema, obj ast.Object) (ast.Object, error) {
+	if !obj.Type.ImplementsVariant() {
+		return obj, nil
+	}
+
+	if !obj.Type.IsDisjunction() {
+		return obj, nil
+	}
+
+	for _, def := range obj.Type.Disjunction.Branches {
+		if !def.IsRef() {
+			continue
+		}
+
+		referredObj, found := schema.LocateObject(def.Ref.ReferredType)
+		if !found {
+			return referredObj, fmt.Errorf("could not resolve reference %s", def.Ref)
+		}
+
+		referredObj.Type.Hints[ast.HintImplementsVariant] = obj.Type.Hints[ast.HintImplementsVariant]
+		referredObj.AddToPassesTrail("DisjunctionPropagateVariant")
+	}
+
+	return obj, nil
+}

--- a/internal/ast/compiler/rename_object.go
+++ b/internal/ast/compiler/rename_object.go
@@ -19,6 +19,12 @@ func (pass *RenameObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) 
 		OnRef:    pass.processRef,
 	}
 
+	for _, schema := range schemas {
+		if schema.Package == pass.From.Package && schema.EntryPoint == pass.From.Object {
+			schema.EntryPoint = pass.To
+		}
+	}
+
 	return visitor.VisitSchemas(schemas)
 }
 

--- a/internal/ast/types.go
+++ b/internal/ast/types.go
@@ -153,7 +153,7 @@ func (t Type) IsAnyOf(kinds ...Kind) bool {
 }
 
 func (t Type) ImplementsVariant() bool {
-	return t.HasHint(HintImplementsVariant)
+	return t.HasHint(HintImplementsVariant) && t.Hints[HintImplementsVariant] != nil
 }
 
 func (t Type) ImplementedVariant() string {
@@ -169,10 +169,23 @@ func (t Type) IsDataqueryVariant() bool {
 		return false
 	}
 
-	return t.Hints[HintImplementsVariant].(string) == string(SchemaVariantDataQuery)
+	if t.Hints[HintImplementsVariant] == nil {
+		return false
+	}
+
+	variant, ok := t.Hints[HintImplementsVariant].(string)
+	if !ok {
+		return false
+	}
+
+	return variant == string(SchemaVariantDataQuery)
 }
 
 func (t Type) HasHint(hintName string) bool {
+	if t.Hints == nil {
+		return false
+	}
+
 	_, found := t.Hints[hintName]
 
 	return found

--- a/internal/jennies/php/jennies.go
+++ b/internal/jennies/php/jennies.go
@@ -168,6 +168,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.DisjunctionInferMapping{},
 		&compiler.UndiscriminatedDisjunctionToAny{},
 		&compiler.RemoveIntersections{},
+		&compiler.DisjunctionPropagateVariant{},
 		&compiler.InlineObjectsWithTypes{
 			InlineTypes: []ast.Kind{ast.KindScalar, ast.KindArray, ast.KindMap, ast.KindDisjunction},
 		},

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -119,6 +119,7 @@ func (language *Language) CompilerPasses() compiler.Passes {
 		&compiler.FlattenDisjunctions{},
 		&compiler.DisjunctionInferMapping{},
 		&compiler.RenameNumericEnumValues{},
+		&compiler.DisjunctionPropagateVariant{},
 	}
 }
 

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -155,6 +155,7 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 func (language *Language) CompilerPasses() compiler.Passes {
 	return compiler.Passes{
 		&compiler.RenameNumericEnumValues{},
+		&compiler.DisjunctionPropagateVariant{},
 	}
 }
 

--- a/internal/veneers/builder/selectors.go
+++ b/internal/veneers/builder/selectors.go
@@ -62,8 +62,9 @@ func StructGeneratedFromDisjunction() *Selector {
 		description: "struct_generated_from_disjunction",
 		matcher: func(schemas ast.Schemas, builder ast.Builder) bool {
 			resolved := schemas.ResolveToType(builder.For.Type)
+			implementsVariant := builder.For.Type.ImplementsVariant()
 
-			return resolved.IsStructGeneratedFromDisjunction()
+			return resolved.IsStructGeneratedFromDisjunction() && !implementsVariant
 		},
 	}
 }


### PR DESCRIPTION
The way cog/the foundation SDK deals with dataqueries was slightly broken for dataqueries defined as a disjunction of types.

See https://github.com/grafana/grafana-foundation-sdk/issues/1204

Fixing this issue requires that cog deals slightly differently with these types.
For languages that do support disjunctions/union types (such as Python, PHP, ...) : no changes.
For other languages, we need to make sure that only the disjunction will be considered a dataquery and that a builder will be generated for it.

Some codegen configuration changes are also required on the SDK's side, that's what https://github.com/grafana/grafana-foundation-sdk/pull/1275 does.