### PR TITLE
Fix DeprecationWarning usage in Python

### DIFF
--- a/internal/jennies/python/templates/builders/builder.tmpl
+++ b/internal/jennies/python/templates/builders/builder.tmpl
@@ -1,6 +1,6 @@
 {{- if .Builder.DeprecationMessage -}}
 {{- $warnings := importModule "warnings" "warnings" "" -}}
-@warnings.warn({{ .Builder.DeprecationMessage|formatConcrete }}, warnings.DeprecationWarning)
+@warnings.warn({{ .Builder.DeprecationMessage|formatConcrete }}, DeprecationWarning)
 {{ end -}}
 class {{ .Builder.Name|formatObjectName }}(cogbuilder.Builder[{{ .ObjectName }}]):
     {{- include "comments" (dict "Comments" .Builder.For.Comments) | indent 4 }}

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -174,7 +174,7 @@ func (formatter *typeFormatter) formatStruct(def ast.Object) string {
 
 	if def.DeprecationMessage != "" {
 		formatter.importPkg("warnings", "warnings")
-		fmt.Fprintf(&buffer, "@warnings.warn(%s, warnings.DeprecationWarning)\n", formatValue(def.DeprecationMessage))
+		fmt.Fprintf(&buffer, "@warnings.warn(%s, DeprecationWarning)\n", formatValue(def.DeprecationMessage))
 	}
 	fmt.Fprintf(&buffer, "class %s%s:\n", formatObjectName(def.Name), classBases)
 	buffer.WriteString(formatter.formatClassComments(def.Comments))

--- a/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
+++ b/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
@@ -2,7 +2,7 @@ import warnings
 import typing
 
 
-@warnings.warn("This object is deprecated, use NewStruct instead.", warnings.DeprecationWarning)
+@warnings.warn("This object is deprecated, use NewStruct instead.", DeprecationWarning)
 class SomeStruct:
     field_string: str
 


### PR DESCRIPTION
:facepalm: 

Turns out the `DeprecationWarning` exception isn't in the `warnings` package, it's actually a built-in.