### PR TITLE
Expose more schema transformations to yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ docs: dev-env-check-binaries ## Generates the documentation.
 
 .PHONY: serve-docs
 serve-docs: dev-env-check-binaries ## Builds and serves the documentation.
-	$(RUN_DEVBOX) mkdocs serve -w ./docs/ -f ./mkdocs-github.yml
+	$(RUN_DEVBOX) zensical serve -f ./mkdocs-github.yml
 
 .PHONY: fetch-foundation-sdk
 fetch-foundation-sdk: ## Fetches the Foundation SDK.

--- a/docs/reference/schema_transformations.md
+++ b/docs/reference/schema_transformations.md
@@ -28,6 +28,37 @@ add_object:
   comments: []string
 ```
 
+## `anonymous_enum_to_named`
+
+AnonymousEnumToExplicitType turns "anonymous enums" into a named
+object.
+
+Example:
+
+	```
+	Panel struct {
+		Type enum(Foo, Bar, Baz)
+	}
+	```
+
+Will become:
+
+	```
+	Panel struct {
+		Type PanelType
+	}
+
+	PanelType enum(Foo, Bar, Baz)
+	```
+
+Note: this compiler pass looks for anonymous enums in structs and arrays only.
+
+### Usage
+
+```yaml
+anonymous_enum_to_named: {}
+```
+
 ## `anonymous_structs_to_named`
 
 AnonymousStructsToNamed turns "anonymous structs" into a named object.

--- a/docs/reference/schema_transformations.md
+++ b/docs/reference/schema_transformations.md
@@ -368,6 +368,16 @@ retype_object:
   comments: []string
 ```
 
+## `sanitize_enum_member_names`
+
+N/A
+
+### Usage
+
+```yaml
+sanitize_enum_member_names: {}
+```
+
 ## `schema_set_entry_point`
 
 N/A

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -32,7 +32,8 @@ type CompilerPass struct {
 	ExtractK8ResourceNames   *CleanupK8ResourceNames   `yaml:"cleanup_k8_resource_names"`
 	TrimObjectNamePrefix     *TrimObjectNamePrefix     `yaml:"trim_object_name_prefix"`
 
-	AnonymousStructsToNamed *AnonymousStructsToNamed `yaml:"anonymous_structs_to_named"`
+	AnonymousStructsToNamed     *AnonymousStructsToNamed `yaml:"anonymous_structs_to_named"`
+	AnonymousEnumToExplicitType *AnonymousEnumsToNamed   `yaml:"anonymous_enum_to_named"`
 
 	DisjunctionToType                       *DisjunctionToType                       `yaml:"disjunction_to_type"`
 	DisjunctionOfAnonymousStructsToExplicit *DisjunctionOfAnonymousStructsToExplicit `yaml:"disjunction_of_anonymous_structs_to_explicit"`
@@ -114,6 +115,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 
 	if pass.AnonymousStructsToNamed != nil {
 		return pass.AnonymousStructsToNamed.AsCompilerPass()
+	}
+	if pass.AnonymousEnumToExplicitType != nil {
+		return pass.AnonymousEnumToExplicitType.AsCompilerPass()
 	}
 
 	if pass.DisjunctionToType != nil {
@@ -452,6 +456,13 @@ type AnonymousStructsToNamed struct {
 
 func (pass AnonymousStructsToNamed) AsCompilerPass() (*compiler.AnonymousStructsToNamed, error) {
 	return &compiler.AnonymousStructsToNamed{}, nil
+}
+
+type AnonymousEnumsToNamed struct {
+}
+
+func (pass AnonymousEnumsToNamed) AsCompilerPass() (*compiler.AnonymousEnumToExplicitType, error) {
+	return &compiler.AnonymousEnumToExplicitType{}, nil
 }
 
 type DisjunctionToType struct {

--- a/internal/yaml/compilerpasses.go
+++ b/internal/yaml/compilerpasses.go
@@ -31,6 +31,7 @@ type CompilerPass struct {
 	ConstantToEnum           *ConstantToEnum           `yaml:"constant_to_enum"`
 	ExtractK8ResourceNames   *CleanupK8ResourceNames   `yaml:"cleanup_k8_resource_names"`
 	TrimObjectNamePrefix     *TrimObjectNamePrefix     `yaml:"trim_object_name_prefix"`
+	SanitizeEnumMemberNames  *SanitizeEnumMemberNames  `yaml:"sanitize_enum_member_names"`
 
 	AnonymousStructsToNamed     *AnonymousStructsToNamed `yaml:"anonymous_structs_to_named"`
 	AnonymousEnumToExplicitType *AnonymousEnumsToNamed   `yaml:"anonymous_enum_to_named"`
@@ -111,6 +112,9 @@ func (pass CompilerPass) AsCompilerPass() (compiler.Pass, error) {
 	}
 	if pass.TrimObjectNamePrefix != nil {
 		return pass.TrimObjectNamePrefix.AsCompilerPass()
+	}
+	if pass.SanitizeEnumMemberNames != nil {
+		return pass.SanitizeEnumMemberNames.AsCompilerPass()
 	}
 
 	if pass.AnonymousStructsToNamed != nil {
@@ -543,4 +547,11 @@ func (pass TrimObjectNamePrefix) AsCompilerPass() (*compiler.TrimObjectNamePrefi
 	return &compiler.TrimObjectNamePrefix{
 		Prefix: pass.Prefix,
 	}, nil
+}
+
+type SanitizeEnumMemberNames struct {
+}
+
+func (pass SanitizeEnumMemberNames) AsCompilerPass() (*compiler.SanitizeEnumMemberNames, error) {
+	return &compiler.SanitizeEnumMemberNames{}, nil
 }

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -290,6 +290,11 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "YamlAnonymousEnumsToNamed": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
     "YamlAnonymousStructsToNamed": {
       "properties": {},
       "additionalProperties": false,
@@ -389,6 +394,9 @@
         },
         "anonymous_structs_to_named": {
           "$ref": "#/$defs/YamlAnonymousStructsToNamed"
+        },
+        "anonymous_enum_to_named": {
+          "$ref": "#/$defs/YamlAnonymousEnumsToNamed"
         },
         "disjunction_to_type": {
           "$ref": "#/$defs/YamlDisjunctionToType"

--- a/schemas/compiler_passes.json
+++ b/schemas/compiler_passes.json
@@ -392,6 +392,9 @@
         "trim_object_name_prefix": {
           "$ref": "#/$defs/YamlTrimObjectNamePrefix"
         },
+        "sanitize_enum_member_names": {
+          "$ref": "#/$defs/YamlSanitizeEnumMemberNames"
+        },
         "anonymous_structs_to_named": {
           "$ref": "#/$defs/YamlAnonymousStructsToNamed"
         },
@@ -629,6 +632,11 @@
           "type": "array"
         }
       },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "YamlSanitizeEnumMemberNames": {
+      "properties": {},
       "additionalProperties": false,
       "type": "object"
     },


### PR DESCRIPTION
This will allow external applications (like the Foundation SDK) to use these schema transformations.