### PR TITLE
Python deprecated in body

### DIFF
--- a/internal/jennies/python/templates/builders/builder.tmpl
+++ b/internal/jennies/python/templates/builders/builder.tmpl
@@ -1,9 +1,9 @@
-{{- if .Builder.DeprecationMessage -}}
-{{- $warnings := importModule "warnings" "warnings" "" -}}
-@warnings.warn({{ .Builder.DeprecationMessage|formatConcrete }}, DeprecationWarning)
-{{ end -}}
 class {{ .Builder.Name|formatObjectName }}(cogbuilder.Builder[{{ .ObjectName }}]):
     {{- include "comments" (dict "Comments" .Builder.For.Comments) | indent 4 }}
+{{- if .Builder.DeprecationMessage }}
+    {{- $warnings := importModule "warnings" "warnings" "" }}
+    warnings.warn({{ .Builder.DeprecationMessage|formatConcrete }}, DeprecationWarning)
+{{ end }}
     _internal: {{ .ObjectName }}
     {{- range .Builder.Properties }}
     __{{ .Name|formatIdentifier }}: {{ .Type | formatType }} = {{ defaultForType .Type }}

--- a/internal/jennies/python/types.go
+++ b/internal/jennies/python/types.go
@@ -172,12 +172,13 @@ func (formatter *typeFormatter) formatStruct(def ast.Object) string {
 		classBases = fmt.Sprintf("(%s.%s)", cogVariants, variant)
 	}
 
-	if def.DeprecationMessage != "" {
-		formatter.importPkg("warnings", "warnings")
-		fmt.Fprintf(&buffer, "@warnings.warn(%s, DeprecationWarning)\n", formatValue(def.DeprecationMessage))
-	}
 	fmt.Fprintf(&buffer, "class %s%s:\n", formatObjectName(def.Name), classBases)
 	buffer.WriteString(formatter.formatClassComments(def.Comments))
+
+	if def.DeprecationMessage != "" {
+		formatter.importPkg("warnings", "warnings")
+		fmt.Fprintf(&buffer, "    warnings.warn(%s, DeprecationWarning)\n", formatValue(def.DeprecationMessage))
+	}
 
 	fields := def.Type.AsStruct().Fields
 

--- a/testdata/jennies/builders/deprecated_builder/GoBuilder/sandbox/somestruct_builder_gen.go
+++ b/testdata/jennies/builders/deprecated_builder/GoBuilder/sandbox/somestruct_builder_gen.go
@@ -1,0 +1,48 @@
+package sandbox
+
+import (
+	cog "github.com/grafana/cog/generated/cog"
+)
+
+var _ cog.Builder[SomeStruct] = (*SomeStructBuilder)(nil)
+
+// Deprecated: This builder is deprecated. Don't use. Please.
+type SomeStructBuilder struct {
+    internal *SomeStruct
+    errors cog.BuildErrors
+}
+// Deprecated: "This builder is deprecated. Don't use. Please."
+func NewSomeStructBuilder() *SomeStructBuilder {
+	resource := NewSomeStruct()
+	builder := &SomeStructBuilder{
+		internal: resource,
+		errors: make(cog.BuildErrors, 0),
+	}
+
+	return builder
+}
+
+
+func (builder *SomeStructBuilder) Build() (SomeStruct, error) {
+	if err := builder.internal.Validate(); err != nil {
+		return SomeStruct{}, err
+	}
+	
+	if len(builder.errors) > 0 {
+	    return SomeStruct{}, cog.MakeBuildErrors("sandbox.someStruct", builder.errors)
+	}
+
+	return *builder.internal, nil
+}
+
+func (builder *SomeStructBuilder) RecordError(path string, err error) *SomeStructBuilder {
+	builder.errors = append(builder.errors, cog.MakeBuildErrors(path, err)...)
+	return builder
+}
+
+func (builder *SomeStructBuilder) Title(title string) *SomeStructBuilder {
+    builder.internal.Title = title
+
+    return builder
+}
+

--- a/testdata/jennies/builders/deprecated_builder/GoConverter/sandbox/somestruct_converter_gen.go
+++ b/testdata/jennies/builders/deprecated_builder/GoConverter/sandbox/somestruct_converter_gen.go
@@ -1,0 +1,30 @@
+package sandbox
+
+
+
+import (
+	"strings"
+	"fmt"
+)
+
+// SomeStructConverter accepts a `SomeStruct` object and generates the Go code to build this object using builders.
+func SomeStructConverter(input SomeStruct) string {
+    calls := []string{
+    `sandbox.NewSomeStructBuilder()`,
+    }
+    var buffer strings.Builder
+        if input.Title != "" {
+        
+    buffer.WriteString(`Title(`)
+        arg0 :=fmt.Sprintf("%#v", input.Title)
+        buffer.WriteString(arg0)
+        
+    buffer.WriteString(")")
+
+    calls = append(calls, buffer.String())
+    buffer.Reset()
+    
+    }
+
+    return strings.Join(calls, ".\t\n")
+}

--- a/testdata/jennies/builders/deprecated_builder/JavaBuilder/sandbox/SomeStructBuilder.java
+++ b/testdata/jennies/builders/deprecated_builder/JavaBuilder/sandbox/SomeStructBuilder.java
@@ -1,0 +1,21 @@
+package sandbox;
+
+
+/**
+ * @deprecated This builder is deprecated. Don't use. Please.
+ */
+@Deprecated(forRemoval = true)
+public class SomeStructBuilder implements cog.Builder<SomeStruct> {
+    protected final SomeStruct internal;
+    
+    public SomeStructBuilder() {
+        this.internal = new SomeStruct();
+    }
+    public SomeStructBuilder title(String title) {
+        this.internal.title = title;
+        return this;
+    }
+    public SomeStruct build() {
+        return this.internal;
+    }
+}

--- a/testdata/jennies/builders/deprecated_builder/PHPBuilder/src/Sandbox/SomeStructBuilder.php
+++ b/testdata/jennies/builders/deprecated_builder/PHPBuilder/src/Sandbox/SomeStructBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+/**
+ * @implements \Grafana\Foundation\Cog\Builder<\Grafana\Foundation\Sandbox\SomeStruct>
+ * @deprecated This builder is deprecated. Don't use. Please.
+ */
+class SomeStructBuilder implements \Grafana\Foundation\Cog\Builder
+{
+    protected \Grafana\Foundation\Sandbox\SomeStruct $internal;
+
+    public function __construct()
+    {
+    	$this->internal = new \Grafana\Foundation\Sandbox\SomeStruct();
+    }
+
+    /**
+     * Builds the object.
+     * @return \Grafana\Foundation\Sandbox\SomeStruct
+     */
+    public function build()
+    {
+        return $this->internal;
+    }
+
+    public function title(string $title): static
+    {
+        $this->internal->title = $title;
+    
+        return $this;
+    }
+
+}

--- a/testdata/jennies/builders/deprecated_builder/PHPConverter/src/Sandbox/SomeStructConverter.php
+++ b/testdata/jennies/builders/deprecated_builder/PHPConverter/src/Sandbox/SomeStructConverter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Grafana\Foundation\Sandbox;
+
+final class SomeStructConverter
+{
+    public static function convert(\Grafana\Foundation\Sandbox\SomeStruct $input): string
+    {
+        
+        $calls = [
+            '(new \Grafana\Foundation\Sandbox\SomeStructBuilder())',
+        ];
+            if ($input->title !== "") {
+    
+        
+    $buffer = 'title(';
+        $arg0 =\var_export($input->title, true);
+        $buffer .= $arg0;
+        
+    $buffer .= ')';
+
+    $calls[] = $buffer;
+    
+    
+    }
+
+        return \implode("\n\t->", $calls);
+    }
+}
+

--- a/testdata/jennies/builders/deprecated_builder/PythonBuilder/builders/sandbox.py
+++ b/testdata/jennies/builders/deprecated_builder/PythonBuilder/builders/sandbox.py
@@ -1,0 +1,25 @@
+import typing
+from ..cog import builder as cogbuilder
+from ..models import sandbox
+import warnings
+
+
+class SomeStruct(cogbuilder.Builder[sandbox.SomeStruct]):
+    warnings.warn("This builder is deprecated. Don't use. Please.", DeprecationWarning)
+
+    _internal: sandbox.SomeStruct
+
+    def __init__(self) -> None:
+        self._internal = sandbox.SomeStruct()
+
+    def build(self) -> sandbox.SomeStruct:
+        """
+        Builds the object.
+        """
+        return self._internal    
+    
+    def title(self, title: str) -> typing.Self:    
+        self._internal.title = title
+    
+        return self
+    

--- a/testdata/jennies/builders/deprecated_builder/TypescriptBuilder/src/sandbox/someStructBuilder.gen.ts
+++ b/testdata/jennies/builders/deprecated_builder/TypescriptBuilder/src/sandbox/someStructBuilder.gen.ts
@@ -1,0 +1,26 @@
+import * as cog from '../cog';
+import * as sandbox from '../sandbox';
+
+/**
+ * @deprecated This builder is deprecated. Don't use. Please.
+ */
+export class SomeStructBuilder implements cog.Builder<sandbox.SomeStruct> {
+    protected readonly internal: sandbox.SomeStruct;
+
+    constructor() {
+        this.internal = sandbox.defaultSomeStruct();
+    }
+
+    /**
+     * Builds the object.
+     */
+    build(): sandbox.SomeStruct {
+        return this.internal;
+    }
+
+    title(title: string): this {
+        this.internal.title = title;
+        return this;
+    }
+}
+

--- a/testdata/jennies/builders/deprecated_builder/builders_context.json
+++ b/testdata/jennies/builders/deprecated_builder/builders_context.json
@@ -1,0 +1,115 @@
+{
+  "Schemas": [
+    {
+      "Package": "sandbox",
+      "Metadata": {},
+      "Objects": {
+        "SomeStruct": {
+          "Name": "SomeStruct",
+          "Type": {
+            "Kind": "struct",
+            "Nullable": false,
+            "Struct": {
+              "Fields": [
+                {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  },
+                  "Required": true
+                }
+              ]
+            }
+          },
+          "SelfRef": {
+            "ReferredPkg": "sandbox",
+            "ReferredType": "SomeStruct"
+          }
+        }
+      }
+    }
+  ],
+  "Builders": [
+    {
+      "For": {
+        "Name": "SomeStruct",
+        "Type": {
+          "Kind": "struct",
+          "Nullable": false,
+          "Struct": {
+            "Fields": [
+              {
+                "Name": "title",
+                "Type": {
+                  "Kind": "scalar",
+                  "Nullable": false,
+                  "Scalar": {
+                    "ScalarKind": "string"
+                  }
+                },
+                "Required": true
+              }
+            ]
+          }
+        },
+        "SelfRef": {
+          "ReferredPkg": "sandbox",
+          "ReferredType": "SomeStruct"
+        }
+      },
+      "Package": "sandbox",
+      "Name": "SomeStruct",
+      "DeprecationMessage": "This builder is deprecated. Don't use. Please.",
+      "Options": [
+        {
+          "Name": "title",
+          "Args": [
+            {
+              "Name": "title",
+              "Type": {
+                "Kind": "scalar",
+                "Nullable": false,
+                "Scalar": {
+                  "ScalarKind": "string"
+                }
+              }
+            }
+          ],
+          "Assignments": [
+            {
+              "Path": [
+                {
+                  "Identifier": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              ],
+              "Value": {
+                "Argument": {
+                  "Name": "title",
+                  "Type": {
+                    "Kind": "scalar",
+                    "Nullable": false,
+                    "Scalar": {
+                      "ScalarKind": "string"
+                    }
+                  }
+                }
+              },
+              "Method": "direct"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
+++ b/testdata/jennies/rawtypes/deprecate_object/PythonRawTypes/models/basic.py
@@ -2,8 +2,8 @@ import warnings
 import typing
 
 
-@warnings.warn("This object is deprecated, use NewStruct instead.", DeprecationWarning)
 class SomeStruct:
+    warnings.warn("This object is deprecated, use NewStruct instead.", DeprecationWarning)
     field_string: str
 
     def __init__(self, field_string: str = "") -> None:


### PR DESCRIPTION
Correctly use the `warnings.warn()` function in Python and add tests for deprecated builders.