### PR TITLE
Apply language-specific schema transforms directly in the jennies

### DIFF
--- a/cmd/cli/inspect/command.go
+++ b/cmd/cli/inspect/command.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/codegen"
 	"github.com/grafana/cog/internal/ir"
-	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/tools"
@@ -271,6 +270,6 @@ func (language dummyLanguage) Jennies(_ languages.Config) *codejen.JennyList[lan
 	return nil
 }
 
-func (language dummyLanguage) CompilerPasses() transforms.Transforms {
-	return nil
+func (language dummyLanguage) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	return schemas, nil
 }

--- a/internal/codegen/pipeline.go
+++ b/internal/codegen/pipeline.go
@@ -311,21 +311,21 @@ func (pipeline *Pipeline) OutputLanguages() (languages.Languages, error) {
 	for _, output := range pipeline.Output.Languages {
 		switch {
 		case output.Go != nil:
-			outputs[golang.LanguageRef] = golang.New(*output.Go)
+			outputs[golang.LanguageRef] = golang.New(pipeline.logger.With(slog.String("language", "golang")), *output.Go)
 		case output.Java != nil:
-			outputs[java.LanguageRef] = java.New(*output.Java)
+			outputs[java.LanguageRef] = java.New(pipeline.logger.With(slog.String("language", "java")), *output.Java)
 		case output.JSONSchema != nil:
-			outputs[jsonschema.LanguageRef] = jsonschema.New(*output.JSONSchema)
+			outputs[jsonschema.LanguageRef] = jsonschema.New(pipeline.logger.With(slog.String("language", "jsonschema")), *output.JSONSchema)
 		case output.OpenAPI != nil:
-			outputs[openapi.LanguageRef] = openapi.New(*output.OpenAPI)
+			outputs[openapi.LanguageRef] = openapi.New(pipeline.logger.With(slog.String("language", "openapi")), *output.OpenAPI)
 		case output.PHP != nil:
-			outputs[php.LanguageRef] = php.New(*output.PHP)
+			outputs[php.LanguageRef] = php.New(pipeline.logger.With(slog.String("language", "php")), *output.PHP)
 		case output.Python != nil:
-			outputs[python.LanguageRef] = python.New(*output.Python)
+			outputs[python.LanguageRef] = python.New(pipeline.logger.With(slog.String("language", "python")), *output.Python)
 		case output.Typescript != nil:
-			outputs[typescript.LanguageRef] = typescript.New(*output.Typescript)
+			outputs[typescript.LanguageRef] = typescript.New(pipeline.logger.With(slog.String("language", "typescript")), *output.Typescript)
 		case output.Terraform != nil:
-			outputs[terraform.LanguageRef] = terraform.New(*output.Terraform)
+			outputs[terraform.LanguageRef] = terraform.New(pipeline.logger.With(slog.String("language", "terraform")), *output.Terraform)
 		default:
 			return nil, fmt.Errorf("empty language configuration")
 		}

--- a/internal/codegen/run.go
+++ b/internal/codegen/run.go
@@ -75,9 +75,14 @@ func (pipeline *Pipeline) ContextForLanguage(language languages.Language, schema
 
 	logger := pipeline.logger.With(slog.String("language", language.Name()))
 
-	// apply  language-specific compiler passes
-	compilerPasses := language.CompilerPasses().Concat(pipeline.finalPasses())
-	jenniesInput.Schemas, err = compilerPasses.Process(logger, jenniesInput.Schemas)
+	// apply language-specific schema transformations
+	jenniesInput.Schemas, err = language.Transform(jenniesInput.Schemas)
+	if err != nil {
+		return languages.Context{}, err
+	}
+
+	// apply global schema transformations
+	jenniesInput.Schemas, err = pipeline.finalPasses().Process(logger, jenniesInput.Schemas)
 	if err != nil {
 		return languages.Context{}, err
 	}

--- a/internal/jennies/golang/builder_test.go
+++ b/internal/jennies/golang/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/cog/internal/ir"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/orderedmap"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestBuilder_Generate(t *testing.T) {
 	config := Config{
 		PackageRoot: "github.com/grafana/cog/generated",
 	}
-	language := New(config)
+	language := New(logs.NoopLogger(), config)
 	jenny := Builder{
 		Config:          config,
 		Tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),

--- a/internal/jennies/golang/converter_test.go
+++ b/internal/jennies/golang/converter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestConverter_Generate(t *testing.T) {
 	config := Config{
 		PackageRoot: "github.com/grafana/cog/generated",
 	}
-	language := New(config)
+	language := New(logs.NoopLogger(), config)
 	jenny := Converter{
 		Config:          config,
 		NullableConfig:  language.NullableKinds(),

--- a/internal/jennies/golang/jennies.go
+++ b/internal/jennies/golang/jennies.go
@@ -3,11 +3,12 @@ package golang
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -93,12 +94,14 @@ func (config Config) importPath(suffix string) string {
 }
 
 type Language struct {
+	logger          *slog.Logger
 	config          Config
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger:          logger,
 		config:          config,
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
@@ -154,24 +157,26 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.AnonymousStructsToNamed{},
-		&compiler2.NotRequiredFieldAsNullableType{},
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.DisjunctionOfConstantsToEnum{},
-		&compiler2.AnonymousEnumToExplicitType{},
-		&compiler2.PrefixEnumValues{},
-		&compiler2.FlattenDisjunctions{},
-		&compiler2.DisjunctionOfAnonymousStructsToExplicit{},
-		&compiler2.DisjunctionInferMapping{},
-		&compiler2.UndiscriminatedDisjunctionToAny{
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.AnonymousStructsToNamed{},
+		&transforms.NotRequiredFieldAsNullableType{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.DisjunctionOfConstantsToEnum{},
+		&transforms.AnonymousEnumToExplicitType{},
+		&transforms.PrefixEnumValues{},
+		&transforms.FlattenDisjunctions{},
+		&transforms.DisjunctionOfAnonymousStructsToExplicit{},
+		&transforms.DisjunctionInferMapping{},
+		&transforms.UndiscriminatedDisjunctionToAny{
 			GenerateUndiscriminatedDisjunctions: language.config.GenerateUndiscriminatedDisjunctions,
 		},
-		&compiler2.DisjunctionToType{
+		&transforms.DisjunctionToType{
 			GenerateUndiscriminatedDisjunctions: language.config.GenerateUndiscriminatedDisjunctions,
 		},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/golang/rawtypes_test.go
+++ b/internal/jennies/golang/rawtypes_test.go
@@ -36,7 +36,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -45,7 +45,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Go.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -104,13 +104,13 @@ func TestRawTypes_Generate_WithUndiscriminatedDisjunctions(t *testing.T) {
 		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
 
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -136,7 +136,7 @@ func TestRawTypes_Generate_AllowMarshalEmptyDisjunctions(t *testing.T) {
 		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	schema := &ir.Schema{
 		Package: "tests",
@@ -144,7 +144,7 @@ func TestRawTypes_Generate_AllowMarshalEmptyDisjunctions(t *testing.T) {
 			ir.NewObject("tests", "DisjunctionOfScalars", ir.NewDisjunction(ir.Types{ir.String(), ir.Bool()})),
 		),
 	}
-	schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+	schemas, err := transforms(ir.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{
@@ -185,9 +185,9 @@ func (resource {{ .Object.Name }}) CustomMethod() string {
 			tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 			apiRefCollector: common.NewAPIReferenceCollector(),
 		}
-		compilerPasses := New(config).CompilerPasses()
+		transforms := New(logs.NoopLogger(), config).Transform
 
-		schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+		schemas, err := transforms(ir.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/java/builder_test.go
+++ b/internal/jennies/java/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestBuilder_Generate(t *testing.T) {
 		},
 	}
 
-	language := New(Config{
+	language := New(logs.NoopLogger(), Config{
 		GenerateBuilders: true,
 	})
 	jenny := Builder{

--- a/internal/jennies/java/deserializers_test.go
+++ b/internal/jennies/java/deserializers_test.go
@@ -23,7 +23,7 @@ func TestDeserializers_Generate(t *testing.T) {
 		config: cfg,
 		tmpl:   initTemplates(cfg, common.NewAPIReferenceCollector()),
 	}
-	compilerPasses := New(cfg).CompilerPasses()
+	transforms := New(logs.NoopLogger(), cfg).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -32,7 +32,7 @@ func TestDeserializers_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/java/equality_test.go
+++ b/internal/jennies/java/equality_test.go
@@ -44,7 +44,7 @@ func TestEquality_Java_GeneratesEqualsMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run Java compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ir.Schemas{schema})
+	processedSchemas, err := New(logs.NoopLogger(), config).Transform(ir.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/java/jennies.go
+++ b/internal/jennies/java/jennies.go
@@ -3,11 +3,12 @@ package java
 import (
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"strings"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -92,12 +93,14 @@ func (config *Config) MergeWithGlobal(global languages.Config) Config {
 }
 
 type Language struct {
+	logger          *slog.Logger
 	config          Config
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger:          logger,
 		config:          config,
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
@@ -148,20 +151,22 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.AnonymousStructsToNamed{},
-		&compiler2.NotRequiredFieldAsNullableType{},
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.DisjunctionOfConstantsToEnum{},
-		&compiler2.AnonymousEnumToExplicitType{},
-		&compiler2.FlattenDisjunctions{},
-		&compiler2.DisjunctionInferMapping{},
-		&compiler2.UndiscriminatedDisjunctionToAny{},
-		&compiler2.DisjunctionToType{},
-		&compiler2.RemoveIntersections{},
-		&compiler2.InlineObjectsWithTypes{InlineTypes: []ir.Kind{ir.KindScalar, ir.KindMap, ir.KindArray}},
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.AnonymousStructsToNamed{},
+		&transforms.NotRequiredFieldAsNullableType{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.DisjunctionOfConstantsToEnum{},
+		&transforms.AnonymousEnumToExplicitType{},
+		&transforms.FlattenDisjunctions{},
+		&transforms.DisjunctionInferMapping{},
+		&transforms.UndiscriminatedDisjunctionToAny{},
+		&transforms.DisjunctionToType{},
+		&transforms.RemoveIntersections{},
+		&transforms.InlineObjectsWithTypes{InlineTypes: []ir.Kind{ir.KindScalar, ir.KindMap, ir.KindArray}},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/java/rawtypes_test.go
+++ b/internal/jennies/java/rawtypes_test.go
@@ -27,7 +27,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	}
 
 	jenny := RawTypes{config: cfg, tmpl: initTemplates(cfg, common.NewAPIReferenceCollector())}
-	compilerPasses := New(cfg).CompilerPasses()
+	transforms := New(logs.NoopLogger(), cfg).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -36,7 +36,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -74,9 +74,9 @@ public String customMethod() {
 	}
 	runTest := func(config Config) {
 		jenny := RawTypes{config: config, tmpl: initTemplates(config, common.NewAPIReferenceCollector())}
-		compilerPasses := New(config).CompilerPasses()
+		transforms := New(logs.NoopLogger(), config).Transform
 
-		schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+		schemas, err := transforms(ir.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/java/serializers_test.go
+++ b/internal/jennies/java/serializers_test.go
@@ -23,7 +23,7 @@ func TestSerializers_Generate(t *testing.T) {
 		config: cfg,
 		tmpl:   initTemplates(cfg, common.NewAPIReferenceCollector()),
 	}
-	compilerPasses := New(cfg).CompilerPasses()
+	transforms := New(logs.NoopLogger(), cfg).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -32,7 +32,7 @@ func TestSerializers_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/jsonschema/jennies.go
+++ b/internal/jennies/jsonschema/jennies.go
@@ -2,10 +2,12 @@ package jsonschema
 
 import (
 	"bytes"
+	"log/slog"
 	"strings"
 
 	"github.com/grafana/codejen"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/languages"
 	schemaparser "github.com/santhosh-tekuri/jsonschema/v6"
 )
@@ -28,11 +30,13 @@ func (config Config) MergeWithGlobal(global languages.Config) Config {
 }
 
 type Language struct {
+	logger *slog.Logger
 	config Config
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger: logger,
 		config: config,
 	}
 }
@@ -56,11 +60,13 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.InferEntrypoint{},
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.InferEntrypoint{},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func ValidateSchemas(file codejen.File) (codejen.File, error) {

--- a/internal/jennies/jsonschema/schema_test.go
+++ b/internal/jennies/jsonschema/schema_test.go
@@ -18,7 +18,7 @@ func TestSchema_Generate(t *testing.T) {
 
 	config := Config{Debug: true}
 	jenny := Schema{Config: config}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -26,7 +26,7 @@ func TestSchema_Generate(t *testing.T) {
 		// We run the compiler passes defined fo JSONSchema since without them, we
 		// might not be able to translate some of the IR's semantics.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/openapi/jennies.go
+++ b/internal/jennies/openapi/jennies.go
@@ -1,8 +1,11 @@
 package openapi
 
 import (
+	"log/slog"
+
 	"github.com/grafana/codejen"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/languages"
 )
 
@@ -24,11 +27,13 @@ func (config Config) MergeWithGlobal(global languages.Config) Config {
 }
 
 type Language struct {
+	logger *slog.Logger
 	config Config
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger: logger,
 		config: config,
 	}
 }
@@ -48,10 +53,12 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
 		// should be a superset of the compiler passes defined for jsonschema jennies
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.InferEntrypoint{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.InferEntrypoint{},
 	}
+
+	return passes.Process(language.logger, schemas)
 }

--- a/internal/jennies/openapi/schema_test.go
+++ b/internal/jennies/openapi/schema_test.go
@@ -18,7 +18,7 @@ func TestSchema_Generate(t *testing.T) {
 
 	config := Config{debug: true}
 	jenny := Schema{Config: config}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -26,7 +26,7 @@ func TestSchema_Generate(t *testing.T) {
 		// We run the compiler passes defined fo OpenAPI since without them, we
 		// might not be able to translate some of the IR's semantics.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/php/builder_test.go
+++ b/internal/jennies/php/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,7 @@ func TestBuilder_Generate(t *testing.T) {
 	config := Config{
 		NamespaceRoot: "Grafana\\Foundation",
 	}
-	language := New(config)
+	language := New(logs.NoopLogger(), config)
 	jenny := Builder{
 		config:          config,
 		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),

--- a/internal/jennies/php/converter_test.go
+++ b/internal/jennies/php/converter_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -23,7 +24,7 @@ func TestConverter_Generate(t *testing.T) {
 	config := Config{
 		NamespaceRoot: "Grafana\\Foundation",
 	}
-	language := New(config)
+	language := New(logs.NoopLogger(), config)
 	jenny := Converter{
 		config:         config,
 		nullableConfig: language.NullableKinds(),

--- a/internal/jennies/php/equality_test.go
+++ b/internal/jennies/php/equality_test.go
@@ -45,7 +45,7 @@ func TestEquality_PHP_GeneratesEqualsMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run PHP compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ir.Schemas{schema})
+	processedSchemas, err := New(logs.NoopLogger(), config).Transform(ir.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/php/jennies.go
+++ b/internal/jennies/php/jennies.go
@@ -2,10 +2,11 @@ package php
 
 import (
 	"io/fs"
+	"log/slog"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/template"
 	"github.com/grafana/cog/internal/languages"
@@ -84,12 +85,14 @@ func (config Config) MergeWithGlobal(global languages.Config) Config {
 }
 
 type Language struct {
+	logger          *slog.Logger
 	config          Config
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger:          logger,
 		config:          config,
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
@@ -156,23 +159,25 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.AnonymousStructsToNamed{},
-		&compiler2.NotRequiredFieldAsNullableType{},
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.DisjunctionOfConstantsToEnum{},
-		&compiler2.AnonymousEnumToExplicitType{},
-		&compiler2.SanitizeEnumMemberNames{},
-		&compiler2.FlattenDisjunctions{},
-		&compiler2.DisjunctionInferMapping{},
-		&compiler2.UndiscriminatedDisjunctionToAny{},
-		&compiler2.RemoveIntersections{},
-		&compiler2.DisjunctionPropagateVariant{},
-		&compiler2.InlineObjectsWithTypes{
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.AnonymousStructsToNamed{},
+		&transforms.NotRequiredFieldAsNullableType{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.DisjunctionOfConstantsToEnum{},
+		&transforms.AnonymousEnumToExplicitType{},
+		&transforms.SanitizeEnumMemberNames{},
+		&transforms.FlattenDisjunctions{},
+		&transforms.DisjunctionInferMapping{},
+		&transforms.UndiscriminatedDisjunctionToAny{},
+		&transforms.RemoveIntersections{},
+		&transforms.DisjunctionPropagateVariant{},
+		&transforms.InlineObjectsWithTypes{
 			InlineTypes: []ir.Kind{ir.KindScalar, ir.KindArray, ir.KindMap, ir.KindDisjunction},
 		},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/php/rawtypes_test.go
+++ b/internal/jennies/php/rawtypes_test.go
@@ -34,7 +34,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -43,7 +43,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Go.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -86,9 +86,9 @@ public function customMethod(): string
 			tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 			apiRefCollector: common.NewAPIReferenceCollector(),
 		}
-		compilerPasses := New(config).CompilerPasses()
+		transforms := New(logs.NoopLogger(), config).Transform
 
-		schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+		schemas, err := transforms(ir.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/python/builder_test.go
+++ b/internal/jennies/python/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ func TestBuilder_Generate(t *testing.T) {
 		},
 	}
 
-	language := New(Config{})
+	language := New(logs.NoopLogger(), Config{})
 	jenny := Builder{
 		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),

--- a/internal/jennies/python/equality_test.go
+++ b/internal/jennies/python/equality_test.go
@@ -45,7 +45,7 @@ func TestEquality_Python_GeneratesEqMethods(t *testing.T) {
 	schema := equalitySchema()
 
 	// Run Python compiler passes so nullable types are handled correctly
-	processedSchemas, err := New(config).CompilerPasses().Process(logs.NoopLogger(), ir.Schemas{schema})
+	processedSchemas, err := New(logs.NoopLogger(), config).Transform(ir.Schemas{schema})
 	req.NoError(err)
 
 	context := languages.Context{Schemas: processedSchemas}

--- a/internal/jennies/python/jennies.go
+++ b/internal/jennies/python/jennies.go
@@ -2,10 +2,11 @@ package python
 
 import (
 	"io/fs"
+	"log/slog"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -52,12 +53,14 @@ func (config *Config) InterpolateParameters(interpolator func(input string) stri
 }
 
 type Language struct {
+	logger          *slog.Logger
 	config          Config
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger:          logger,
 		config:          config,
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
@@ -110,17 +113,19 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.AnonymousStructsToNamed{},
-		&compiler2.NotRequiredFieldAsNullableType{},
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.DisjunctionOfConstantsToEnum{},
-		&compiler2.FlattenDisjunctions{},
-		&compiler2.DisjunctionInferMapping{},
-		&compiler2.RenameNumericEnumValues{},
-		&compiler2.DisjunctionPropagateVariant{},
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.AnonymousStructsToNamed{},
+		&transforms.NotRequiredFieldAsNullableType{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.DisjunctionOfConstantsToEnum{},
+		&transforms.FlattenDisjunctions{},
+		&transforms.DisjunctionInferMapping{},
+		&transforms.RenameNumericEnumValues{},
+		&transforms.DisjunctionPropagateVariant{},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/python/rawtypes_test.go
+++ b/internal/jennies/python/rawtypes_test.go
@@ -34,7 +34,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -43,7 +43,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Python.
 		// Example: anonymous objects.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -82,9 +82,9 @@ def custom_method(self) -> str:
 			tmpl:            initTemplates(config, common.NewAPIReferenceCollector()),
 			apiRefCollector: common.NewAPIReferenceCollector(),
 		}
-		compilerPasses := New(config).CompilerPasses()
+		transforms := New(logs.NoopLogger(), config).Transform
 
-		schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+		schemas, err := transforms(ir.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/jennies/terraform/jennies.go
+++ b/internal/jennies/terraform/jennies.go
@@ -2,9 +2,11 @@ package terraform
 
 import (
 	"io/fs"
+	"log/slog"
 
 	"github.com/grafana/codejen"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/jennies/golang"
 	"github.com/grafana/cog/internal/languages"
@@ -52,11 +54,13 @@ type Config struct {
 }
 
 type Language struct {
+	logger *slog.Logger
 	config Config
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger: logger,
 		config: config,
 	}
 }
@@ -97,20 +101,22 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.AnonymousStructsToNamed{},
-		&compiler2.NotRequiredFieldAsNullableType{},
-		&compiler2.DisjunctionWithNullToOptional{},
-		&compiler2.DisjunctionOfConstantsToEnum{},
-		&compiler2.AnonymousEnumToExplicitType{},
-		&compiler2.PrefixEnumValues{},
-		&compiler2.FlattenDisjunctions{},
-		&compiler2.DisjunctionOfAnonymousStructsToExplicit{},
-		&compiler2.DisjunctionInferMapping{},
-		&compiler2.UndiscriminatedDisjunctionToAny{},
-		&compiler2.DisjunctionToType{},
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.AnonymousStructsToNamed{},
+		&transforms.NotRequiredFieldAsNullableType{},
+		&transforms.DisjunctionWithNullToOptional{},
+		&transforms.DisjunctionOfConstantsToEnum{},
+		&transforms.AnonymousEnumToExplicitType{},
+		&transforms.PrefixEnumValues{},
+		&transforms.FlattenDisjunctions{},
+		&transforms.DisjunctionOfAnonymousStructsToExplicit{},
+		&transforms.DisjunctionInferMapping{},
+		&transforms.UndiscriminatedDisjunctionToAny{},
+		&transforms.DisjunctionToType{},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/terraform/rawtypes_test.go
+++ b/internal/jennies/terraform/rawtypes_test.go
@@ -23,7 +23,7 @@ func TestRawTypes_Generate(t *testing.T) {
 	cfg := Config{}
 
 	jenny := RawTypes{config: cfg, tmpl: initTemplates(cfg)}
-	compilerPasses := New(cfg).CompilerPasses()
+	transforms := New(logs.NoopLogger(), cfg).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -32,7 +32,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into Java.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")

--- a/internal/jennies/typescript/builder_test.go
+++ b/internal/jennies/typescript/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
+	"github.com/grafana/cog/internal/logs"
 	"github.com/grafana/cog/internal/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +21,7 @@ func TestBuilder_Generate(t *testing.T) {
 
 	config := Config{}
 	config.applyDefaults()
-	language := New(config)
+	language := New(logs.NoopLogger(), config)
 	jenny := Builder{
 		config:          config,
 		tmpl:            initTemplates(language.config, common.NewAPIReferenceCollector()),

--- a/internal/jennies/typescript/jennies.go
+++ b/internal/jennies/typescript/jennies.go
@@ -2,11 +2,12 @@ package typescript
 
 import (
 	"io/fs"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	compiler2 "github.com/grafana/cog/internal/ir/transforms"
+	"github.com/grafana/cog/internal/ir/transforms"
 	"github.com/grafana/cog/internal/jennies/common"
 	"github.com/grafana/cog/internal/languages"
 	"github.com/grafana/cog/internal/tools"
@@ -97,12 +98,14 @@ func (config *Config) applyDefaults() {
 }
 
 type Language struct {
+	logger          *slog.Logger
 	config          Config
 	apiRefCollector *common.APIReferenceCollector
 }
 
-func New(config Config) *Language {
+func New(logger *slog.Logger, config Config) *Language {
 	return &Language{
+		logger:          logger,
 		config:          config,
 		apiRefCollector: common.NewAPIReferenceCollector(),
 	}
@@ -152,11 +155,13 @@ func (language *Language) Jennies(globalConfig languages.Config) *codejen.JennyL
 	return jenny
 }
 
-func (language *Language) CompilerPasses() compiler2.Transforms {
-	return compiler2.Transforms{
-		&compiler2.RenameNumericEnumValues{},
-		&compiler2.DisjunctionPropagateVariant{},
+func (language *Language) Transform(schemas ir.Schemas) (ir.Schemas, error) {
+	passes := transforms.Transforms{
+		&transforms.RenameNumericEnumValues{},
+		&transforms.DisjunctionPropagateVariant{},
 	}
+
+	return passes.Process(language.logger, schemas)
 }
 
 func (language *Language) NullableKinds() languages.NullableConfig {

--- a/internal/jennies/typescript/rawtypes_test.go
+++ b/internal/jennies/typescript/rawtypes_test.go
@@ -27,7 +27,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		tmpl:   initTemplates(config, common.NewAPIReferenceCollector()),
 		config: config,
 	}
-	compilerPasses := New(config).CompilerPasses()
+	transforms := New(logs.NoopLogger(), config).Transform
 
 	test.Run(t, func(tc *testutils.Test[ir.Schema]) {
 		req := require.New(tc)
@@ -36,7 +36,7 @@ func TestRawTypes_Generate(t *testing.T) {
 		// might not be able to translate some of the IR's semantics into TS.
 		// Example: disjunctions.
 		schema := tc.UnmarshalJSONInput(testutils.RawTypesIRInputFile)
-		processedAsts, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{&schema})
+		processedAsts, err := transforms(ir.Schemas{&schema})
 		req.NoError(err)
 
 		req.Len(processedAsts, 1, "we somehow got more ast.Schema than we put in")
@@ -77,9 +77,9 @@ export const customMethodFor{{ .Object.Name }} = "{{ label .Object.Name }}";
 			tmpl:   initTemplates(config, common.NewAPIReferenceCollector()),
 			config: config,
 		}
-		compilerPasses := New(config).CompilerPasses()
+		transforms := New(logs.NoopLogger(), config).Transform
 
-		schemas, err := compilerPasses.Process(logs.NoopLogger(), ir.Schemas{schema})
+		schemas, err := transforms(ir.Schemas{schema})
 		req.NoError(err)
 
 		files, err := jenny.Generate(languages.Context{Schemas: schemas})

--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -3,13 +3,12 @@ package languages
 import (
 	"github.com/grafana/codejen"
 	"github.com/grafana/cog/internal/ir"
-	"github.com/grafana/cog/internal/ir/transforms"
 )
 
 type Language interface {
 	Name() string
 	Jennies(config Config) *codejen.JennyList[Context]
-	CompilerPasses() transforms.Transforms
+	Transform(schemas ir.Schemas) (ir.Schemas, error)
 }
 
 type NullableConfig struct {


### PR DESCRIPTION
When defining plugins with https://github.com/hashicorp/go-plugin, it won't be possible for plugins to return the language-specific schema transformations to apply.

Instead, jennies now apply these transformations directly.