### PR TITLE
Use `@warnings.warn()` decorator in python

### DIFF
--- a/internal/jennies/python/rawtypes.go
+++ b/internal/jennies/python/rawtypes.go
@@ -237,7 +237,7 @@ func (jenny RawTypes) generateInitMethod(schemas ast.Schemas, object ast.Object)
 		assignments = append(assignments, fmt.Sprintf("        self.%[1]s = %[1]s", fieldName))
 	}
 
-	buffer.WriteString(fmt.Sprintf("    def __init__(self, %s) -> None:\n", strings.Join(args, ", ")))
+	fmt.Fprintf(&buffer, "    def __init__(self, %s) -> None:\n", strings.Join(args, ", "))
 	buffer.WriteString(strings.Join(assignments, "\n"))
 
 	return strings.TrimSuffix(buffer.String(), "\n")
@@ -262,7 +262,7 @@ func (jenny RawTypes) generateToJSONMethod(object ast.Object) string {
 			continue
 		}
 
-		buffer.WriteString(fmt.Sprintf(`            "%s": self.%s,`+"\n", field.Name, formatIdentifier(field.Name)))
+		fmt.Fprintf(&buffer, `            "%s": self.%s,`+"\n", field.Name, formatIdentifier(field.Name))
 	}
 
 	buffer.WriteString("        }\n")
@@ -274,8 +274,8 @@ func (jenny RawTypes) generateToJSONMethod(object ast.Object) string {
 
 		fieldName := formatIdentifier(field.Name)
 
-		buffer.WriteString(fmt.Sprintf("        if self.%s is not None:\n", fieldName))
-		buffer.WriteString(fmt.Sprintf(`            payload["%s"] = self.%s`+"\n", field.Name, fieldName))
+		fmt.Fprintf(&buffer, "        if self.%s is not None:\n", fieldName)
+		fmt.Fprintf(&buffer, `            payload["%s"] = self.%s`+"\n", field.Name, fieldName)
 	}
 
 	buffer.WriteString("        return payload")
@@ -311,9 +311,8 @@ func (jenny RawTypes) generateFromJSONMethod(context languages.Context, object a
 	typingPkg := jenny.importPkg("typing", "typing")
 
 	buffer.WriteString("    @classmethod\n")
-	buffer.WriteString(fmt.Sprintf("    def from_json(cls, data: dict[str, %[1]s.Any]) -> %[1]s.Self:\n", typingPkg))
-
-	buffer.WriteString(fmt.Sprintf("        args: dict[str, %s.Any] = {}\n", typingPkg))
+	fmt.Fprintf(&buffer, "    def from_json(cls, data: dict[str, %[1]s.Any]) -> %[1]s.Self:\n", typingPkg)
+	fmt.Fprintf(&buffer, "        args: dict[str, %s.Any] = {}\n", typingPkg)
 	var assignments []string
 	for _, field := range object.Type.AsStruct().Fields {
 		value := fmt.Sprintf(`data["%s"]`, field.Name)

--- a/internal/jennies/python/templates/builders/builder.tmpl
+++ b/internal/jennies/python/templates/builders/builder.tmpl
@@ -1,6 +1,6 @@
 {{- if .Builder.DeprecationMessage -}}
 {{- $warnings := importModule "warnings" "warnings" "" -}}
-@warnings.deprecated({{ .Builder.DeprecationMessage|formatConcrete }})
+@warnings.warn({{ .Builder.DeprecationMessage|formatConcrete }}, warnings.DeprecationWarning)
 {{ end -}}
 class {{ .Builder.Name|formatObjectName }}(cogbuilder.Builder[{{ .ObjectName }}]):
     {{- include "comments" (dict "Comments" .Builder.For.Comments) | indent 4 }}

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -174,7 +174,7 @@ func (formatter *typeFormatter) formatStruct(def ast.Object) string {
 
 	if def.DeprecationMessage != "" {
 		formatter.importPkg("warnings", "warnings")
-		fmt.Fprintf(&buffer, "@warnings.deprecated(%s)\n", formatValue(def.DeprecationMessage))
+		fmt.Fprintf(&buffer, "@warnings.warn(%s, warnings.DeprecationWarning)\n", formatValue(def.DeprecationMessage))
 	}
 	fmt.Fprintf(&buffer, "class %s%s:\n", formatObjectName(def.Name), classBases)
 	buffer.WriteString(formatter.formatClassComments(def.Comments))

--- a/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
+++ b/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
@@ -2,7 +2,7 @@ import warnings
 import typing
 
 
-@warnings.deprecated("This object is deprecated, use NewStruct instead.")
+@warnings.warn("This object is deprecated, use NewStruct instead.", warnings.DeprecationWarning)
 class SomeStruct:
     field_string: str
 


### PR DESCRIPTION
Instead of `@warnings.deprecated()` that was added in version 3.13.