### PR TITLE
Support disabling the "Code generated - EDITING IS FUTILE" header in TF jenny

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -290,7 +290,14 @@ type TerraformValidators struct {
 }
 
 type TerraformConfig struct {
+	// SkipPostFormatting disables formatting of Go files done with go imports
+	// after code generation.
 	SkipPostFormatting bool
+
+	// SkipGeneratedHeader disables the addition of a
+	// "Code generated - EDITING IS FUTILE. DO NOT EDIT." comment in generated
+	// files headers.
+	SkipGeneratedHeader bool
 
 	// CustomTemplatesDirectories accepts a list of directories containing custom templates.
 	CustomTemplatesDirectories []string
@@ -306,6 +313,7 @@ func (pipeline *SchemaToTypesPipeline) Terraform(config TerraformConfig) *Schema
 	pipeline.output = &codegen.OutputLanguage{
 		Terraform: &terraform.Config{
 			SkipPostFormatting:            config.SkipPostFormatting,
+			SkipGeneratedHeader:           config.SkipGeneratedHeader,
 			OverridesTemplatesDirectories: config.CustomTemplatesDirectories,
 			OverridesTemplatesFS:          config.CustomTemplatesFS,
 			OverridesTemplateFuncs:        config.CustomTemplatesFuncs,

--- a/internal/jennies/terraform/jennies.go
+++ b/internal/jennies/terraform/jennies.go
@@ -43,6 +43,11 @@ type Config struct {
 	// after code generation.
 	SkipPostFormatting bool `yaml:"skip_post_formatting"`
 
+	// SkipGeneratedHeader disables the addition of a
+	// "Code generated - EDITING IS FUTILE. DO NOT EDIT." comment in generated
+	// files headers.
+	SkipGeneratedHeader bool `yaml:"skip_generated_header"`
+
 	Validators ValidatorsConfig `yaml:"-"`
 }
 
@@ -82,7 +87,9 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	jenny.AppendOneToMany(
 		common.If(globalConfig.Types, RawTypes{config: config, tmpl: tmpl}))
 
-	jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+	if !config.SkipGeneratedHeader {
+		jenny.AddPostprocessors(common.GeneratedCommentHeader(globalConfig))
+	}
 	if !config.SkipPostFormatting {
 		jenny.AddPostprocessors(golang.FormatGoFiles)
 	}


### PR DESCRIPTION
The goal of https://github.com/grafana/terraform-provider-grafana/pull/2569 is to provide a skeleton/generate most of the boilerplate required to support new resources in terraform. The generated code is very much expected to be reviewed and adjusted, so we need to make sure that no comment indicating the opposite is added to each file :sweat_smile: 