### PR TITLE
Emit diagnoses from schema transforms

### DIFF
--- a/internal/ast/compiler/add_fields.go
+++ b/internal/ast/compiler/add_fields.go
@@ -11,11 +11,14 @@ var _ Pass = (*AddFields)(nil)
 // AddFields rewrites the definition of an object to add new fields.
 // Note: existing fields will not be overwritten.
 type AddFields struct {
-	Object ObjectReference
-	Fields []ast.StructField
+	Object      ObjectReference
+	Fields      []ast.StructField
+	objectFound bool
 }
 
 func (pass *AddFields) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectFound = false
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -43,5 +46,17 @@ func (pass *AddFields) processObject(_ *Visitor, _ *ast.Schema, object ast.Objec
 		object.Type.Struct.Fields = append(object.Type.Struct.Fields, field)
 	}
 
+	pass.objectFound = true
+
 	return object, nil
+}
+
+func (pass *AddFields) Diagnostics() []string {
+	if pass.objectFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("object '%s' not found", pass.Object),
+	}
 }

--- a/internal/ast/compiler/add_object.go
+++ b/internal/ast/compiler/add_object.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -8,12 +10,15 @@ var _ Pass = (*AddObject)(nil)
 
 // AddObject adds a new object to a schema.
 type AddObject struct {
-	Object   ObjectReference
-	As       ast.Type
-	Comments []string
+	Object       ObjectReference
+	As           ast.Type
+	Comments     []string
+	packageFound bool
 }
 
 func (pass *AddObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.packageFound = false
+
 	visitor := &Visitor{
 		OnSchema: pass.processSchema,
 	}
@@ -32,5 +37,17 @@ func (pass *AddObject) processSchema(visitor *Visitor, schema *ast.Schema) (*ast
 
 	visitor.RegisterNewObject(newObject)
 
+	pass.packageFound = true
+
 	return schema, nil
+}
+
+func (pass *AddObject) Diagnostics() []string {
+	if pass.packageFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("package '%s' not found", pass.Object.Package),
+	}
 }

--- a/internal/ast/compiler/compiler.go
+++ b/internal/ast/compiler/compiler.go
@@ -1,6 +1,9 @@
 package compiler
 
 import (
+	"log/slog"
+	"reflect"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -15,7 +18,7 @@ func (passes Passes) Concat(other Passes) Passes {
 	return concat
 }
 
-func (passes Passes) Process(schemas ast.Schemas) (ast.Schemas, error) {
+func (passes Passes) Process(logger *slog.Logger, schemas ast.Schemas) (ast.Schemas, error) {
 	var err error
 	processedSchemas := schemas.DeepCopy()
 
@@ -24,6 +27,16 @@ func (passes Passes) Process(schemas ast.Schemas) (ast.Schemas, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		p, ok := compilerPass.(Diagnosable)
+		if !ok {
+			continue
+		}
+
+		passName := reflect.TypeOf(p).Elem().Name()
+		for _, msg := range p.Diagnostics() {
+			logger.Warn(msg, slog.String("pass", passName))
+		}
 	}
 
 	return processedSchemas, nil
@@ -31,4 +44,8 @@ func (passes Passes) Process(schemas ast.Schemas) (ast.Schemas, error) {
 
 type Pass interface {
 	Process(schemas []*ast.Schema) ([]*ast.Schema, error)
+}
+
+type Diagnosable interface {
+	Diagnostics() []string
 }

--- a/internal/ast/compiler/constant_to_enum.go
+++ b/internal/ast/compiler/constant_to_enum.go
@@ -1,7 +1,10 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
 )
 
 var _ Pass = (*ConstantToEnum)(nil)
@@ -11,10 +14,15 @@ var _ Pass = (*ConstantToEnum)(nil)
 // This is useful to "future-proof" a schema where a type can have a single
 // value for now but is expected to allow more in the future.
 type ConstantToEnum struct {
-	Objects ObjectReferences
+	Objects      ObjectReferences
+	objectsFound []string
+	warnings     []string
 }
 
 func (pass *ConstantToEnum) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectsFound = nil
+	pass.warnings = nil
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -28,6 +36,7 @@ func (pass *ConstantToEnum) processObject(_ *Visitor, _ *ast.Schema, object ast.
 	}
 
 	if !object.Type.IsConcreteScalar() || object.Type.Scalar.ScalarKind != ast.KindString {
+		pass.warnings = append(pass.warnings, fmt.Sprintf("object '%s' is not a concrete string", object.SelfRef))
 		return object, nil
 	}
 
@@ -40,5 +49,25 @@ func (pass *ConstantToEnum) processObject(_ *Visitor, _ *ast.Schema, object ast.
 	})
 	object.AddToPassesTrail("ConstantToEnum")
 
+	pass.objectsFound = append(pass.objectsFound, object.SelfRef.String())
+
 	return object, nil
+}
+
+func (pass *ConstantToEnum) Diagnostics() []string {
+	var diags []string
+	diags = append(diags, pass.warnings...)
+
+	if len(pass.objectsFound) == len(pass.Objects) {
+		return diags
+	}
+
+	expected := tools.Map(pass.Objects, func(ref ObjectReference) string {
+		return ref.String()
+	})
+	missing := tools.Map(tools.SliceFindMissing(pass.objectsFound, expected), func(ref string) string {
+		return fmt.Sprintf("object not found '%s'", ref)
+	})
+
+	return append(diags, missing...)
 }

--- a/internal/ast/compiler/duplicate_object.go
+++ b/internal/ast/compiler/duplicate_object.go
@@ -18,11 +18,13 @@ type DuplicateObject struct {
 	As         ObjectReference
 	OmitFields []string
 
-	schemas ast.Schemas
+	schemas     ast.Schemas
+	objectFound bool
 }
 
 func (pass *DuplicateObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
 	pass.schemas = schemas
+	pass.objectFound = false
 
 	visitor := &Visitor{
 		OnSchema: pass.processSchema,
@@ -41,6 +43,8 @@ func (pass *DuplicateObject) processSchema(visitor *Visitor, schema *ast.Schema)
 		return schema, nil
 	}
 
+	pass.objectFound = true
+
 	duplicate := sourceObj.DeepCopy()
 	duplicate.Name = pass.As.Object
 	duplicate.SelfRef.ReferredPkg = pass.As.Package
@@ -58,4 +62,14 @@ func (pass *DuplicateObject) processSchema(visitor *Visitor, schema *ast.Schema)
 	visitor.RegisterNewObject(duplicate)
 
 	return schema, nil
+}
+
+func (pass *DuplicateObject) Diagnostics() []string {
+	if pass.objectFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("object '%s' not found", pass.Object),
+	}
 }

--- a/internal/ast/compiler/fields_set_default.go
+++ b/internal/ast/compiler/fields_set_default.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
 )
 
 var _ Pass = (*FieldsSetDefault)(nil)
@@ -11,9 +12,12 @@ var _ Pass = (*FieldsSetDefault)(nil)
 // FieldsSetDefault sets the default value for the given fields.
 type FieldsSetDefault struct {
 	DefaultValues map[FieldReference]any
+	fieldsFound   []string
 }
 
 func (pass *FieldsSetDefault) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldsFound = nil
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -36,8 +40,24 @@ func (pass *FieldsSetDefault) processObject(_ *Visitor, _ *ast.Schema, object as
 			field.AddToPassesTrail(fmt.Sprintf("FieldsSetDefault[default=%v]", value))
 
 			object.Type.Struct.Fields[i] = field
+			pass.fieldsFound = append(pass.fieldsFound, fieldRef.String())
 		}
 	}
 
 	return object, nil
+}
+
+func (pass *FieldsSetDefault) Diagnostics() []string {
+	if len(pass.fieldsFound) == len(pass.DefaultValues) {
+		return nil
+	}
+
+	expected := make([]string, 0, len(pass.DefaultValues))
+	for fieldRef := range pass.DefaultValues {
+		expected = append(expected, fieldRef.String())
+	}
+
+	return tools.Map(tools.SliceFindMissing(pass.fieldsFound, expected), func(ref string) string {
+		return fmt.Sprintf("field not found '%s'", ref)
+	})
 }

--- a/internal/ast/compiler/fields_set_not_required.go
+++ b/internal/ast/compiler/fields_set_not_required.go
@@ -1,17 +1,23 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
 )
 
 var _ Pass = (*FieldsSetNotRequired)(nil)
 
 // FieldsSetNotRequired rewrites the definition of given fields to mark them as nullable and not required.
 type FieldsSetNotRequired struct {
-	Fields []FieldReference
+	Fields      []FieldReference
+	fieldsFound []string
 }
 
 func (pass *FieldsSetNotRequired) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldsFound = nil
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -35,8 +41,24 @@ func (pass *FieldsSetNotRequired) processObject(_ *Visitor, _ *ast.Schema, objec
 			field.AddToPassesTrail("FieldsSetNotRequired[nullable=true, required=false]")
 
 			object.Type.Struct.Fields[i] = field
+			pass.fieldsFound = append(pass.fieldsFound, fieldRef.String())
 		}
 	}
 
 	return object, nil
+}
+
+func (pass *FieldsSetNotRequired) Diagnostics() []string {
+	if len(pass.fieldsFound) == len(pass.Fields) {
+		return nil
+	}
+
+	expected := tools.Map(pass.Fields, func(ref FieldReference) string {
+		return ref.String()
+	})
+	missing := tools.SliceFindMissing(pass.fieldsFound, expected)
+
+	return tools.Map(missing, func(ref string) string {
+		return fmt.Sprintf("field not found '%s'", ref)
+	})
 }

--- a/internal/ast/compiler/fields_set_required.go
+++ b/internal/ast/compiler/fields_set_required.go
@@ -1,17 +1,23 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
 )
 
 var _ Pass = (*FieldsSetRequired)(nil)
 
 // FieldsSetRequired rewrites the definition of given fields to mark them as not nullable and required.
 type FieldsSetRequired struct {
-	Fields []FieldReference
+	Fields      []FieldReference
+	fieldsFound []string
 }
 
 func (pass *FieldsSetRequired) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldsFound = nil
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -35,8 +41,24 @@ func (pass *FieldsSetRequired) processObject(_ *Visitor, _ *ast.Schema, object a
 			field.AddToPassesTrail("FieldsSetRequired[nullable=false, required=true]")
 
 			object.Type.Struct.Fields[i] = field
+			pass.fieldsFound = append(pass.fieldsFound, fieldRef.String())
 		}
 	}
 
 	return object, nil
+}
+
+func (pass *FieldsSetRequired) Diagnostics() []string {
+	if len(pass.fieldsFound) == len(pass.Fields) {
+		return nil
+	}
+
+	expected := tools.Map(pass.Fields, func(ref FieldReference) string {
+		return ref.String()
+	})
+	missing := tools.SliceFindMissing(pass.fieldsFound, expected)
+
+	return tools.Map(missing, func(ref string) string {
+		return fmt.Sprintf("field not found '%s'", ref)
+	})
 }

--- a/internal/ast/compiler/hint_object.go
+++ b/internal/ast/compiler/hint_object.go
@@ -11,11 +11,13 @@ import (
 var _ Pass = (*HintObject)(nil)
 
 type HintObject struct {
-	Object ObjectReference
-	Hints  ast.JenniesHints
+	Object      ObjectReference
+	Hints       ast.JenniesHints
+	objectFound bool
 }
 
 func (pass *HintObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectFound = false
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -27,6 +29,8 @@ func (pass *HintObject) processObject(_ *Visitor, _ *ast.Schema, object ast.Obje
 	if !pass.Object.Matches(object) {
 		return object, nil
 	}
+
+	pass.objectFound = true
 
 	hintsTrail := make([]string, 0, len(pass.Hints))
 	for hint, val := range pass.Hints {
@@ -40,4 +44,14 @@ func (pass *HintObject) processObject(_ *Visitor, _ *ast.Schema, object ast.Obje
 	object.AddToPassesTrail(fmt.Sprintf("HintObject[%s]", strings.Join(hintsTrail, ", ")))
 
 	return object, nil
+}
+
+func (pass *HintObject) Diagnostics() []string {
+	if pass.objectFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("object '%s' not found", pass.Object),
+	}
 }

--- a/internal/ast/compiler/name_anonymous_struct.go
+++ b/internal/ast/compiler/name_anonymous_struct.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -9,11 +11,14 @@ var _ Pass = (*NameAnonymousStruct)(nil)
 // NameAnonymousStruct rewrites the definition of a struct field typed as an
 // anonymous struct to instead refer to a named type.
 type NameAnonymousStruct struct {
-	Field FieldReference
-	As    string
+	Field      FieldReference
+	As         string
+	fieldFound bool
 }
 
 func (pass *NameAnonymousStruct) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldFound = false
+
 	for i, schema := range schemas {
 		schemas[i] = pass.processSchema(schema)
 	}
@@ -55,10 +60,12 @@ func (pass *NameAnonymousStruct) processObject(object ast.Object) (ast.Object, a
 			continue
 		}
 
-		// we expect the target field to be defined an inline struct
+		// we expect the target field to be defined as an inline struct
 		if !field.Type.IsStruct() {
 			continue
 		}
+
+		pass.fieldFound = true
 
 		newObject = ast.NewObject(pkg, pass.As, field.Type)
 		newObject.AddToPassesTrail("NameAnonymousStruct")
@@ -67,4 +74,14 @@ func (pass *NameAnonymousStruct) processObject(object ast.Object) (ast.Object, a
 	}
 
 	return object, newObject
+}
+
+func (pass *NameAnonymousStruct) Diagnostics() []string {
+	if pass.fieldFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("field '%s' not found", pass.Field),
+	}
 }

--- a/internal/ast/compiler/omit.go
+++ b/internal/ast/compiler/omit.go
@@ -1,17 +1,23 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
+	"github.com/grafana/cog/internal/tools"
 )
 
 var _ Pass = (*Omit)(nil)
 
 // Omit rewrites schemas to omit the configured objects.
 type Omit struct {
-	Objects []ObjectReference
+	Objects      []ObjectReference
+	objectsFound []string
 }
 
 func (pass *Omit) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectsFound = nil
+
 	for i, schema := range schemas {
 		schemas[i] = pass.processSchema(schema)
 	}
@@ -24,6 +30,7 @@ func (pass *Omit) processSchema(schema *ast.Schema) *ast.Schema {
 		// if any reference matches the current object, we filter it out
 		for _, objectRef := range pass.Objects {
 			if objectRef.Matches(object) {
+				pass.objectsFound = append(pass.objectsFound, objectRef.String())
 				return false
 			}
 		}
@@ -32,4 +39,19 @@ func (pass *Omit) processSchema(schema *ast.Schema) *ast.Schema {
 	})
 
 	return schema
+}
+
+func (pass *Omit) Diagnostics() []string {
+	if len(pass.objectsFound) == len(pass.Objects) {
+		return nil
+	}
+
+	expected := tools.Map(pass.Objects, func(ref ObjectReference) string {
+		return ref.String()
+	})
+	missing := tools.SliceFindMissing(pass.objectsFound, expected)
+
+	return tools.Map(missing, func(ref string) string {
+		return fmt.Sprintf("object not found '%s'", ref)
+	})
 }

--- a/internal/ast/compiler/omit_fields.go
+++ b/internal/ast/compiler/omit_fields.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/tools"
 )
@@ -9,10 +11,13 @@ var _ Pass = (*OmitFields)(nil)
 
 // OmitFields removes the selected fields from their object definition.
 type OmitFields struct {
-	Fields []FieldReference
+	Fields      []FieldReference
+	fieldsFound []string
 }
 
 func (pass *OmitFields) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldsFound = nil
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -28,6 +33,7 @@ func (pass *OmitFields) processObject(_ *Visitor, _ *ast.Schema, object ast.Obje
 	object.Type.Struct.Fields = tools.Filter(object.Type.Struct.Fields, func(field ast.StructField) bool {
 		for _, fieldRef := range pass.Fields {
 			if fieldRef.Matches(object, field) {
+				pass.fieldsFound = append(pass.fieldsFound, fieldRef.String())
 				return false
 			}
 		}
@@ -36,4 +42,19 @@ func (pass *OmitFields) processObject(_ *Visitor, _ *ast.Schema, object ast.Obje
 	})
 
 	return object, nil
+}
+
+func (pass *OmitFields) Diagnostics() []string {
+	if len(pass.fieldsFound) == len(pass.Fields) {
+		return nil
+	}
+
+	expected := tools.Map(pass.Fields, func(ref FieldReference) string {
+		return ref.String()
+	})
+	missing := tools.SliceFindMissing(pass.fieldsFound, expected)
+
+	return tools.Map(missing, func(ref string) string {
+		return fmt.Sprintf("field not found '%s'", ref)
+	})
 }

--- a/internal/ast/compiler/rename_object.go
+++ b/internal/ast/compiler/rename_object.go
@@ -9,11 +9,14 @@ import (
 var _ Pass = (*RenameObject)(nil)
 
 type RenameObject struct {
-	From ObjectReference
-	To   string
+	From        ObjectReference
+	To          string
+	objectFound bool
 }
 
 func (pass *RenameObject) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.objectFound = false
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 		OnRef:    pass.processRef,
@@ -32,6 +35,8 @@ func (pass *RenameObject) processObject(visitor *Visitor, schema *ast.Schema, ob
 	var err error
 
 	if pass.From.Matches(object) {
+		pass.objectFound = true
+
 		originalName := object.Name
 		object.Name = pass.To
 		object.SelfRef.ReferredType = pass.To
@@ -52,4 +57,14 @@ func (pass *RenameObject) processRef(_ *Visitor, _ *ast.Schema, def ast.Type) (a
 	}
 
 	return def, nil
+}
+
+func (pass *RenameObject) Diagnostics() []string {
+	if pass.objectFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("object '%s' not found", pass.From),
+	}
 }

--- a/internal/ast/compiler/replace_reference.go
+++ b/internal/ast/compiler/replace_reference.go
@@ -8,11 +8,14 @@ import (
 
 // ReplaceReference replaces any usage of the `From` reference by the one given in `To`.
 type ReplaceReference struct {
-	From ObjectReference
-	To   ObjectReference
+	From     ObjectReference
+	To       ObjectReference
+	refFound bool
 }
 
 func (pass *ReplaceReference) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.refFound = false
+
 	visitor := Visitor{
 		OnRef: pass.processRef,
 	}
@@ -25,5 +28,17 @@ func (pass *ReplaceReference) processRef(_ *Visitor, _ *ast.Schema, def ast.Type
 		return def, nil
 	}
 
+	pass.refFound = true
+
 	return ast.NewRef(pass.To.Package, pass.To.Object, ast.Trail(fmt.Sprintf("ReplaceReference[%s → %s]", def.Ref, pass.To))), nil
+}
+
+func (pass *ReplaceReference) Diagnostics() []string {
+	if pass.refFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("reference '%s' not found", pass.From),
+	}
 }

--- a/internal/ast/compiler/retype_field.go
+++ b/internal/ast/compiler/retype_field.go
@@ -9,12 +9,15 @@ import (
 var _ Pass = (*RetypeField)(nil)
 
 type RetypeField struct {
-	Field    FieldReference
-	As       ast.Type
-	Comments []string
+	Field      FieldReference
+	As         ast.Type
+	Comments   []string
+	fieldFound bool
 }
 
 func (pass *RetypeField) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.fieldFound = false
+
 	visitor := &Visitor{
 		OnObject: pass.processObject,
 	}
@@ -39,8 +42,20 @@ func (pass *RetypeField) processObject(_ *Visitor, _ *ast.Schema, object ast.Obj
 			object.Type.Struct.Fields[i].Comments = pass.Comments
 		}
 
+		pass.fieldFound = true
+
 		break
 	}
 
 	return object, nil
+}
+
+func (pass *RetypeField) Diagnostics() []string {
+	if pass.fieldFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("field '%s' not found", pass.Field),
+	}
 }

--- a/internal/ast/compiler/schema_set_entrypoint.go
+++ b/internal/ast/compiler/schema_set_entrypoint.go
@@ -9,11 +9,14 @@ import (
 var _ Pass = (*SchemaSetEntrypoint)(nil)
 
 type SchemaSetEntrypoint struct {
-	Package    string // we don't have a "clear" identifier, so we use the package to identify a schema.
-	EntryPoint string
+	Package     string // we don't have a "clear" identifier, so we use the package to identify a schema.
+	EntryPoint  string
+	schemaFound bool
 }
 
 func (pass *SchemaSetEntrypoint) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.schemaFound = false
+
 	for _, schema := range schemas {
 		if schema.Package != pass.Package {
 			continue
@@ -25,7 +28,19 @@ func (pass *SchemaSetEntrypoint) Process(schemas []*ast.Schema) ([]*ast.Schema, 
 
 		schema.EntryPoint = pass.EntryPoint
 		schema.EntryPointType = ast.NewRef(schema.Package, pass.EntryPoint)
+
+		pass.schemaFound = true
 	}
 
 	return schemas, nil
+}
+
+func (pass *SchemaSetEntrypoint) Diagnostics() []string {
+	if pass.schemaFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("schema '%s' not found", pass.Package),
+	}
 }

--- a/internal/ast/compiler/schema_set_identifier.go
+++ b/internal/ast/compiler/schema_set_identifier.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"fmt"
+
 	"github.com/grafana/cog/internal/ast"
 )
 
@@ -8,18 +10,32 @@ var _ Pass = (*SchemaSetIdentifier)(nil)
 
 // SchemaSetIdentifier overwrites the Metadata.Identifier field of a schema.
 type SchemaSetIdentifier struct {
-	Package    string // we don't have a "clear" identifier, so we use the package to identify a schema.
-	Identifier string
+	Package     string // we don't have a "clear" identifier, so we use the package to identify a schema.
+	Identifier  string
+	schemaFound bool
 }
 
 func (pass *SchemaSetIdentifier) Process(schemas []*ast.Schema) ([]*ast.Schema, error) {
+	pass.schemaFound = false
+
 	for _, schema := range schemas {
 		if schema.Package != pass.Package {
 			continue
 		}
 
 		schema.Metadata.Identifier = pass.Identifier
+		pass.schemaFound = true
 	}
 
 	return schemas, nil
+}
+
+func (pass *SchemaSetIdentifier) Diagnostics() []string {
+	if pass.schemaFound {
+		return nil
+	}
+
+	return []string{
+		fmt.Sprintf("schema '%s' not found", pass.Package),
+	}
 }

--- a/internal/ast/compiler/types.go
+++ b/internal/ast/compiler/types.go
@@ -67,6 +67,10 @@ func (ref FieldReference) Matches(object ast.Object, field ast.StructField) bool
 		strings.EqualFold(field.Name, ref.Field)
 }
 
+func (ref FieldReference) String() string {
+	return fmt.Sprintf("%s.%s.%s", ref.Package, ref.Object, ref.Field)
+}
+
 func FieldReferenceFromString(ref string) (FieldReference, error) {
 	parts := strings.Split(ref, ".")
 	if len(parts) != 3 {

--- a/internal/codegen/input.go
+++ b/internal/codegen/input.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/ast/compiler"
@@ -115,7 +116,7 @@ func (input *Input) loader() (schemaLoader, error) {
 	return nil, fmt.Errorf("empty input")
 }
 
-func (input *Input) LoadSchemas(ctx context.Context) (ast.Schemas, error) {
+func (input *Input) LoadSchemas(ctx context.Context, logger *slog.Logger) (ast.Schemas, error) {
 	var err error
 
 	loader, err := input.loader()
@@ -134,7 +135,10 @@ func (input *Input) LoadSchemas(ctx context.Context) (ast.Schemas, error) {
 			return nil, err
 		}
 
-		return passes.Process(schemas)
+		schemas, err = passes.Process(logger, schemas)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return schemas, nil

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -274,7 +274,7 @@ func (pipeline *Pipeline) LoadSchemas(ctx context.Context) (ast.Schemas, error) 
 
 	// Parse inputs
 	for _, input := range pipeline.Inputs {
-		schemas, err := input.LoadSchemas(ctx)
+		schemas, err := input.LoadSchemas(ctx, pipeline.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +297,12 @@ func (pipeline *Pipeline) LoadSchemas(ctx context.Context) (ast.Schemas, error) 
 		return nil, err
 	}
 
-	return commonPasses.Process(allSchemas)
+	allSchemas, err = commonPasses.Process(pipeline.logger, allSchemas)
+	if err != nil {
+		return nil, err
+	}
+
+	return allSchemas, err
 }
 
 func (pipeline *Pipeline) OutputLanguages() (languages.Languages, error) {

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -74,7 +74,7 @@ func (pipeline *Pipeline) ContextForLanguage(language languages.Language, schema
 
 	// apply  language-specific compiler passes
 	compilerPasses := language.CompilerPasses().Concat(pipeline.finalPasses())
-	jenniesInput.Schemas, err = compilerPasses.Process(jenniesInput.Schemas)
+	jenniesInput.Schemas, err = compilerPasses.Process(pipeline.logger, jenniesInput.Schemas)
 	if err != nil {
 		return languages.Context{}, err
 	}

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ast"
@@ -72,9 +73,11 @@ func (pipeline *Pipeline) ContextForLanguage(language languages.Language, schema
 		Schemas: schemas,
 	}
 
+	logger := pipeline.logger.With(slog.String("language", language.Name()))
+
 	// apply  language-specific compiler passes
 	compilerPasses := language.CompilerPasses().Concat(pipeline.finalPasses())
-	jenniesInput.Schemas, err = compilerPasses.Process(pipeline.logger, jenniesInput.Schemas)
+	jenniesInput.Schemas, err = compilerPasses.Process(logger, jenniesInput.Schemas)
 	if err != nil {
 		return languages.Context{}, err
 	}

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Go.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -109,7 +110,7 @@ func TestRawTypes_Generate_WithUndiscriminatedDisjunctions(t *testing.T) {
 		req := require.New(tc)
 
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -143,7 +144,7 @@ func TestRawTypes_Generate_AllowMarshalEmptyDisjunctions(t *testing.T) {
 			ast.NewObject("tests", "DisjunctionOfScalars", ast.NewDisjunction(ast.Types{ast.String(), ast.Bool()})),
 		),
 	}
-	schemas, err := compilerPasses.Process([]*ast.Schema{schema})
+	schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{
@@ -186,7 +187,7 @@ func (resource {{ .Object.Name }}) CustomMethod() string {
 		}
 		compilerPasses := New(config).CompilerPasses()
 
-		schemas, err := compilerPasses.Process(ast.Schemas{schema})
+		schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/java/deserializers_test.go
+++ b/internal/jennies/java/deserializers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestDeserializers_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/java/equality_test.go
+++ b/internal/jennies/java/equality_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestEquality_Java_GeneratesEqualsMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run Java compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(ast.Schemas{schema})
+	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ast.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -75,7 +76,7 @@ public String customMethod() {
 		jenny := RawTypes{config: config, tmpl: initTemplates(config, common.NewAPIReferenceCollector())}
 		compilerPasses := New(config).CompilerPasses()
 
-		schemas, err := compilerPasses.Process(ast.Schemas{schema})
+		schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/java/serializers_test.go
+++ b/internal/jennies/java/serializers_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestSerializers_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestSchema_Generate(t *testing.T) {
 		// We run the compiler passes defined fo JSONSchema since without them, we
 		// might not be able to translate some of the IR's semantics.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +26,7 @@ func TestSchema_Generate(t *testing.T) {
 		// We run the compiler passes defined fo OpenAPI since without them, we
 		// might not be able to translate some of the IR's semantics.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/php/equality_test.go
+++ b/internal/jennies/php/equality_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,7 @@ func TestEquality_PHP_GeneratesEqualsMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run PHP compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(ast.Schemas{schema})
+	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ast.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/php/rawtypes_test.go
+++ b/internal/jennies/php/rawtypes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Go.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -87,7 +88,7 @@ public function customMethod(): string
 		}
 		compilerPasses := New(config).CompilerPasses()
 
-		schemas, err := compilerPasses.Process(ast.Schemas{schema})
+		schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/python/equality_test.go
+++ b/internal/jennies/python/equality_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +45,7 @@ func TestEquality_Python_GeneratesEqMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run Python compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(ast.Schemas{schema})
+	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ast.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Python.
 		// Example: anonymous objects.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -83,7 +84,7 @@ def custom_method(self) -> str:
 		}
 		compilerPasses := New(config).CompilerPasses()
 
-		schemas, err := compilerPasses.Process(ast.Schemas{schema})
+		schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/terraform/rawtypes_test.go
+++ b/internal/jennies/terraform/rawtypes_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/cog/internal/ast"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into TS.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(ast.Schemas{&schema})
+		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -78,7 +79,7 @@ export const customMethodFor{{ .Object.Name }} = "{{ label .Object.Name }}";
 		}
 		compilerPasses := New(config).CompilerPasses()
 
-		schemas, err := compilerPasses.Process(ast.Schemas{schema})
+		schemas, err := compilerPasses.Process(logs.NoopLogger(), ast.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/tools/arrays.go
+++ b/internal/tools/arrays.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"cmp"
 	"slices"
 	"strings"
 )
@@ -49,4 +50,21 @@ func Filter[T any](input []T, predicate func(T) bool) []T {
 	}
 
 	return output
+}
+
+func SliceFindMissing[T cmp.Ordered](got []T, expected []T) []T {
+	mapLeft := make(map[T]struct{}, len(got))
+	var diffs []T
+
+	for _, value := range got {
+		mapLeft[value] = struct{}{}
+	}
+
+	for _, value := range expected {
+		if _, ok := mapLeft[value]; !ok {
+			diffs = append(diffs, value)
+		}
+	}
+
+	return diffs
 }


### PR DESCRIPTION
Like we did for [builder transforms](https://github.com/grafana/cog/pull/1007), this PR changes schema transforms to support emitting diagnoses/warnings from them.

The goal is to make it easier to surface configuration errors.